### PR TITLE
fix unable to reuse an aliased field data sources (TT-538)

### DIFF
--- a/pkg/engine/datasource/graphql_datasource/graphql_datasource.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_datasource.go
@@ -46,6 +46,10 @@ type Planner struct {
 	rootTypeName               string
 }
 
+func (p *Planner) MergeAliasedRootNodes() bool {
+	return true
+}
+
 type Configuration struct {
 	Fetch        FetchConfiguration
 	Subscription SubscriptionConfiguration

--- a/pkg/engine/datasource/graphql_datasource/graphql_datasource.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_datasource.go
@@ -46,8 +46,11 @@ type Planner struct {
 	rootTypeName               string
 }
 
-func (p *Planner) MergeAliasedRootNodes() bool {
-	return true
+func (p *Planner) DataSourcePlanningBehavior() plan.DataSourcePlanningBehavior {
+	return plan.DataSourcePlanningBehavior{
+		MergeAliasedRootNodes:      true,
+		OverrideFieldPathFromAlias: true,
+	}
 }
 
 type Configuration struct {

--- a/pkg/engine/datasource/graphql_datasource/graphql_datasource.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_datasource.go
@@ -46,6 +46,34 @@ type Planner struct {
 	rootTypeName               string
 }
 
+func (p *Planner) DownstreamResponseFieldAlias(downstreamFieldRef int) (alias string, exists bool) {
+
+	// If there's no alias but the downstream Query re-uses the same path on different root fields,
+	// we rewrite the downstream Query using an alias so that we can have an aliased Query to the upstream
+	// while keeping a non aliased Query to the downstream but with a path rewrite on an existing root field.
+
+	fieldName := p.visitor.Operation.FieldNameString(downstreamFieldRef)
+
+	if p.visitor.Operation.FieldAliasIsDefined(downstreamFieldRef) {
+		return "", false
+	}
+
+	typeName := p.visitor.Walker.EnclosingTypeDefinition.NameString(p.visitor.Definition)
+	for i := range p.visitor.Config.Fields {
+		if p.visitor.Config.Fields[i].TypeName == typeName &&
+			p.visitor.Config.Fields[i].FieldName == fieldName &&
+			len(p.visitor.Config.Fields[i].Path) == 1 {
+
+			if p.visitor.Config.Fields[i].Path[0] != fieldName {
+				aliasBytes := p.visitor.Operation.FieldNameBytes(downstreamFieldRef)
+				return string(aliasBytes), true
+			}
+			break
+		}
+	}
+	return "", false
+}
+
 func (p *Planner) DataSourcePlanningBehavior() plan.DataSourcePlanningBehavior {
 	return plan.DataSourcePlanningBehavior{
 		MergeAliasedRootNodes:      true,
@@ -196,8 +224,6 @@ func (p *Planner) EnterField(ref int) {
 	p.handleFederation(ref)
 
 	p.addField(ref)
-
-	// fmt.Printf("Planner::%s::%s::EnterField::%s::%d\n", p.id, p.visitor.Walker.Path.DotDelimitedString(), p.visitor.Operation.FieldNameString(ref), ref)
 
 	upstreamFieldRef := p.nodes[len(p.nodes)-1].Ref
 	typeName := p.lastFieldEnclosingTypeName
@@ -612,12 +638,8 @@ func (p *Planner) stopWithError(msg string, args ...interface{}) {
 //
 // TODO: implement less hacky solution to normalize upstream queries
 func (p *Planner) normalizeOperation(operation, definition *ast.Document, report *operationreport.Report, withRetry bool) (ok bool) {
+
 	report.Reset()
-
-	operationStr, _ := astprinter.PrintStringIndent(operation, definition, "  ")
-	schemaStr, _ := astprinter.PrintStringIndent(definition, nil, "  ")
-	_, _ = schemaStr, operationStr
-
 	normalizer := astnormalization.NewNormalizer(true, true)
 	normalizer.NormalizeOperation(operation, definition, report)
 
@@ -653,7 +675,15 @@ func (p *Planner) addField(ref int) {
 		if p.visitor.Config.Fields[i].TypeName == typeName &&
 			p.visitor.Config.Fields[i].FieldName == fieldName &&
 			len(p.visitor.Config.Fields[i].Path) == 1 {
+
+			if p.visitor.Config.Fields[i].Path[0] != fieldName && !alias.IsDefined {
+				alias.IsDefined = true
+				aliasBytes := p.visitor.Operation.FieldNameBytes(ref)
+				alias.Name = p.upstreamOperation.Input.AppendInputBytes(aliasBytes)
+			}
+
 			fieldName = p.visitor.Config.Fields[i].Path[0]
+
 			break
 		}
 	}

--- a/pkg/engine/datasource/graphql_datasource/graphql_datasource_test.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_datasource_test.go
@@ -156,8 +156,7 @@ func TestGraphQLDataSource(t *testing.T) {
 						FieldNames: []string{"name", "primaryFunction", "friends"},
 					},
 				},
-				Factory:                    &Factory{},
-				OverrideFieldPathFromAlias: true,
+				Factory: &Factory{},
 				Custom: ConfigJson(Configuration{
 					Fetch: FetchConfiguration{
 						URL: "https://swapi.com/graphql",
@@ -257,7 +256,6 @@ func TestGraphQLDataSource(t *testing.T) {
 							FieldNames: []string{"id", "name"},
 						},
 					},
-					OverrideFieldPathFromAlias: true,
 					Custom: ConfigJson(Configuration{
 						Fetch: FetchConfiguration{
 							URL: "https://service.one",
@@ -352,8 +350,7 @@ func TestGraphQLDataSource(t *testing.T) {
 							FieldNames: []string{"bar"},
 						},
 					},
-					Factory:                    &Factory{},
-					OverrideFieldPathFromAlias: true,
+					Factory: &Factory{},
 					Custom: ConfigJson(Configuration{
 						Fetch: FetchConfiguration{
 							URL: "https://foo.service",
@@ -641,8 +638,7 @@ func TestGraphQLDataSource(t *testing.T) {
 							URL: "https://service.one",
 						},
 					}),
-					Factory:                    nestedGraphQLEngineFactory,
-					OverrideFieldPathFromAlias: true,
+					Factory: nestedGraphQLEngineFactory,
 				},
 				{
 					RootNodes: []plan.TypeField{
@@ -662,8 +658,7 @@ func TestGraphQLDataSource(t *testing.T) {
 							URL: "https://service.two",
 						},
 					}),
-					Factory:                    nestedGraphQLEngineFactory,
-					OverrideFieldPathFromAlias: true,
+					Factory: nestedGraphQLEngineFactory,
 				},
 				{
 					RootNodes: []plan.TypeField{
@@ -683,8 +678,7 @@ func TestGraphQLDataSource(t *testing.T) {
 							URL: "https://country.service",
 						},
 					}),
-					Factory:                    nestedGraphQLEngineFactory,
-					OverrideFieldPathFromAlias: true,
+					Factory: nestedGraphQLEngineFactory,
 				},
 			},
 			Fields: []plan.FieldConfiguration{

--- a/pkg/engine/datasource/graphql_datasource/graphql_datasource_test.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_datasource_test.go
@@ -440,7 +440,7 @@ func TestGraphQLDataSource(t *testing.T) {
 							Name:      []byte("alias"),
 							Value: &resolve.Object{
 								Nullable: true,
-								Path:     []string{"country"},
+								Path:     []string{"alias"},
 								Fields: []*resolve.Field{
 									{
 										Name: []byte("name"),
@@ -561,7 +561,7 @@ func TestGraphQLDataSource(t *testing.T) {
 							Name:      []byte("countryAlias"),
 							Value: &resolve.Object{
 								Nullable: true,
-								Path:     []string{"country"},
+								Path:     []string{"countryAlias"},
 								Fields: []*resolve.Field{
 									{
 										Name: []byte("name"),
@@ -587,10 +587,6 @@ func TestGraphQLDataSource(t *testing.T) {
 						},
 					},
 					ChildNodes: []plan.TypeField{
-						{
-							TypeName:   "Country",
-							FieldNames: []string{"name", "code"},
-						},
 						{
 							TypeName:   "Country",
 							FieldNames: []string{"name", "code"},
@@ -698,7 +694,6 @@ func TestGraphQLDataSource(t *testing.T) {
 							},
 							{
 								BufferId: 2,
-								// 			 {"method":"POST","url":"https://service.two","body":{"query":"query($secondArg: Boolean, $fourthArg: Float){serviceTwo(serviceTwoArg: $secondArg){fieldTwo} secondServiceTwo(secondServiceTwoArg: $fourthArg){fieldTwo serviceOneField}}","variables":{"fourthArg":$$1$$,"secondArg":$$0$$}}}
 								Input:      `{"method":"POST","url":"https://service.two","body":{"query":"query($secondArg: Boolean, $fourthArg: Float){serviceTwo(serviceTwoArg: $secondArg){fieldTwo serviceOneField} secondServiceTwo(secondServiceTwoArg: $fourthArg){fieldTwo serviceOneField}}","variables":{"fourthArg":$$1$$,"secondArg":$$0$$}}}`,
 								DataSource: &Source{},
 								Variables: resolve.NewVariables(
@@ -722,7 +717,7 @@ func TestGraphQLDataSource(t *testing.T) {
 								Path:     []string{"serviceOne"},
 
 								Fetch: &resolve.SingleFetch{
-									BufferId:   1, // here is ok
+									BufferId:   1,
 									DataSource: &Source{},
 									Input:      `{"method":"POST","url":"https://country.service","body":{"query":"{countries {name}}"}}`,
 								},
@@ -765,7 +760,7 @@ func TestGraphQLDataSource(t *testing.T) {
 								Fetch: &resolve.SingleFetch{
 									BufferId:   3,
 									DataSource: &Source{},
-									Input:      `{"method":"POST","url":"https://service.one","body":{"query":"query($a: String){serviceOne(serviceOneArg: $a){fieldOne}}","variables":{"a":"$$0$$"}}}`,
+									Input:      `{"method":"POST","url":"https://service.one","body":{"query":"query($a: String){serviceOneResponse: serviceOne(serviceOneArg: $a){fieldOne}}","variables":{"a":"$$0$$"}}}`,
 									Variables: resolve.NewVariables(
 										&resolve.ObjectVariable{
 											Path: []string{"serviceOneField"},
@@ -786,7 +781,7 @@ func TestGraphQLDataSource(t *testing.T) {
 										Name:      []byte("serviceOneResponse"),
 										Value: &resolve.Object{
 											Nullable: true,
-											Path:     []string{"serviceOne"},
+											Path:     []string{"serviceOneResponse"},
 											Fields: []*resolve.Field{
 												{
 													Name: []byte("fieldOne"),

--- a/pkg/engine/datasource/rest_datasource/rest_datasource.go
+++ b/pkg/engine/datasource/rest_datasource/rest_datasource.go
@@ -28,8 +28,11 @@ type Planner struct {
 	operationDefinition int
 }
 
-func (p *Planner) MergeAliasedRootNodes() bool {
-	return false
+func (p *Planner) DataSourcePlanningBehavior() plan.DataSourcePlanningBehavior {
+	return plan.DataSourcePlanningBehavior{
+		MergeAliasedRootNodes:      false,
+		OverrideFieldPathFromAlias: false,
+	}
 }
 
 func (p *Planner) EnterOperationDefinition(ref int) {

--- a/pkg/engine/datasource/rest_datasource/rest_datasource.go
+++ b/pkg/engine/datasource/rest_datasource/rest_datasource.go
@@ -28,6 +28,10 @@ type Planner struct {
 	operationDefinition int
 }
 
+func (p *Planner) MergeAliasedRootNodes() bool {
+	return false
+}
+
 func (p *Planner) EnterOperationDefinition(ref int) {
 	p.operationDefinition = ref
 }

--- a/pkg/engine/datasource/rest_datasource/rest_datasource.go
+++ b/pkg/engine/datasource/rest_datasource/rest_datasource.go
@@ -28,6 +28,11 @@ type Planner struct {
 	operationDefinition int
 }
 
+func (p *Planner) DownstreamResponseFieldAlias(downstreamFieldRef int) (alias string, exists bool) {
+	// the REST DataSourcePlanner doesn't rewrite upstream fields: skip
+	return
+}
+
 func (p *Planner) DataSourcePlanningBehavior() plan.DataSourcePlanningBehavior {
 	return plan.DataSourcePlanningBehavior{
 		MergeAliasedRootNodes:      false,

--- a/pkg/engine/datasource/staticdatasource/static_datasource.go
+++ b/pkg/engine/datasource/staticdatasource/static_datasource.go
@@ -31,6 +31,11 @@ type Planner struct {
 	config Configuration
 }
 
+func (p *Planner) DownstreamResponseFieldAlias(downstreamFieldRef int) (alias string, exists bool) {
+	// skip, not required
+	return
+}
+
 func (p *Planner) DataSourcePlanningBehavior() plan.DataSourcePlanningBehavior {
 	return plan.DataSourcePlanningBehavior{
 		MergeAliasedRootNodes:      false,

--- a/pkg/engine/datasource/staticdatasource/static_datasource.go
+++ b/pkg/engine/datasource/staticdatasource/static_datasource.go
@@ -31,6 +31,10 @@ type Planner struct {
 	config Configuration
 }
 
+func (p *Planner) MergeAliasedRootNodes() bool {
+	return false
+}
+
 func (p *Planner) Register(visitor *plan.Visitor, customConfiguration json.RawMessage, isNested bool) error {
 	return json.Unmarshal(customConfiguration, &p.config)
 }

--- a/pkg/engine/datasource/staticdatasource/static_datasource.go
+++ b/pkg/engine/datasource/staticdatasource/static_datasource.go
@@ -31,8 +31,11 @@ type Planner struct {
 	config Configuration
 }
 
-func (p *Planner) MergeAliasedRootNodes() bool {
-	return false
+func (p *Planner) DataSourcePlanningBehavior() plan.DataSourcePlanningBehavior {
+	return plan.DataSourcePlanningBehavior{
+		MergeAliasedRootNodes:      false,
+		OverrideFieldPathFromAlias: false,
+	}
 }
 
 func (p *Planner) Register(visitor *plan.Visitor, customConfiguration json.RawMessage, isNested bool) error {

--- a/pkg/engine/datasourcetesting/datasourcetesting.go
+++ b/pkg/engine/datasourcetesting/datasourcetesting.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/jensneuse/graphql-go-tools/internal/pkg/unsafeparser"
+	"github.com/jensneuse/graphql-go-tools/pkg/ast"
 	"github.com/jensneuse/graphql-go-tools/pkg/astnormalization"
 	"github.com/jensneuse/graphql-go-tools/pkg/astprinter"
 	"github.com/jensneuse/graphql-go-tools/pkg/asttransform"
@@ -14,7 +15,9 @@ import (
 	"github.com/jensneuse/graphql-go-tools/pkg/operationreport"
 )
 
-func RunTest(definition, operation, operationName string, expectedPlan plan.Plan, config plan.Configuration) func(t *testing.T) {
+type CheckFunc func(t *testing.T, op ast.Document, actualPlan plan.Plan)
+
+func RunTest(definition, operation, operationName string, expectedPlan plan.Plan, config plan.Configuration, extraChecks ...CheckFunc) func(t *testing.T) {
 	return func(t *testing.T) {
 		def := unsafeparser.ParseGraphqlDocumentString(definition)
 		op := unsafeparser.ParseGraphqlDocumentString(operation)
@@ -41,5 +44,10 @@ func RunTest(definition, operation, operationName string, expectedPlan plan.Plan
 			t.Fatal(report.Error())
 		}
 		assert.Equal(t, expectedPlan, actualPlan)
+
+		for _, extraCheck := range extraChecks {
+			extraCheck(t, op, actualPlan)
+		}
+
 	}
 }

--- a/pkg/engine/plan/plan.go
+++ b/pkg/engine/plan/plan.go
@@ -569,7 +569,10 @@ func (v *Visitor) resolveFieldPath(ref int) []string {
 	typeName := v.Walker.EnclosingTypeDefinition.NameString(v.Definition)
 	fieldName := v.Operation.FieldNameString(ref)
 	config := v.currentOrParentPlannerConfiguration()
-	aliasOverride := config.planner.DataSourcePlanningBehavior().OverrideFieldPathFromAlias
+	aliasOverride := false
+	if config.planner != nil {
+		aliasOverride = config.planner.DataSourcePlanningBehavior().OverrideFieldPathFromAlias
+	}
 
 	for i := range v.Config.Fields {
 		if v.Config.Fields[i].TypeName == typeName && v.Config.Fields[i].FieldName == fieldName {

--- a/pkg/engine/plan/plan.go
+++ b/pkg/engine/plan/plan.go
@@ -323,16 +323,6 @@ func (v *Visitor) currentFullPath() string {
 	return path
 }
 
-func (v *Visitor) currentPlannerConfiguration() plannerConfiguration {
-	path := v.currentFullPath()
-	for i := range v.planners {
-		if v.planners[i].hasPath(path) {
-			return v.planners[i]
-		}
-	}
-	return plannerConfiguration{}
-}
-
 func (v *Visitor) EnterDirective(ref int) {
 	directiveName := v.Operation.DirectiveNameString(ref)
 	ancestor := v.Walker.Ancestors[len(v.Walker.Ancestors)-1]
@@ -628,6 +618,7 @@ func (v *Visitor) currentOrParentPlannerConfiguration() plannerConfiguration {
 				if currentPlannerPathDeepness > plannerPathDeepness {
 					plannerPathDeepness = currentPlannerPathDeepness
 					plannerIndex = i
+					break
 				}
 			}
 		}


### PR DESCRIPTION
This PR will fix a problem, where it wasn't possible to execute an aliased field data source when this data source was already invoked with the same field.
This resulted in a problem, where REST Data Source could only be used once.

Example:
```
{
  hello(name = "world")
  anotherHello: hell(name = "max")
}
```

This would result in invoking the `Query.hello` data source only once.