### PR TITLE
Optimize contract performance

### DIFF
--- a/internal/pkg/quotes/quotes.go
+++ b/internal/pkg/quotes/quotes.go
@@ -1,0 +1,19 @@
+package quotes
+
+const (
+	quoteStr = "\""
+)
+
+var (
+	quoteBytes = []byte(quoteStr)
+)
+
+func WrapBytes(bytes []byte) []byte {
+	cp := make([]byte, len(bytes))
+	copy(cp, bytes)
+	return append(quoteBytes, append(cp, quoteBytes...)...)
+}
+
+func WrapString(str string) string {
+	return quoteStr + str + quoteStr
+}

--- a/pkg/ast/ast_node.go
+++ b/pkg/ast/ast_node.go
@@ -310,7 +310,13 @@ func (d *Document) NodeIsLastRootNode(node Node) bool {
 	if len(d.RootNodes) == 0 {
 		return false
 	}
-	return d.RootNodes[len(d.RootNodes)-1] == node
+	for i := len(d.RootNodes) - 1; i >= 0; i-- {
+		if d.RootNodes[i].Kind == NodeKindUnknown {
+			continue
+		}
+		return d.RootNodes[i] == node
+	}
+	return false
 }
 
 func (d *Document) RemoveNodeFromNode(remove, from Node) {

--- a/pkg/ast/ast_object_field.go
+++ b/pkg/ast/ast_object_field.go
@@ -3,6 +3,7 @@ package ast
 import (
 	"bytes"
 
+	"github.com/jensneuse/graphql-go-tools/internal/pkg/unsafebytes"
 	"github.com/jensneuse/graphql-go-tools/pkg/lexer/position"
 )
 
@@ -21,6 +22,10 @@ func (d *Document) ObjectField(ref int) ObjectField {
 
 func (d *Document) ObjectFieldNameBytes(ref int) ByteSlice {
 	return d.Input.ByteSlice(d.ObjectFields[ref].Name)
+}
+
+func (d *Document) ObjectFieldNameString(ref int) string {
+	return unsafebytes.BytesToString(d.Input.ByteSlice(d.ObjectFields[ref].Name))
 }
 
 func (d *Document) ObjectFieldValue(ref int) Value {

--- a/pkg/ast/ast_operation_definition.go
+++ b/pkg/ast/ast_operation_definition.go
@@ -36,15 +36,6 @@ func (d *Document) OperationDefinitionNameString(ref int) string {
 	return unsafebytes.BytesToString(d.Input.ByteSlice(d.OperationDefinitions[ref].Name))
 }
 
-func (d *Document) OperationDefinitionIsLastRootNode(ref int) bool {
-	for i := range d.RootNodes {
-		if d.RootNodes[i].Kind == NodeKindOperationDefinition && d.RootNodes[i].Ref == ref {
-			return len(d.RootNodes)-1 == i
-		}
-	}
-	return false
-}
-
 func (d *Document) AddOperationDefinitionToRootNodes(definition OperationDefinition) Node {
 	d.OperationDefinitions = append(d.OperationDefinitions, definition)
 	node := Node{Kind: NodeKindOperationDefinition, Ref: len(d.OperationDefinitions) - 1}

--- a/pkg/ast/ast_operation_definition.go
+++ b/pkg/ast/ast_operation_definition.go
@@ -1,6 +1,8 @@
 package ast
 
 import (
+	"math"
+
 	"github.com/jensneuse/graphql-go-tools/internal/pkg/unsafebytes"
 	"github.com/jensneuse/graphql-go-tools/pkg/lexer/position"
 )
@@ -66,4 +68,24 @@ func (d *Document) AddVariableDefinitionToOperationDefinition(operationDefinitio
 	ref := len(d.VariableDefinitions) - 1
 	d.OperationDefinitions[operationDefinitionRef].VariableDefinitions.Refs =
 		append(d.OperationDefinitions[operationDefinitionRef].VariableDefinitions.Refs, ref)
+}
+
+const (
+	alphabet = `abcdefghijklmnopqrstuvwxyz`
+)
+
+func (d *Document) GenerateUnusedVariableDefinitionName(operationDefinition int) []byte {
+	for i := 1;i<math.MaxInt64;i++{
+		out := make([]byte,i)
+		for j := range alphabet {
+			for k := 0;k<i;k++{
+				out[k] = alphabet[j]
+			}
+			_,exists := d.VariableDefinitionByNameAndOperation(operationDefinition,out)
+			if !exists {
+				return out
+			}
+		}
+	}
+	return nil
 }

--- a/pkg/ast/ast_operation_definition_test.go
+++ b/pkg/ast/ast_operation_definition_test.go
@@ -1,0 +1,32 @@
+package ast
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDocument_GenerateUnusedVariableDefinitionName(t *testing.T) {
+	doc := &Document{}
+	runCase := func(expected string, existing ...string) func(t *testing.T) {
+		return func(t *testing.T) {
+			actual := string(doc.generateUniqueShortIdentifier(func(b []byte) bool {
+				for i := range existing {
+					if string(b) == existing[i] {
+						return true
+					}
+				}
+				return false
+			}))
+			assert.Equal(t, expected, actual)
+		}
+	}
+
+	t.Run("empty -> a", runCase("a"))
+	t.Run("existing -> d", runCase("d", "a", "b", "c"))
+	all := make([]string, len(alphabet))
+	for i := range alphabet {
+		all[i] = alphabet[i : i+1]
+	}
+	t.Run("all -> aa", runCase("aa", all...))
+}

--- a/pkg/ast/ast_value_test.go
+++ b/pkg/ast/ast_value_test.go
@@ -1,0 +1,175 @@
+package ast
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDocument_ValueToJSON(t *testing.T) {
+	run := func(prepareDoc func(doc *Document) Value, expectedOutput string) func(t *testing.T) {
+		operation := NewDocument()
+		return func(t *testing.T) {
+			out, err := operation.ValueToJSON(prepareDoc(operation))
+			assert.NoError(t, err)
+			assert.Equal(t, expectedOutput, string(out))
+		}
+	}
+
+	t.Run("ValueKindNull", run(func(doc *Document) Value {
+		return Value{
+			Kind: ValueKindNull,
+			Ref:  0,
+		}
+	}, `null`))
+	t.Run("ValueKindEnum", run(func(doc *Document) Value {
+		doc.EnumValues = append(doc.EnumValues, EnumValue{
+			Name: doc.Input.AppendInputString("FOO"),
+		})
+		return Value{
+			Kind: ValueKindEnum,
+			Ref:  0,
+		}
+	}, `"FOO"`))
+	t.Run("ValueKindInteger - positive", run(func(doc *Document) Value {
+		doc.IntValues = append(doc.IntValues, IntValue{
+			Raw: doc.Input.AppendInputString("123"),
+		})
+		return Value{
+			Kind: ValueKindInteger,
+			Ref:  0,
+		}
+	}, `123`))
+	t.Run("ValueKindInteger - negative", run(func(doc *Document) Value {
+		doc.IntValues = append(doc.IntValues, IntValue{
+			Raw:      doc.Input.AppendInputString("123"),
+			Negative: true,
+		})
+		return Value{
+			Kind: ValueKindInteger,
+			Ref:  0,
+		}
+	}, `-123`))
+	t.Run("ValueKindFloat - positive", run(func(doc *Document) Value {
+		doc.FloatValues = append(doc.FloatValues, FloatValue{
+			Raw: doc.Input.AppendInputString("12.34"),
+		})
+		return Value{
+			Kind: ValueKindFloat,
+			Ref:  0,
+		}
+	}, `12.34`))
+	t.Run("ValueKindFloat - negative", run(func(doc *Document) Value {
+		doc.FloatValues = append(doc.FloatValues, FloatValue{
+			Raw:      doc.Input.AppendInputString("12.34"),
+			Negative: true,
+		})
+		return Value{
+			Kind: ValueKindFloat,
+			Ref:  0,
+		}
+	}, `-12.34`))
+	t.Run("ValueKindBoolean - false", run(func(doc *Document) Value {
+		return Value{
+			Kind: ValueKindBoolean,
+			Ref:  0,
+		}
+	}, `false`))
+	t.Run("ValueKindBoolean - true", run(func(doc *Document) Value {
+		return Value{
+			Kind: ValueKindBoolean,
+			Ref:  1,
+		}
+	}, `true`))
+	t.Run("ValueKindString", run(func(doc *Document) Value {
+		doc.StringValues = append(doc.StringValues, StringValue{
+			Content: doc.Input.AppendInputString("foo"),
+		})
+		return Value{
+			Kind: ValueKindString,
+			Ref:  0,
+		}
+	}, `"foo"`))
+	t.Run("ValueKindList", run(func(doc *Document) Value {
+		doc.StringValues = append(doc.StringValues, StringValue{
+			Content: doc.Input.AppendInputString("foo"),
+		})
+		doc.StringValues = append(doc.StringValues, StringValue{
+			Content: doc.Input.AppendInputString("bar"),
+		})
+		doc.StringValues = append(doc.StringValues, StringValue{
+			Content: doc.Input.AppendInputString("baz"),
+		})
+		for i := 0; i < 3; i++ {
+			doc.Values = append(doc.Values, Value{Kind: ValueKindString, Ref: i})
+		}
+		doc.IntValues = append(doc.IntValues, IntValue{
+			Raw: doc.Input.AppendInputString("123"),
+		})
+		doc.Values = append(doc.Values, Value{Kind: ValueKindInteger, Ref: 0})
+		doc.ListValues = append(doc.ListValues, ListValue{
+			Refs: []int{0, 1, 2, 3},
+		})
+		return Value{
+			Kind: ValueKindList,
+			Ref:  0,
+		}
+	}, `["foo","bar","baz",123]`))
+	t.Run("ValueKindObject", run(func(doc *Document) Value {
+		doc.StringValues = append(doc.StringValues, StringValue{
+			Content: doc.Input.AppendInputString("bar"),
+		})
+		doc.StringValues = append(doc.StringValues, StringValue{
+			Content: doc.Input.AppendInputString("bal"),
+		})
+		doc.ObjectFields = append(doc.ObjectFields, ObjectField{
+			Name: doc.Input.AppendInputString("bat"),
+			Value: Value{
+				Kind: ValueKindString,
+				Ref:  1,
+			},
+		})
+		doc.ObjectFields = append(doc.ObjectFields,
+			ObjectField{
+				Name: doc.Input.AppendInputString("foo"),
+				Value: Value{
+					Kind: ValueKindString,
+					Ref:  0,
+				},
+			},
+			ObjectField{
+				Name: doc.Input.AppendInputString("baz"),
+				Value: Value{
+					Kind: ValueKindObject,
+					Ref:  1,
+				},
+			})
+		for i := 0; i < 3; i++ {
+			doc.IntValues = append(doc.IntValues, IntValue{
+				Raw: doc.Input.AppendInputString(strconv.Itoa(i + 1)),
+			})
+			doc.Values = append(doc.Values, Value{Kind: ValueKindInteger, Ref: i})
+		}
+		doc.ListValues = append(doc.ListValues, ListValue{
+			Refs: []int{0, 1, 2},
+		})
+		doc.ObjectFields = append(doc.ObjectFields, ObjectField{
+			Name: doc.Input.AppendInputString("list"),
+			Value: Value{
+				Kind: ValueKindList,
+				Ref:  0,
+			},
+		})
+		doc.ObjectValues = append(doc.ObjectValues, ObjectValue{
+			Refs: []int{1, 2, 3},
+		})
+		doc.ObjectValues = append(doc.ObjectValues, ObjectValue{
+			Refs: []int{0},
+		})
+		return Value{
+			Kind: ValueKindObject,
+			Ref:  0,
+		}
+	}, `{"foo":"bar","baz":{"bat":"bal"},"list":[1,2,3]}`))
+}

--- a/pkg/ast/ast_variable_definition.go
+++ b/pkg/ast/ast_variable_definition.go
@@ -38,6 +38,19 @@ func (d *Document) VariableDefinitionByName(name ByteSlice) (definition int, exi
 	return -1, false
 }
 
+func (d *Document) VariableDefinitionByNameAndOperation(operationDefinition int, name ByteSlice) (definition int, exists bool) {
+	if !d.OperationDefinitions[operationDefinition].HasVariableDefinitions {
+		return -1, false
+	}
+	for _, i := range d.OperationDefinitions[operationDefinition].VariableDefinitions.Refs {
+		definitionName := d.VariableValueNameBytes(d.VariableDefinitions[i].VariableValue.Ref)
+		if bytes.Equal(name, definitionName) {
+			return i, true
+		}
+	}
+	return -1, false
+}
+
 func (d *Document) VariableDefinitionsBefore(variableDefinition int) bool {
 	return variableDefinition != 0
 }

--- a/pkg/ast/input.go
+++ b/pkg/ast/input.go
@@ -25,6 +25,7 @@ type Input struct {
 // Reset empties the Input
 func (i *Input) Reset() {
 	i.RawBytes = i.RawBytes[:0]
+	i.Variables = i.Variables[:]
 	i.InputPosition = 0
 	i.TextPosition.Reset()
 }

--- a/pkg/ast/input.go
+++ b/pkg/ast/input.go
@@ -18,6 +18,8 @@ type Input struct {
 	InputPosition int
 	// TextPosition is the current position within the text (line and character information about the current Tokens)
 	TextPosition position.Position
+	// Variables are the json encoded variables of the operation
+	Variables []byte
 }
 
 // Reset empties the Input

--- a/pkg/astnormalization/astnormalization.go
+++ b/pkg/astnormalization/astnormalization.go
@@ -77,7 +77,7 @@ import (
 // In case you're using OperationNormalizer in a hot path you shouldn't be using this function.
 // Create a new OperationNormalizer using NewNormalizer() instead and re-use it.
 func NormalizeOperation(operation, definition *ast.Document, report *operationreport.Report) {
-	normalizer := NewNormalizer(false)
+	normalizer := NewNormalizer(false,false)
 	normalizer.NormalizeOperation(operation, definition, report)
 }
 
@@ -87,12 +87,14 @@ type registerNormalizeFunc func(walker *astvisitor.Walker)
 type OperationNormalizer struct {
 	walkers                   []*astvisitor.Walker
 	removeFragmentDefinitions bool
+	extractVariables          bool
 }
 
 // NewNormalizer creates a new OperationNormalizer and sets up all default rules
-func NewNormalizer(removeFragmentDefinitions bool) *OperationNormalizer {
+func NewNormalizer(removeFragmentDefinitions, extractVariables bool) *OperationNormalizer {
 	normalizer := &OperationNormalizer{
 		removeFragmentDefinitions: removeFragmentDefinitions,
+		extractVariables: extractVariables,
 	}
 	normalizer.setupWalkers()
 	return normalizer
@@ -108,6 +110,9 @@ func (o *OperationNormalizer) setupWalkers() {
 	mergeInlineFragments(&other)
 	mergeFieldSelections(&other)
 	deduplicateFields(&other)
+	if o.extractVariables {
+		extractVariables(&other)
+	}
 	if o.removeFragmentDefinitions {
 		removeFragmentDefinitions(&other)
 	}

--- a/pkg/astnormalization/variables_extraction.go
+++ b/pkg/astnormalization/variables_extraction.go
@@ -9,7 +9,7 @@ import (
 	"github.com/jensneuse/graphql-go-tools/pkg/astvisitor"
 )
 
-func variablesExtraction(walker *astvisitor.Walker) {
+func extractVariables(walker *astvisitor.Walker) {
 	visitor := &variablesExtractionVisitor{
 		Walker: walker,
 	}
@@ -25,6 +25,10 @@ type variablesExtractionVisitor struct {
 
 func (v *variablesExtractionVisitor) EnterArgument(ref int) {
 	if v.operation.Arguments[ref].Value.Kind == ast.ValueKindVariable {
+		return
+	}
+
+	if len(v.Ancestors) == 0 || v.Ancestors[0].Kind != ast.NodeKindOperationDefinition {
 		return
 	}
 

--- a/pkg/astnormalization/variables_extraction.go
+++ b/pkg/astnormalization/variables_extraction.go
@@ -1,36 +1,92 @@
 package astnormalization
 
 import (
-	"fmt"
+	"bytes"
 
 	"github.com/jensneuse/graphql-go-tools/pkg/ast"
+	"github.com/jensneuse/graphql-go-tools/pkg/astimport"
 	"github.com/jensneuse/graphql-go-tools/pkg/astvisitor"
 )
 
-func variablesExtraction(walker *astvisitor.Walker){
+func variablesExtraction(walker *astvisitor.Walker) {
 	visitor := &variablesExtractionVisitor{
-		Walker:walker,
+		Walker: walker,
 	}
 	walker.RegisterEnterDocumentVisitor(visitor)
-	walker.RegisterEnterOperationVisitor(visitor)
-	walker.RegisterEnterVariableDefinitionVisitor(visitor)
+	walker.RegisterEnterArgumentVisitor(visitor)
 }
 
 type variablesExtractionVisitor struct {
 	*astvisitor.Walker
-	operation,definition *ast.Document
+	operation, definition *ast.Document
+	importer              astimport.Importer
 }
 
-func (v *variablesExtractionVisitor) EnterVariableDefinition(ref int) {
-	name := v.operation.VariableValueNameString(ref)
-	fmt.Println(name)
+func (v *variablesExtractionVisitor) EnterArgument(ref int) {
+	if v.operation.Arguments[ref].Value.Kind == ast.ValueKindVariable {
+		return
+	}
+
+	variable := ast.VariableValue{
+		Name: v.getNextVariableName(),
+	}
+
+	v.operation.VariableValues = append(v.operation.VariableValues, variable)
+
+	varRef := len(v.operation.VariableValues) - 1
+
+	v.operation.Arguments[ref].Value.Ref = varRef
+	v.operation.Arguments[ref].Value.Kind = ast.ValueKindVariable
+
+	defRef, ok := v.ArgumentInputValueDefinition(ref)
+	if !ok {
+		return
+	}
+
+	defType := v.definition.InputValueDefinitions[defRef].Type
+
+	importedDefType := v.importer.ImportType(defType, v.definition, v.operation)
+
+	v.operation.VariableDefinitions = append(v.operation.VariableDefinitions, ast.VariableDefinition{
+		VariableValue: ast.Value{
+			Kind: ast.ValueKindVariable,
+			Ref:  varRef,
+		},
+		Type: importedDefType,
+	})
+
+	newVariableRef := len(v.operation.VariableDefinitions) - 1
+
+	v.operation.OperationDefinitions[v.Ancestors[0].Ref].VariableDefinitions.Refs =
+		append(v.operation.OperationDefinitions[v.Ancestors[0].Ref].VariableDefinitions.Refs, newVariableRef)
+	v.operation.OperationDefinitions[v.Ancestors[0].Ref].HasVariableDefinitions = true
 }
 
 func (v *variablesExtractionVisitor) EnterDocument(operation, definition *ast.Document) {
-	v.operation,v.definition = operation,definition
+	v.operation, v.definition = operation, definition
 }
 
-func (v *variablesExtractionVisitor) EnterOperationDefinition(ref int) {
-	name := v.operation.OperationDefinitionNameString(ref)
-	fmt.Println(name)
+var (
+	alphabet = []byte("abcdefghijklmnopqrstuvwxyz")
+)
+
+// TODO: this can be better - Need to be able to support more than 26 variables
+func (v *variablesExtractionVisitor) getNextVariableName() ast.ByteSliceReference {
+	for o := 1; o < len(alphabet)+1; o++ {
+		for i := 0; i < len(alphabet); i++ {
+			potentialName := alphabet[i : i+o]
+			exists := false
+			for _, j := range v.operation.OperationDefinitions[v.Ancestors[0].Ref].VariableDefinitions.Refs {
+				if bytes.Equal(v.operation.VariableDefinitionNameBytes(j), potentialName) {
+					exists = true
+					break
+				}
+			}
+			if exists {
+				continue
+			}
+			return v.operation.Input.AppendInputBytes(potentialName)
+		}
+	}
+	return ast.ByteSliceReference{}
 }

--- a/pkg/astnormalization/variables_extraction.go
+++ b/pkg/astnormalization/variables_extraction.go
@@ -1,0 +1,36 @@
+package astnormalization
+
+import (
+	"fmt"
+
+	"github.com/jensneuse/graphql-go-tools/pkg/ast"
+	"github.com/jensneuse/graphql-go-tools/pkg/astvisitor"
+)
+
+func variablesExtraction(walker *astvisitor.Walker){
+	visitor := &variablesExtractionVisitor{
+		Walker:walker,
+	}
+	walker.RegisterEnterDocumentVisitor(visitor)
+	walker.RegisterEnterOperationVisitor(visitor)
+	walker.RegisterEnterVariableDefinitionVisitor(visitor)
+}
+
+type variablesExtractionVisitor struct {
+	*astvisitor.Walker
+	operation,definition *ast.Document
+}
+
+func (v *variablesExtractionVisitor) EnterVariableDefinition(ref int) {
+	name := v.operation.VariableValueNameString(ref)
+	fmt.Println(name)
+}
+
+func (v *variablesExtractionVisitor) EnterDocument(operation, definition *ast.Document) {
+	v.operation,v.definition = operation,definition
+}
+
+func (v *variablesExtractionVisitor) EnterOperationDefinition(ref int) {
+	name := v.operation.OperationDefinitionNameString(ref)
+	fmt.Println(name)
+}

--- a/pkg/astnormalization/variables_extraction_test.go
+++ b/pkg/astnormalization/variables_extraction_test.go
@@ -1,0 +1,57 @@
+package astnormalization
+
+import (
+	"testing"
+)
+
+const (
+	variablesExtractionDefinition = `
+		schema { mutation: Mutation }
+		type Mutation {
+			httpBinPost(input: HttpBinPostInput): HttpBinPostResponse
+		}
+		input HttpBinPostInput {
+			foo: String!
+		}
+		type HttpBinPostResponse {
+			headers: Headers
+			data: HttpBinPostResponseData
+		}
+		type HttpBinPostResponseData {
+			foo: String
+		}
+		type Headers {
+			userAgent: String!
+			host: String!
+			acceptEncoding: String
+			Authorization: String
+		}
+		scalar String
+	`
+)
+
+func TestVariablesExtraction(t *testing.T) {
+	t.Run("simple http bin example", func(t *testing.T) {
+		run(variablesExtraction, variablesExtractionDefinition, `
+			mutation HttpBinPost{
+			  httpBinPost(input: {foo: "bar"}){
+				headers {
+				  userAgent
+				}
+				data {
+				  foo
+				}
+			  }
+			}`, `
+			mutation HttpBinPost($input: HttpBinPostInput){
+			  httpBinPost(input: $input){
+				headers {
+				  userAgent
+				}
+				data {
+				  foo
+				}
+			  }
+			}`)
+	})
+}

--- a/pkg/astnormalization/variables_extraction_test.go
+++ b/pkg/astnormalization/variables_extraction_test.go
@@ -32,7 +32,7 @@ const (
 
 func TestVariablesExtraction(t *testing.T) {
 	t.Run("simple http bin example", func(t *testing.T) {
-		runWithVariables(t,variablesExtraction, variablesExtractionDefinition, `
+		runWithVariables(t, extractVariables, variablesExtractionDefinition, `
 			mutation HttpBinPost{
 			  httpBinPost(input: {foo: "bar"}){
 				headers {

--- a/pkg/astnormalization/variables_extraction_test.go
+++ b/pkg/astnormalization/variables_extraction_test.go
@@ -43,8 +43,8 @@ func TestVariablesExtraction(t *testing.T) {
 				}
 			  }
 			}`, `
-			mutation HttpBinPost($input: HttpBinPostInput){
-			  httpBinPost(input: $input){
+			mutation HttpBinPost($a: HttpBinPostInput){
+			  httpBinPost(input: $a){
 				headers {
 				  userAgent
 				}

--- a/pkg/astnormalization/variables_extraction_test.go
+++ b/pkg/astnormalization/variables_extraction_test.go
@@ -32,7 +32,7 @@ const (
 
 func TestVariablesExtraction(t *testing.T) {
 	t.Run("simple http bin example", func(t *testing.T) {
-		run(variablesExtraction, variablesExtractionDefinition, `
+		runWithVariables(t,variablesExtraction, variablesExtractionDefinition, `
 			mutation HttpBinPost{
 			  httpBinPost(input: {foo: "bar"}){
 				headers {
@@ -52,6 +52,6 @@ func TestVariablesExtraction(t *testing.T) {
 				  foo
 				}
 			  }
-			}`)
+			}`,``,`{"a":{"foo":"bar"}}`)
 	})
 }

--- a/pkg/astprinter/astprinter.go
+++ b/pkg/astprinter/astprinter.go
@@ -256,7 +256,7 @@ func (p *printVisitor) EnterOperationDefinition(ref int) {
 }
 
 func (p *printVisitor) LeaveOperationDefinition(ref int) {
-	if !p.document.OperationDefinitionIsLastRootNode(ref) {
+	if !p.document.NodeIsLastRootNode(ast.Node{Kind: ast.NodeKindOperationDefinition,Ref: ref}) {
 		if p.indent != nil {
 			p.write(literal.LINETERMINATOR)
 			p.write(literal.LINETERMINATOR)

--- a/pkg/astvalidation/overlapping_fields_test.go
+++ b/pkg/astvalidation/overlapping_fields_test.go
@@ -24,7 +24,7 @@ func TestOverlappingFieldsCanBeMerged(t *testing.T) {
 		definition := unsafeparser.ParseGraphqlDocumentBytes(definitionBytes)
 		operation := unsafeparser.ParseGraphqlDocumentBytes(operationBytes)
 		report := operationreport.Report{}
-		normalizer := astnormalization.NewNormalizer(false)
+		normalizer := astnormalization.NewNormalizer(false,false)
 		validator := DefaultOperationValidator()
 
 		normalizer.NormalizeOperation(&operation, &definition, &report)
@@ -45,7 +45,7 @@ func TestOverlappingFieldsCanBeMerged(t *testing.T) {
 		definition := unsafeparser.ParseGraphqlDocumentBytes(definitionBytes)
 		operation := unsafeparser.ParseGraphqlDocumentBytes(operationBytes)
 		report := operationreport.Report{}
-		normalizer := astnormalization.NewNormalizer(false)
+		normalizer := astnormalization.NewNormalizer(false,false)
 		validator := DefaultOperationValidator()
 
 		normalizer.NormalizeOperation(&operation, &definition, &report)
@@ -70,7 +70,7 @@ func BenchmarkOverlappingFieldsCanBeMerged(b *testing.B) {
 			definition := unsafeparser.ParseGraphqlDocumentBytes(definitionBytes)
 			operation := unsafeparser.ParseGraphqlDocumentBytes(operationBytes)
 			report := operationreport.Report{}
-			normalizer := astnormalization.NewNormalizer(false)
+			normalizer := astnormalization.NewNormalizer(false,false)
 			validator := DefaultOperationValidator()
 
 			b.ReportAllocs()
@@ -96,7 +96,7 @@ func BenchmarkOverlappingFieldsCanBeMerged(b *testing.B) {
 			definition := unsafeparser.ParseGraphqlDocumentBytes(definitionBytes)
 			operation := unsafeparser.ParseGraphqlDocumentBytes(operationBytes)
 			report := operationreport.Report{}
-			normalizer := astnormalization.NewNormalizer(false)
+			normalizer := astnormalization.NewNormalizer(false,false)
 			validator := DefaultOperationValidator()
 
 			b.ReportAllocs()

--- a/pkg/execution/datasource/datasource.go
+++ b/pkg/execution/datasource/datasource.go
@@ -130,11 +130,11 @@ type PlannerConfiguration struct {
 }
 
 type TypeFieldConfiguration struct {
-	TypeName                 string
-	FieldName                string
-	Mapping                  *MappingConfiguration
-	DataSource               SourceConfig `json:"data_source"`
-	DataSourcePlannerFactory PlannerFactory
+	TypeName                 string                `json:"type_name"`
+	FieldName                string                `json:"field_name"`
+	Mapping                  *MappingConfiguration `json:"mapping"`
+	DataSource               SourceConfig          `json:"data_source"`
+	DataSourcePlannerFactory PlannerFactory        `json:"-"`
 }
 
 type SourceConfig struct {
@@ -143,12 +143,12 @@ type SourceConfig struct {
 	Name string `json:"kind"`
 	// Config is the DataSource specific configuration object
 	// Each Planner needs to make sure to parse their Config Object correctly
-	Config json.RawMessage `json:"dataSourceConfig"`
+	Config json.RawMessage `json:"data_source_config"`
 }
 
 type MappingConfiguration struct {
-	Disabled bool
-	Path     string
+	Disabled bool   `json:"disabled"`
+	Path     string `json:"path"`
 }
 
 func (p *PlannerConfiguration) DataSourcePlannerFactoryForTypeField(typeName, fieldName string) PlannerFactory {

--- a/pkg/execution/datasource/datasource_graphql.go
+++ b/pkg/execution/datasource/datasource_graphql.go
@@ -32,11 +32,11 @@ type GraphqlRequest struct {
 // GraphQLDataSourceConfig is the configuration for the GraphQL DataSource
 type GraphQLDataSourceConfig struct {
 	// Host is the hostname of the upstream
-	Host string
+	Host string `json:"host"`
 	// URL is the url of the upstream
-	URL string
+	URL string `json:"url"`
 	// Method is the http.Method of the upstream, defaults to POST (optional)
-	Method *string
+	Method *string `json:"method"`
 }
 
 type GraphQLDataSourcePlanner struct {

--- a/pkg/execution/datasource/datasource_http_json.go
+++ b/pkg/execution/datasource/datasource_http_json.go
@@ -27,33 +27,33 @@ var httpJsonSchemes = []string{
 // HttpJsonDataSourceConfig is the configuration object for the HttpJsonDataSource
 type HttpJsonDataSourceConfig struct {
 	// Host is the hostname of the upstream
-	Host string
+	Host string `json:"host"`
 	// URL is the url of the upstream
-	URL string
+	URL string `json:"url"`
 	// Method is the http.Method, e.g. GET, POST, UPDATE, DELETE
 	// default is GET
-	Method *string
+	Method *string `json:"method"`
 	// Body is the http body to send
 	// default is null/nil (no body)
-	Body *string
+	Body *string `json:"body"`
 	// Headers defines the header mappings
-	Headers []HttpJsonDataSourceConfigHeader
+	Headers []HttpJsonDataSourceConfigHeader `json:"headers"`
 	// DefaultTypeName is the optional variable to define a default type name for the response object
 	// This is useful in case the response might be a Union or Interface type which uses StatusCodeTypeNameMappings
-	DefaultTypeName *string
+	DefaultTypeName *string `json:"default_type_name"`
 	// StatusCodeTypeNameMappings is a slice of mappings from http.StatusCode to GraphQL TypeName
 	// This can be used when the TypeName depends on the http.StatusCode
-	StatusCodeTypeNameMappings []StatusCodeTypeNameMapping
+	StatusCodeTypeNameMappings []StatusCodeTypeNameMapping `json:"status_code_type_name_mappings"`
 }
 
 type StatusCodeTypeNameMapping struct {
-	StatusCode int
-	TypeName   string
+	StatusCode int    `json:"status_code"`
+	TypeName   string `json:"type_name"`
 }
 
 type HttpJsonDataSourceConfigHeader struct {
-	Key   string
-	Value string
+	Key   string `json:"key"`
+	Value string `json:"value"`
 }
 
 type HttpJsonDataSourcePlannerFactoryFactory struct {

--- a/pkg/execution/datasource/datasource_http_json.go
+++ b/pkg/execution/datasource/datasource_http_json.go
@@ -28,33 +28,33 @@ var httpJsonSchemes = []string{
 // HttpJsonDataSourceConfig is the configuration object for the HttpJsonDataSource
 type HttpJsonDataSourceConfig struct {
 	// Host is the hostname of the upstream
-	Host string
+	Host string `json:"host"`
 	// URL is the url of the upstream
-	URL string
+	URL string `json:"url"`
 	// Method is the http.Method, e.g. GET, POST, UPDATE, DELETE
 	// default is GET
-	Method *string
+	Method *string `json:"method"`
 	// Body is the http body to send
 	// default is null/nil (no body)
-	Body *string
+	Body *string `json:"body"`
 	// Headers defines the header mappings
-	Headers []HttpJsonDataSourceConfigHeader
+	Headers []HttpJsonDataSourceConfigHeader `json:"headers"`
 	// DefaultTypeName is the optional variable to define a default type name for the response object
 	// This is useful in case the response might be a Union or Interface type which uses StatusCodeTypeNameMappings
-	DefaultTypeName *string
+	DefaultTypeName *string `json:"default_type_name"`
 	// StatusCodeTypeNameMappings is a slice of mappings from http.StatusCode to GraphQL TypeName
 	// This can be used when the TypeName depends on the http.StatusCode
-	StatusCodeTypeNameMappings []StatusCodeTypeNameMapping
+	StatusCodeTypeNameMappings []StatusCodeTypeNameMapping `json:"status_code_type_name_mappings"`
 }
 
 type StatusCodeTypeNameMapping struct {
-	StatusCode int
-	TypeName   string
+	StatusCode int    `json:"status_code"`
+	TypeName   string `json:"type_name"`
 }
 
 type HttpJsonDataSourceConfigHeader struct {
-	Key   string
-	Value string
+	Key   string `json:"key"`
+	Value string `json:"value"`
 }
 
 type HttpJsonDataSourcePlannerFactoryFactory struct {

--- a/pkg/execution/handler.go
+++ b/pkg/execution/handler.go
@@ -71,7 +71,7 @@ func (h *Handler) Handle(requestData, extraVariables []byte) (executor *Executor
 		err = report
 		return
 	}
-	normalizer := astnormalization.NewNormalizer(true)
+	normalizer := astnormalization.NewNormalizer(true,true)
 	normalizer.NormalizeOperation(&operationDocument, h.base.Definition, &report)
 	if report.HasErrors() {
 		err = report

--- a/pkg/execution/planning_test.go
+++ b/pkg/execution/planning_test.go
@@ -57,7 +57,7 @@ func run(definition string, operation string, configureBase func(base *datasourc
 		op := unsafeparser.ParseGraphqlDocumentString(operation)
 
 		var report operationreport.Report
-		normalizer := astnormalization.NewNormalizer(true)
+		normalizer := astnormalization.NewNormalizer(true,true)
 		normalizer.NormalizeOperation(&op, &def, &report)
 		if report.HasErrors() {
 			t.Error(report)

--- a/pkg/graphql/request.go
+++ b/pkg/graphql/request.go
@@ -76,7 +76,7 @@ func (r *Request) Normalize(schema *Schema) (result NormalizationResult, err err
 	}
 
 	r.isNormalized = true
-	
+
 	r.Variables = r.document.Input.Variables
 
 	return NormalizationResult{Successful: true, Errors: nil}, nil

--- a/pkg/graphql/request.go
+++ b/pkg/graphql/request.go
@@ -67,7 +67,7 @@ func (r *Request) Normalize(schema *Schema) (result NormalizationResult, err err
 		return normalizationResultFromReport(report)
 	}
 
-	normalizer := astnormalization.NewNormalizer(true)
+	normalizer := astnormalization.NewNormalizer(true,true)
 	normalizer.NormalizeOperation(&r.document, &schema.document, &report)
 	if report.HasErrors() {
 		return normalizationResultFromReport(report)

--- a/pkg/graphql/request.go
+++ b/pkg/graphql/request.go
@@ -67,13 +67,18 @@ func (r *Request) Normalize(schema *Schema) (result NormalizationResult, err err
 		return normalizationResultFromReport(report)
 	}
 
-	normalizer := astnormalization.NewNormalizer(true,true)
+	r.document.Input.Variables = r.Variables
+
+	normalizer := astnormalization.NewNormalizer(true, true)
 	normalizer.NormalizeOperation(&r.document, &schema.document, &report)
 	if report.HasErrors() {
 		return normalizationResultFromReport(report)
 	}
 
 	r.isNormalized = true
+	
+	r.Variables = r.document.Input.Variables
+
 	return NormalizationResult{Successful: true, Errors: nil}, nil
 }
 

--- a/pkg/middleware/operation_complexity/operation_complexity_test.go
+++ b/pkg/middleware/operation_complexity/operation_complexity_test.go
@@ -102,14 +102,14 @@ var run = func(t *testing.T, definition, operation string, expectedNodeCount, ex
 
 	astnormalization.NormalizeOperation(&op, &def, &report)
 
-	nodeCount, complexity, depth := CalculateOperationComplexity(&op, &def, &report)
+	actualNodeCount, actualComplexity, actualDepth := CalculateOperationComplexity(&op, &def, &report)
 	if report.HasErrors() {
 		require.NoError(t, report)
 	}
 
-	assert.Equal(t, nodeCount, expectedNodeCount, "unexpected node count")
-	assert.Equal(t, complexity, expectedComplexity, "unexpected complexity")
-	assert.Equal(t, depth, expectedDepth, "unexpected depth")
+	assert.Equal(t, expectedNodeCount, actualNodeCount, "unexpected node count")
+	assert.Equal(t, expectedComplexity, actualComplexity, "unexpected complexity")
+	assert.Equal(t, expectedDepth, actualDepth, "unexpected depth")
 }
 
 func BenchmarkEstimateComplexity(b *testing.B) {


### PR DESCRIPTION
This is a proposal to improve the performance of the graphql package as well as reduce gc pressure.

Initial results:

```
go test -run=none -bench=BenchmarkExecutionEngine -count=1 -memprofile=mem.out && go tool pprof -alloc_space mem.out
goos: darwin
goarch: amd64
pkg: github.com/jensneuse/graphql-go-tools/pkg/graphql
BenchmarkExecutionEngine-16    	  723003	      1578 ns/op	  16.47 MB/s	    6990 B/op	      39 allocs/op
```

final results:

```
graphql % go test -run=none -bench=BenchmarkExecutionEngine -count=1 -memprofile=mem.out && go tool pprof -alloc_space mem.out
goos: darwin
goarch: amd64
pkg: github.com/jensneuse/graphql-go-tools/pkg/graphql
BenchmarkExecutionEngine-16    	 4696146	       242 ns/op	 107.40 MB/s	     582 B/op	      12 allocs/op
```

Overall a 6x improvement.

One thing to consider is I'm not 100% if there is no data race with re-using query plans across requests. I've tested this with parallel benchmarking and it worked fine. However I'd like to ask you to carefully review @pvormste @spetrunin @buger as this could potentially result in huge problems.