### PR TITLE
enforce dot as first non-space character in templates (TT-1769)

### DIFF
--- a/pkg/engine/datasource/graphql_datasource/graphql_datasource_test.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_datasource_test.go
@@ -32,7 +32,7 @@ func TestGraphQLDataSource(t *testing.T) {
 				Fetch: &resolve.SingleFetch{
 					DataSource: &Source{},
 					BufferId:   0,
-					Input:      `{"method":"POST","url":"https://swapi.com/graphql","header":{"Authorization":["$$1$$"]},"body":{"query":"query($id: ID!){droid(id: $id){name aliased: name friends {name} primaryFunction} hero {name} stringList nestedStringList}","variables":{"id":"$$0$$"}}}`,
+					Input:      `{"method":"POST","url":"https://swapi.com/graphql","header":{"Authorization":["$$1$$"],"Invalid-Template":["{{ request.header.Authorization }}"]},"body":{"query":"query($id: ID!){droid(id: $id){name aliased: name friends {name} primaryFunction} hero {name} stringList nestedStringList}","variables":{"id":"$$0$$"}}}`,
 					Variables: resolve.NewVariables(
 						&resolve.ContextVariable{
 							Path: []string{"id"},
@@ -162,7 +162,8 @@ func TestGraphQLDataSource(t *testing.T) {
 					Fetch: FetchConfiguration{
 						URL: "https://swapi.com/graphql",
 						Header: http.Header{
-							"Authorization": []string{"{{ .request.header.Authorization }}"},
+							"Authorization":    []string{"{{ .request.header.Authorization }}"},
+							"Invalid-Template": []string{"{{ request.header.Authorization }}"},
 						},
 					},
 				}),

--- a/pkg/engine/datasource/graphql_datasource/graphql_datasource_test.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_datasource_test.go
@@ -32,7 +32,7 @@ func TestGraphQLDataSource(t *testing.T) {
 				Fetch: &resolve.SingleFetch{
 					DataSource: &Source{},
 					BufferId:   0,
-					Input:      `{"method":"POST","url":"https://swapi.com/graphql","header":{"Authorization":["$$1$$"],"Invalid-Template":["{{ request.header.Authorization }}"]},"body":{"query":"query($id: ID!){droid(id: $id){name aliased: name friends {name} primaryFunction} hero {name} stringList nestedStringList}","variables":{"id":"$$0$$"}}}`,
+					Input:      `{"method":"POST","url":"https://swapi.com/graphql","header":{"Authorization":["$$1$$"],"Invalid-Template":["{{ request.headers.Authorization }}"]},"body":{"query":"query($id: ID!){droid(id: $id){name aliased: name friends {name} primaryFunction} hero {name} stringList nestedStringList}","variables":{"id":"$$0$$"}}}`,
 					Variables: resolve.NewVariables(
 						&resolve.ContextVariable{
 							Path: []string{"id"},
@@ -162,8 +162,8 @@ func TestGraphQLDataSource(t *testing.T) {
 					Fetch: FetchConfiguration{
 						URL: "https://swapi.com/graphql",
 						Header: http.Header{
-							"Authorization":    []string{"{{ .request.header.Authorization }}"},
-							"Invalid-Template": []string{"{{ request.header.Authorization }}"},
+							"Authorization":    []string{"{{ .request.headers.Authorization }}"},
+							"Invalid-Template": []string{"{{ request.headers.Authorization }}"},
 						},
 					},
 				}),

--- a/pkg/engine/datasource/rest_datasource/rest_datasource_test.go
+++ b/pkg/engine/datasource/rest_datasource/rest_datasource_test.go
@@ -473,7 +473,7 @@ func TestFastHttpJsonDataSourcePlanning(t *testing.T) {
 				Data: &resolve.Object{
 					Fetch: &resolve.SingleFetch{
 						BufferId:   0,
-						Input:      `{"header":{"Authorization":["Bearer 123"],"Invalid-Template":["{{ request.header.Authorization }}"],"Token":["Bearer $$0$$"],"X-API-Key":["456"]},"method":"GET","url":"https://example.com/friend"}`,
+						Input:      `{"header":{"Authorization":["Bearer 123"],"Invalid-Template":["{{ request.headers.Authorization }}"],"Token":["Bearer $$0$$"],"X-API-Key":["456"]},"method":"GET","url":"https://example.com/friend"}`,
 						DataSource: &Source{},
 						Variables: []resolve.Variable{
 							&resolve.HeaderVariable{
@@ -519,8 +519,8 @@ func TestFastHttpJsonDataSourcePlanning(t *testing.T) {
 							Header: http.Header{
 								"Authorization":    []string{"Bearer 123"},
 								"X-API-Key":        []string{"456"},
-								"Token":            []string{"Bearer {{ .request.header.Authorization }}"},
-								"Invalid-Template": []string{"{{ request.header.Authorization }}"},
+								"Token":            []string{"Bearer {{ .request.headers.Authorization }}"},
+								"Invalid-Template": []string{"{{ request.headers.Authorization }}"},
 							},
 						},
 					}),

--- a/pkg/engine/datasource/rest_datasource/rest_datasource_test.go
+++ b/pkg/engine/datasource/rest_datasource/rest_datasource_test.go
@@ -473,7 +473,7 @@ func TestFastHttpJsonDataSourcePlanning(t *testing.T) {
 				Data: &resolve.Object{
 					Fetch: &resolve.SingleFetch{
 						BufferId:   0,
-						Input:      `{"header":{"Authorization":["Bearer 123"],"Token":["Bearer $$0$$"],"X-API-Key":["456"]},"method":"GET","url":"https://example.com/friend"}`,
+						Input:      `{"header":{"Authorization":["Bearer 123"],"Invalid-Template":["{{ request.header.Authorization }}"],"Token":["Bearer $$0$$"],"X-API-Key":["456"]},"method":"GET","url":"https://example.com/friend"}`,
 						DataSource: &Source{},
 						Variables: []resolve.Variable{
 							&resolve.HeaderVariable{
@@ -517,9 +517,10 @@ func TestFastHttpJsonDataSourcePlanning(t *testing.T) {
 							URL:    "https://example.com/friend",
 							Method: "GET",
 							Header: http.Header{
-								"Authorization": []string{"Bearer 123"},
-								"X-API-Key":     []string{"456"},
-								"Token":         []string{"Bearer {{ .request.header.Authorization }}"},
+								"Authorization":    []string{"Bearer 123"},
+								"X-API-Key":        []string{"456"},
+								"Token":            []string{"Bearer {{ .request.header.Authorization }}"},
+								"Invalid-Template": []string{"{{ request.header.Authorization }}"},
 							},
 						},
 					}),

--- a/pkg/engine/plan/plan.go
+++ b/pkg/engine/plan/plan.go
@@ -612,7 +612,7 @@ func (v *Visitor) LeaveDocument(operation, definition *ast.Document) {
 
 var (
 	templateRegex = regexp.MustCompile(`{{.*?}}`)
-	selectorRegex = regexp.MustCompile(`{{\s*(.*?)\s*}}`)
+	selectorRegex = regexp.MustCompile(`{{\s*\.(.*?)\s*}}`)
 )
 
 func (v *Visitor) resolveInputTemplates(config objectFetchConfiguration, input *string, variables *resolve.Variables) {

--- a/pkg/engine/plan/plan.go
+++ b/pkg/engine/plan/plan.go
@@ -657,7 +657,7 @@ func (v *Visitor) resolveInputTemplates(config objectFetchConfiguration, input *
 				break
 			}
 			switch path[0] {
-			case "header":
+			case "headers":
 				key := path[1]
 				variableName, _ = variables.AddVariable(&resolve.HeaderVariable{
 					Path: []string{key},

--- a/pkg/graphql/execution_engine_v2_test.go
+++ b/pkg/graphql/execution_engine_v2_test.go
@@ -212,7 +212,7 @@ func TestExecutionEngineV2_Execute(t *testing.T) {
 					},
 					Custom: rest_datasource.ConfigJSON(rest_datasource.Configuration{
 						Fetch: rest_datasource.FetchConfiguration{
-							URL:    "https://example.com/{{ .request.header.Authorization }}",
+							URL:    "https://example.com/{{ .request.headers.Authorization }}",
 							Method: "GET",
 						},
 					}),


### PR DESCRIPTION
This PR will enforce dot as the first non-space character in templates.

Currently it is possible to use `{{ .request.headers.XXX }}` as well as `{{ request.headers.XXX }}`

It will also change `{{ .request.header.XXX }}` to `{{ .request.headers.XXX }}`