### PR TITLE
Enable matrix testing for CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,13 +2,17 @@ name: ci
 on: [push]
 jobs:
   build:
-    name: Build
-    runs-on: ubuntu-latest
+    name: Build (go ${{ matrix.go }}/${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        go: [ '1.12', '1.13' ]
+        os: [ 'ubuntu-latest', 'macos-latest', 'windows-latest' ]
     steps:
-      - name: Set up Go 1.13
+      - name: Set up Go ${{ matrix.go }}
         uses: actions/setup-go@v1
         with:
-          go-version: 1.13
+          go-version: ${{ matrix.go }}
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         go: [ '1.12', '1.13' ]
-        os: [ 'ubuntu-latest', 'macos-latest', 'windows-latest' ]
+        os: [ 'ubuntu-latest', 'macos-latest' ]
     steps:
       - name: Set up Go ${{ matrix.go }}
         uses: actions/setup-go@v1


### PR DESCRIPTION
As for now, only the latest go version is used in the pipeline.
This situation could lead to incompatibilities between tyk and graphql-go-tools, so I have added a build matrix which will test at least against tyk's go version, and the latest go version.

It will also run on all defined OS, currently `ubuntu-latest` and `macos-latest`. `windows-latest` could also be added, but this would require much more work because the pipeline currently relies on makefiles and bash scripts.