### PR TITLE
Fix nested escaping of `\` escape symbol

### DIFF
--- a/pkg/escape/bytes.go
+++ b/pkg/escape/bytes.go
@@ -5,7 +5,6 @@ func Bytes(in, out []byte) []byte {
 	out = out[:0]
 
 	for i := range in {
-
 		switch in[i] {
 		case 9:
 			out = append(out, 92, 116) // \t
@@ -17,6 +16,14 @@ func Bytes(in, out []byte) []byte {
 			} else {
 				out = append(out, 92, 34) // \"
 			}
+		case 92:
+			// if we have `\\` inside string
+			if in[i-1] == 92 {
+				// make 4 in a row
+				out = append(out, 92, 92, 92)
+				continue
+			}
+			fallthrough
 		default:
 			out = append(out, in[i])
 		}

--- a/pkg/escape/bytes_test.go
+++ b/pkg/escape/bytes_test.go
@@ -63,7 +63,7 @@ func TestBytes(t *testing.T) {
 	t.Run(run(t, `"foo"`, `\"foo\"`))
 	t.Run(run(t, `foo\n`, `foo\n`))
 	t.Run(run(t, `foo\t`, `foo\t`))
-	t.Run(run(t, `{"test": "{\"foo\": \"bar\"}"}`, `{\"test\": \"{\\\"foo\\\": \\\"bar\\\"}\"}`))
+	t.Run(run(t, `{"test": "{\"foo\": \"bar\", \"re\":\"\\w+\"}"}`, `{\"test\": \"{\\\"foo\\\": \\\"bar\\\", \\\"re\\\":\\\"\\\\w+\\\"}\"}`))
 	t.Run(run(t, `"Hello, 世界"`, `\"Hello, 世界\"`))
 
 }

