### PR TITLE
Return ExecutionResult object from Execute

### DIFF
--- a/pkg/graphql/execution_engine_test.go
+++ b/pkg/graphql/execution_engine_test.go
@@ -87,7 +87,7 @@ func TestExecutionEngine_ExecuteWithOptions(t *testing.T) {
 		err = engine.AddHttpJsonDataSourceWithOptions("HttpJsonDataSource", httpJsonOptions)
 		assert.NoError(t, err)
 
-		executionRes, err := engine.ExecuteWithOptions(context.Background(), &request, ExecutionOptions{ExtraArguments: extraVariablesBytes})
+		executionRes, err := engine.Execute(context.Background(), &request, ExecutionOptions{ExtraArguments: extraVariablesBytes})
 		assert.NoError(t, err)
 		assert.Equal(t, `{"data":{"hero":{"name":"Luke Skywalker"}}}`, executionRes.Buffer().String())
 	})
@@ -145,7 +145,7 @@ func TestExecutionEngine_ExecuteWithOptions(t *testing.T) {
 		err = engine.AddGraphqlDataSourceWithOptions("GraphqlDataSource", graphqlOptions)
 		assert.NoError(t, err)
 
-		executionRes, err := engine.ExecuteWithOptions(context.Background(), &request, ExecutionOptions{ExtraArguments: extraVariablesBytes})
+		executionRes, err := engine.Execute(context.Background(), &request, ExecutionOptions{ExtraArguments: extraVariablesBytes})
 		assert.NoError(t, err)
 		assert.Equal(t, `{"data":{"hero":{"name":"Luke Skywalker"}}}`, executionRes.Buffer().String())
 	})

--- a/pkg/graphql/execution_engine_test.go
+++ b/pkg/graphql/execution_engine_test.go
@@ -87,10 +87,9 @@ func TestExecutionEngine_ExecuteWithOptions(t *testing.T) {
 		err = engine.AddHttpJsonDataSourceWithOptions("HttpJsonDataSource", httpJsonOptions)
 		assert.NoError(t, err)
 
-		buf := bytes.Buffer{}
-		err = engine.ExecuteWithOptions(context.Background(), &request, &buf, ExecutionOptions{ExtraArguments: extraVariablesBytes})
+		executionRes, err := engine.ExecuteWithOptions(context.Background(), &request, ExecutionOptions{ExtraArguments: extraVariablesBytes})
 		assert.NoError(t, err)
-		assert.Equal(t, `{"data":{"hero":{"name":"Luke Skywalker"}}}`, buf.String())
+		assert.Equal(t, `{"data":{"hero":{"name":"Luke Skywalker"}}}`, executionRes.Buffer().String())
 	})
 
 	t.Run("execute with custom roundtripper for simple hero query on GraphqlDataSource", func(t *testing.T) {
@@ -146,9 +145,8 @@ func TestExecutionEngine_ExecuteWithOptions(t *testing.T) {
 		err = engine.AddGraphqlDataSourceWithOptions("GraphqlDataSource", graphqlOptions)
 		assert.NoError(t, err)
 
-		buf := bytes.Buffer{}
-		err = engine.ExecuteWithOptions(context.Background(), &request, &buf, ExecutionOptions{ExtraArguments: extraVariablesBytes})
+		executionRes, err := engine.ExecuteWithOptions(context.Background(), &request, ExecutionOptions{ExtraArguments: extraVariablesBytes})
 		assert.NoError(t, err)
-		assert.Equal(t, `{"data":{"hero":{"name":"Luke Skywalker"}}}`, buf.String())
+		assert.Equal(t, `{"data":{"hero":{"name":"Luke Skywalker"}}}`, executionRes.Buffer().String())
 	})
 }


### PR DESCRIPTION
Let's give a helper function to user to convert the buffer to HTTP response. We give http request as parameter, most user will expect http response and will get by just this: `executionResult.GetAsHTTPResponse()`. 

If they want to read the result, they will be able to use `executionResult.Buffer()` and they will read how they want.

Usage on the  Gateway side: 
```
result, err = p.TykAPISpec.GraphQLExecutor.Engine.Execute(context.Background(), gqlRequest, graphql.ExecutionOptions{ExtraArguments: nil})
res = result.GetAsHTTPResponse()
```
