### PR TITLE
fix operation name regression (TT-687)

### DIFF
--- a/pkg/ast/ast_operation_definition.go
+++ b/pkg/ast/ast_operation_definition.go
@@ -81,7 +81,11 @@ func (d *Document) AddImportedVariableDefinitionToOperationDefinition(operationD
 }
 
 func (d *Document) OperationNameExists(operationName string) bool {
-	for i := 0; i < len(d.OperationDefinitions); i++ {
+
+	for i := range d.RootNodes {
+		if d.RootNodes[i].Kind != NodeKindOperationDefinition {
+			continue
+		}
 		if d.OperationDefinitionNameString(i) == operationName {
 			return true
 		}

--- a/pkg/ast/ast_operation_definition.go
+++ b/pkg/ast/ast_operation_definition.go
@@ -81,15 +81,13 @@ func (d *Document) AddImportedVariableDefinitionToOperationDefinition(operationD
 }
 
 func (d *Document) OperationNameExists(operationName string) bool {
-	nameExists := false
 	for i := 0; i < len(d.OperationDefinitions); i++ {
 		if d.OperationDefinitionNameString(i) == operationName {
-			nameExists = true
-			break
+			return true
 		}
 	}
 
-	return nameExists
+	return false
 }
 
 const (

--- a/pkg/ast/ast_operation_definition.go
+++ b/pkg/ast/ast_operation_definition.go
@@ -94,6 +94,15 @@ func (d *Document) OperationNameExists(operationName string) bool {
 	return false
 }
 
+func (d *Document) NumOfOperationDefinitions () (n int) {
+	for i := range d.RootNodes {
+		if d.RootNodes[i].Kind == NodeKindOperationDefinition {
+			n++
+		}
+	}
+	return
+}
+
 const (
 	alphabet = `abcdefghijklmnopqrstuvwxyz`
 )

--- a/pkg/ast/ast_operation_definition.go
+++ b/pkg/ast/ast_operation_definition.go
@@ -80,6 +80,18 @@ func (d *Document) AddImportedVariableDefinitionToOperationDefinition(operationD
 		append(d.OperationDefinitions[operationDefinition].VariableDefinitions.Refs, variableDefinition)
 }
 
+func (d *Document) OperationNameExists(operationName string) bool {
+	nameExists := false
+	for i := 0; i < len(d.OperationDefinitions); i++ {
+		if d.OperationDefinitionNameString(i) == operationName {
+			nameExists = true
+			break
+		}
+	}
+
+	return nameExists
+}
+
 const (
 	alphabet = `abcdefghijklmnopqrstuvwxyz`
 )

--- a/pkg/ast/ast_operation_definition_test.go
+++ b/pkg/ast/ast_operation_definition_test.go
@@ -12,6 +12,12 @@ func TestDocument_OperationNameExists(t *testing.T) {
 			doc := Document{}
 			operationDefinitions := operationDefinitionsFunc(&doc)
 			doc.OperationDefinitions = append(doc.OperationDefinitions, operationDefinitions...)
+			for i := range doc.OperationDefinitions {
+				doc.RootNodes = append(doc.RootNodes, Node{
+					Kind: NodeKindOperationDefinition,
+					Ref: i,
+				})
+			}
 			exists := doc.OperationNameExists(operationName)
 			assert.Equal(t, expectedExists, exists)
 		}

--- a/pkg/ast/ast_operation_definition_test.go
+++ b/pkg/ast/ast_operation_definition_test.go
@@ -40,6 +40,18 @@ func TestDocument_OperationNameExists(t *testing.T) {
 		false,
 	))
 
+	t.Run("found on document with a single operations", run(
+		func(doc *Document) []OperationDefinition {
+			return []OperationDefinition{
+				{
+					Name: doc.Input.AppendInputString("MyOperation"),
+				},
+			}
+		},
+		"MyOperation",
+		true,
+	))
+
 	t.Run("found on document with multiple operations", run(
 		func(doc *Document) []OperationDefinition {
 			return []OperationDefinition{

--- a/pkg/ast/ast_operation_definition_test.go
+++ b/pkg/ast/ast_operation_definition_test.go
@@ -1,0 +1,60 @@
+package ast
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDocument_OperationNameExists(t *testing.T) {
+	run := func(operationDefinitionsFunc func(doc *Document) []OperationDefinition, operationName string, expectedExists bool) func(t *testing.T) {
+		return func(t *testing.T) {
+			doc := Document{}
+			operationDefinitions := operationDefinitionsFunc(&doc)
+			doc.OperationDefinitions = append(doc.OperationDefinitions, operationDefinitions...)
+			exists := doc.OperationNameExists(operationName)
+			assert.Equal(t, expectedExists, exists)
+		}
+	}
+
+	t.Run("not found on empty document", run(
+		func(doc *Document) []OperationDefinition {
+			return []OperationDefinition{}
+		},
+		"MyOperation",
+		false,
+	))
+
+	t.Run("not found on document with multiple operations", run(
+		func(doc *Document) []OperationDefinition {
+			return []OperationDefinition{
+				{
+					Name: doc.Input.AppendInputString("OtherOperation"),
+				},
+				{
+					Name: doc.Input.AppendInputString("AnotherOperation"),
+				},
+			}
+		},
+		"MyOperation",
+		false,
+	))
+
+	t.Run("found on document with multiple operations", run(
+		func(doc *Document) []OperationDefinition {
+			return []OperationDefinition{
+				{
+					Name: doc.Input.AppendInputString("OtherOperation"),
+				},
+				{
+					Name: doc.Input.AppendInputString("MyOperation"),
+				},
+				{
+					Name: doc.Input.AppendInputString("AnotherOperation"),
+				},
+			}
+		},
+		"MyOperation",
+		true,
+	))
+}

--- a/pkg/engine/plan/plan.go
+++ b/pkg/engine/plan/plan.go
@@ -215,13 +215,15 @@ func (p *Planner) Plan(operation, definition *ast.Document, operationName string
 }
 
 func (p *Planner) selectOperation(operation *ast.Document, operationName string, report *operationreport.Report) {
+
+	numOfOperations := operation.NumOfOperationDefinitions()
 	operationName = strings.TrimSpace(operationName)
-	if len(operationName) == 0 && len(operation.OperationDefinitions) > 1 {
+	if len(operationName) == 0 && numOfOperations > 1 {
 		report.AddExternalError(operationreport.ErrRequiredOperationNameIsMissing())
 		return
 	}
 
-	if len(operationName) == 0 && len(operation.OperationDefinitions) == 1 {
+	if len(operationName) == 0 && numOfOperations == 1 {
 		operationName = operation.OperationDefinitionNameString(0)
 	}
 

--- a/pkg/engine/plan/plan_test.go
+++ b/pkg/engine/plan/plan_test.go
@@ -44,7 +44,7 @@ func TestPlanner_Plan(t *testing.T) {
 		return func(t *testing.T) {
 			var report operationreport.Report
 			_ = testLogic(definition, operation, operationName, config, &report)
-			assert.Error(t, report)
+			assert.True(t, report.HasErrors())
 		}
 	}
 


### PR DESCRIPTION
From GraphQL Spec:
```
GetOperation(document, operationName)
 - If operationName is null:
   - If document contains exactly one operation.
     - Return the Operation contained in the document.
   - Otherwise produce a query error requiring operationName.
Otherwise:
 - Let operation be the Operation named operationName in document.
 - If operation was not found, produce a query error.
 - Return operation.
```