--- a/pkg/execution/datasource/datasource_http_json.go
+++ b/pkg/execution/datasource/datasource_http_json.go
@@ -277,8 +277,6 @@ func (r *HttpJsonDataSource) Resolve(ctx context.Context, args ResolverArgs, out
 
 	var bodyReader io.Reader
 	if len(bodyArg) != 0 {
-		bodyArg = bytes.ReplaceAll(bodyArg, []byte(`\"`), []byte(`\\"`))
-		bodyArg = bytes.ReplaceAll(bodyArg, []byte(`\"`), []byte(`"`))
 		bodyReader = bytes.NewReader(bodyArg)
 	}
 

--- a/pkg/execution/execution.go
+++ b/pkg/execution/execution.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"strconv"
+	"strings"
 	"sync"
 	"unicode/utf8"
 
@@ -283,13 +284,7 @@ func (e *Executor) ResolveArgs(args []datasource.Argument, data []byte) Resolved
 				result := gjson.GetBytes(resolved[j].Value, unsafebytes.BytesToString(key))
 
 				if result.Type == gjson.String {
-					resultBytes := unsafebytes.StringToBytes(result.Str)
-					if isJSONObjectAsBytes(resultBytes) {
-						resultBytes = bytes.ReplaceAll(resultBytes, []byte(`"`), []byte(`\"`))
-					} else if byteSliceContainsQuotes(resultBytes) {
-						resultBytes = bytes.ReplaceAll(resultBytes, []byte(`"`), []byte(`\"`))
-					}
-
+					resultBytes := unsafebytes.StringToBytes(strings.Trim(strconv.Quote(result.Str), `"`))
 					return w.Write(resultBytes)
 				}
 

--- a/pkg/execution/execution_test.go
+++ b/pkg/execution/execution_test.go
@@ -2151,7 +2151,7 @@ func TestExecutor_HTTPJSONDataSourceWithBody(t *testing.T) {
 	t.Run("should successfully use data source with body including complex json object with escaped strings", func(t *testing.T) {
 		wantUpstream := map[string]interface{}{
 			"meta_data": map[string]interface{}{
-				"test": "{foo: \"bar\"}",
+				"test": "{\"foo\": \"bar\", \"re\":\"\\w+\"}",
 			},
 		}
 		wantBytes, err := json.MarshalIndent(wantUpstream, "", "  ")
@@ -2170,7 +2170,7 @@ func TestExecutor_HTTPJSONDataSourceWithBody(t *testing.T) {
 		restServer := createRESTServer(wantString)
 		defer restServer.Client()
 
-		run(t, restServer, `{{ .arguments.input.query }}`, `{"query": { "meta_data": { "test": "{foo: \"bar\"}" } }`, expectedResult)
+		run(t, restServer, `{{ .arguments.input.query }}`, `{"query": { "meta_data": { "test": "{\"foo\": \"bar\", \"re\":\"\\w+\"}" } }`, expectedResult)
 	})
 
 }

--- a/pkg/execution/execution_test.go
+++ b/pkg/execution/execution_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/cespare/xxhash"
 	log "github.com/jensneuse/abstractlogger"
-	"github.com/jensneuse/diffview"
 	"github.com/sebdah/goldie"
 	"github.com/stretchr/testify/assert"
 
@@ -588,7 +587,7 @@ func TestExecution(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		diffview.NewGoland().DiffViewBytes("execution", fixture, pretty)
+		assert.Equal(t, fixture, pretty)
 	}
 }
 
@@ -3010,13 +3009,12 @@ func TestExecutor_Introspection(t *testing.T) {
 
 	goldie.Assert(t, "introspection_execution", response)
 	if t.Failed() {
-
 		fixture, err := ioutil.ReadFile("./fixtures/introspection_execution.golden")
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		diffview.NewGoland().DiffViewBytes("execution", fixture, response)
+		assert.Equal(t, fixture, response)
 	}
 }
 

--- a/pkg/execution/jsonvaluetype.go
+++ b/pkg/execution/jsonvaluetype.go
@@ -6,10 +6,8 @@ import (
 	"fmt"
 	"io"
 	"strconv"
-	_ "strings"
 
 	"github.com/jensneuse/graphql-go-tools/internal/pkg/unsafebytes"
-	_ "github.com/jensneuse/graphql-go-tools/pkg/escape"
 	"github.com/jensneuse/graphql-go-tools/pkg/lexer/literal"
 )
 

--- a/pkg/execution/jsonvaluetype.go
+++ b/pkg/execution/jsonvaluetype.go
@@ -5,9 +5,11 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"strconv"
+	_ "strings"
 
 	"github.com/jensneuse/graphql-go-tools/internal/pkg/unsafebytes"
-	"github.com/jensneuse/graphql-go-tools/pkg/escape"
+	_ "github.com/jensneuse/graphql-go-tools/pkg/escape"
 	"github.com/jensneuse/graphql-go-tools/pkg/lexer/literal"
 )
 
@@ -38,9 +40,7 @@ func (i JSONValueType) writeValue(value, escapeBuf []byte, out io.Writer) (n int
 
 	switch i {
 	case StringValueType:
-		n, err = i.write(n, err, out, literal.QUOTE)
-		n, err = i.write(n, err, out, escape.Bytes(value, escapeBuf))
-		return i.write(n, err, out, literal.QUOTE)
+		return i.write(n, err, out, []byte(strconv.Quote(string(value))))
 	case IntegerValueType:
 		if !unsafebytes.BytesIsValidInt64(value) {
 			return n, ErrJSONValueTypeValueIncompatible{


### PR DESCRIPTION
Essentially it is an additional set of fixes, for the previous PR https://github.com/TykTechnologies/graphql-go-tools/pull/61
Quoting and Unquoting is not that straightforward, take a loot at https://golang.org/src/encoding/json/decode.go `unquoteBytes` function. 

We continue hitting bugs related to escaped symbols, because built-in "escape" function does not handle some cases. And based on the implementation I see in Golang there are way more. 

This PR makes it use standard `strconv.Quote` function, which handles all these scenarios. 

Additionally, I was not able to figure out what this lines do (and frankly the logic itself is a bit off), so I just removed them:
https://github.com/TykTechnologies/graphql-go-tools/pull/66/files#diff-b07a4e25e3d7f6482ed988bdf67cbfe8L280-L281

Plus in some test we dependent on the byte diff viewer which requires goland to be installed, I made it work with `assert` package, and it actually prints a really nice bytes diff. 

Fix https://github.com/TykTechnologies/graphql-go-tools/issues/65