### PR TITLE
Fix/empty object panic

### DIFF
--- a/pkg/execution/planning.go
+++ b/pkg/execution/planning.go
@@ -72,6 +72,12 @@ type dataSourcePlannerRef struct {
 
 func (p *planningVisitor) EnterDocument(operation, definition *ast.Document) {
 	p.operation, p.definition, p.base.Definition = operation, definition, definition
+
+	if len(operation.OperationDefinitions) == 0 {
+		p.Walker.StopWithExternalErr(operationreport.ErrDocumentDoesntContainExecutableOperation())
+		return
+	}
+
 	obj := &Object{}
 	p.rootNode = &Object{
 		operationType: operation.OperationDefinitions[0].OperationType,

--- a/pkg/graphql/execution_engine.go
+++ b/pkg/graphql/execution_engine.go
@@ -99,6 +99,7 @@ func (e *ExecutionEngine) AddDataSource(name string, plannerFactoryFactory datas
 
 func (e *ExecutionEngine) ExecuteWithWriter(ctx context.Context, operation *Request, writer io.Writer, options ExecutionOptions) error {
 	var report operationreport.Report
+
 	if !operation.IsNormalized() {
 		normalizationResult, err := operation.Normalize(e.schema)
 		if err != nil {

--- a/pkg/graphql/request_test.go
+++ b/pkg/graphql/request_test.go
@@ -49,6 +49,18 @@ func TestRequest_ValidateForSchema(t *testing.T) {
 		assert.Equal(t, ValidationResult{Valid: false, Errors: nil}, result)
 	})
 
+	t.Run("should return gql errors no valid operation is in the the request", func(t *testing.T) {
+		request := Request{}
+
+		schema, err := NewSchemaFromString("schema { query: Query } type Query { hello: String }")
+		require.NoError(t, err)
+
+		result, err := request.ValidateForSchema(schema)
+		assert.NoError(t, err)
+		assert.False(t, result.Valid)
+		assert.Greater(t, result.Errors.Count(), 0)
+	})
+
 	t.Run("should return gql errors when validation fails", func(t *testing.T) {
 		request := Request{
 			OperationName: "Goodbye",

--- a/pkg/operationreport/externalerror.go
+++ b/pkg/operationreport/externalerror.go
@@ -17,6 +17,11 @@ type Location struct {
 	Column uint32 `json:"column"`
 }
 
+func ErrDocumentDoesntContainExecutableOperation() (err ExternalError){
+	err.Message = "document doesn't contain any executable operation"
+	return
+}
+
 func ErrFieldUndefinedOnType(fieldName, typeName ast.ByteSlice) (err ExternalError) {
 	err.Message = fmt.Sprintf("field: %s not defined on type: %s", fieldName, typeName)
 	return err


### PR DESCRIPTION
This PR will ensure that no panic happens during execution when the request object doesn't contain any operation. It also adds a new rule to operation validation to catch this error ahead of execution.