### PR TITLE
Respect trailing slashes during playground url concatenation

### DIFF
--- a/pkg/playground/playground.go
+++ b/pkg/playground/playground.go
@@ -7,6 +7,7 @@ import (
 	"html/template"
 	"net/http"
 	"path"
+	"strings"
 
 	"github.com/gobuffalo/packr"
 )
@@ -151,6 +152,10 @@ func (p *Playground) configurePlaygroundHandler(handlers *Handlers) (err error) 
 	}
 
 	playgroundURL := path.Join(p.cfg.PathPrefix, p.cfg.PlaygroundPath)
+	if strings.HasSuffix(p.cfg.PlaygroundPath, "/") || (p.cfg.PlaygroundPath == "" && strings.HasSuffix(p.cfg.PathPrefix, "/")) {
+		playgroundURL += "/"
+	}
+
 	handlers.add(playgroundURL, func(writer http.ResponseWriter, request *http.Request) {
 		writer.Header().Add(contentTypeHeader, contentTypeTextHTML)
 


### PR DESCRIPTION
`path.Join` doesn't respect trailing `/`, so we need to make manual check and concatenate it at the end of playground url.