### PR TITLE
Add separate definition normalizer

### DIFF
--- a/pkg/ast/ast_object_type_extension.go
+++ b/pkg/ast/ast_object_type_extension.go
@@ -48,6 +48,13 @@ func (d *Document) ExtendObjectTypeDefinitionByObjectTypeExtension(objectTypeDef
 		d.ObjectTypeDefinitions[objectTypeDefinitionRef].HasDirectives = true
 	}
 
+	if len(d.ObjectTypeExtensions[objectTypeExtensionRef].ImplementsInterfaces.Refs) > 0 {
+		d.ObjectTypeDefinitions[objectTypeDefinitionRef].ImplementsInterfaces.Refs = append(
+			d.ObjectTypeDefinitions[objectTypeDefinitionRef].ImplementsInterfaces.Refs,
+			d.ObjectTypeExtensions[objectTypeExtensionRef].ImplementsInterfaces.Refs...,
+		)
+	}
+
 	d.Index.MergedTypeExtensions = append(d.Index.MergedTypeExtensions, Node{Ref: objectTypeExtensionRef, Kind: NodeKindObjectTypeExtension})
 }
 

--- a/pkg/astnormalization/astnormalization.go
+++ b/pkg/astnormalization/astnormalization.go
@@ -94,11 +94,10 @@ type registerNormalizeDeleteVariablesFunc func(walker *astvisitor.Walker) *delet
 
 // OperationNormalizer walks a given AST and applies all registered rules
 type OperationNormalizer struct {
-	operationWalkers        []*astvisitor.Walker
-	prepareDefinitionWalker *astvisitor.Walker
-	variablesExtraction     *variablesExtractionVisitor
-	options                 options
-	definitionNormalizer    *DefinitionNormalizer
+	operationWalkers     []*astvisitor.Walker
+	variablesExtraction  *variablesExtractionVisitor
+	options              options
+	definitionNormalizer *DefinitionNormalizer
 }
 
 // NewNormalizer creates a new OperationNormalizer and sets up all default rules

--- a/pkg/astnormalization/astnormalization_test.go
+++ b/pkg/astnormalization/astnormalization_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/jensneuse/graphql-go-tools/internal/pkg/unsafeparser"
 	"github.com/jensneuse/graphql-go-tools/pkg/astprinter"
@@ -16,11 +17,10 @@ import (
 func TestNormalizeOperation(t *testing.T) {
 
 	run := func(t *testing.T, definition, operation, expectedOutput, variablesInput, expectedVariables string) {
+		t.Helper()
+
 		definitionDocument := unsafeparser.ParseGraphqlDocumentString(definition)
-		err := asttransform.MergeDefinitionWithBaseSchema(&definitionDocument)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, asttransform.MergeDefinitionWithBaseSchema(&definitionDocument))
 
 		operationDocument := unsafeparser.ParseGraphqlDocumentString(operation)
 		expectedOutputDocument := unsafeparser.ParseGraphqlDocumentString(expectedOutput)
@@ -34,6 +34,7 @@ func TestNormalizeOperation(t *testing.T) {
 			WithExtractVariables(),
 			WithRemoveFragmentDefinitions(),
 			WithRemoveUnusedVariables(),
+			WithNormalizeDefinition(),
 		)
 		normalizer.NormalizeOperation(&operationDocument, &definitionDocument, &report)
 
@@ -575,7 +576,6 @@ extend input Location {
 `
 
 const extendedRootOperationTypeDefinition = `
-scalar String
 extend type Query {
 	me: String
 }

--- a/pkg/astnormalization/definition_normalization.go
+++ b/pkg/astnormalization/definition_normalization.go
@@ -1,0 +1,47 @@
+package astnormalization
+
+import (
+	"github.com/jensneuse/graphql-go-tools/pkg/ast"
+	"github.com/jensneuse/graphql-go-tools/pkg/astvisitor"
+	"github.com/jensneuse/graphql-go-tools/pkg/operationreport"
+)
+
+// NormalizeDefinition creates a default DefinitionNormalizer and applies all rules to a given AST
+// In case you're using DefinitionNormalizer in a hot path you shouldn't be using this function.
+// Create a new DefinitionNormalizer using NewDefinitionNormalizer() instead and re-use it.
+func NormalizeDefinition(definition *ast.Document, report *operationreport.Report) {
+	normalizer := NewDefinitionNormalizer()
+	normalizer.NormalizeDefinition(definition, report)
+}
+
+// DefinitionNormalizer walks a given AST and applies all registered rules
+type DefinitionNormalizer struct {
+	walker *astvisitor.Walker
+}
+
+// NewDefinitionNormalizer creates a new DefinitionNormalizer and sets up all default rules
+func NewDefinitionNormalizer() *DefinitionNormalizer {
+	normalizer := &DefinitionNormalizer{}
+	normalizer.setupWalkers()
+	return normalizer
+}
+
+func (o *DefinitionNormalizer) setupWalkers() {
+	walker := astvisitor.NewWalker(48)
+
+	extendObjectTypeDefinition(&walker)
+	extendInputObjectTypeDefinition(&walker)
+	extendEnumTypeDefinition(&walker)
+	extendInterfaceTypeDefinition(&walker)
+	extendScalarTypeDefinition(&walker)
+	extendUnionTypeDefinition(&walker)
+	removeMergedTypeExtensions(&walker)
+	implicitSchemaDefinition(&walker)
+
+	o.walker = &walker
+}
+
+// NormalizeDefinition applies all registered rules to the AST
+func (o *DefinitionNormalizer) NormalizeDefinition(definition *ast.Document, report *operationreport.Report) {
+	o.walker.Walk(definition, nil, report)
+}

--- a/pkg/astnormalization/definition_normalization_test.go
+++ b/pkg/astnormalization/definition_normalization_test.go
@@ -68,7 +68,6 @@ func TestNormalizeDefinition(t *testing.T) {
 			interface Entity {
 				id: ID
 			}
-			
 				
 			enum Planet {
 				EARTH
@@ -83,7 +82,7 @@ func TestNormalizeDefinition(t *testing.T) {
 		)
 	})
 
-	t.Run("remove extensions and creates missing schema and root operation types", func(t *testing.T) {
+	t.Run("removes extensions and creates missing schema and root operation types", func(t *testing.T) {
 		run(t, extendedRootOperationTypeDefinition, `
 			schema {
 				query: Query

--- a/pkg/astnormalization/definition_normalization_test.go
+++ b/pkg/astnormalization/definition_normalization_test.go
@@ -1,0 +1,104 @@
+package astnormalization
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/jensneuse/graphql-go-tools/internal/pkg/unsafeparser"
+	"github.com/jensneuse/graphql-go-tools/pkg/astprinter"
+	"github.com/jensneuse/graphql-go-tools/pkg/operationreport"
+)
+
+func TestNormalizeDefinition(t *testing.T) {
+	run := func(t *testing.T, definition, expectedOutput string) {
+		t.Helper()
+
+		definitionDocument := unsafeparser.ParseGraphqlDocumentString(definition)
+		expectedOutputDocument := unsafeparser.ParseGraphqlDocumentString(expectedOutput)
+
+		report := operationreport.Report{}
+		normalizer := NewDefinitionNormalizer()
+		normalizer.NormalizeDefinition(&definitionDocument, &report)
+
+		if report.HasErrors() {
+			t.Fatal(report.Error())
+		}
+
+		got := mustString(astprinter.PrintString(&definitionDocument, nil))
+		want := mustString(astprinter.PrintString(&expectedOutputDocument, nil))
+
+		assert.Equal(t, want, got)
+	}
+
+	t.Run("removes extensions and creates missing types", func(t *testing.T) {
+		run(t, typeExtensionsDefinition, `
+			schema { query: Query }
+			
+			type User implements Entity {
+				name: String
+				id: ID
+				age: Int
+				type: UserType
+				metadata: JSONPayload
+			}
+
+			type TrialUser {
+				enabled: Boolean
+			}
+			
+			type SubscribedUser {
+				subscription: SubscriptionType
+			}
+
+			enum SubscriptionType {
+				BASIC
+				PRO
+				ULTIMATE
+			}
+
+			scalar JSONPayload
+
+			union UserType = TrialUser | SubscribedUser
+			
+			type Query {
+				findUserByLocation(loc: Location): [User]
+			}
+			
+			interface Entity {
+				id: ID
+			}
+			
+				
+			enum Planet {
+				EARTH
+				MARS
+			}
+			
+			input Location {
+				lat: Float 
+				lon: Float
+				planet: Planet
+			}`,
+		)
+	})
+
+	t.Run("remove extensions and creates missing schema and root operation types", func(t *testing.T) {
+		run(t, extendedRootOperationTypeDefinition, `
+			schema {
+				query: Query
+				mutation: Mutation
+				subscription: Subscription
+			}
+			type Query {
+				me: String
+			}
+			type Mutation {
+				increaseTextCounter: String
+			}
+			type Subscription {
+				textCounter: String
+			}`,
+		)
+	})
+}

--- a/pkg/astnormalization/definition_normalization_test.go
+++ b/pkg/astnormalization/definition_normalization_test.go
@@ -82,6 +82,42 @@ func TestNormalizeDefinition(t *testing.T) {
 		)
 	})
 
+	t.Run("removes type extension and includes interfaces when type already has implements interface", func(t *testing.T) {
+		run(t, `
+			schema { query: Query }
+			
+			type User implements Named {
+				name: String
+			}
+	
+			interface Named {
+				name: String
+			}
+
+			extend type User implements Entity {
+				id: ID
+			}
+			
+			interface Entity {
+				id: ID
+			}`, `
+			schema { query: Query }
+			
+			type User implements Named & Entity {
+				name: String
+				id: ID
+			}
+	
+			interface Named {
+				name: String
+			}
+			
+			interface Entity {
+				id: ID
+			}`,
+		)
+	})
+
 	t.Run("removes extensions and creates missing schema and root operation types", func(t *testing.T) {
 		run(t, extendedRootOperationTypeDefinition, `
 			schema {

--- a/pkg/astnormalization/object_type_extending_test.go
+++ b/pkg/astnormalization/object_type_extending_test.go
@@ -100,4 +100,60 @@ func TestExtendObjectType(t *testing.T) {
 			type Cat @deprecated(reason: "not as cool as dogs") @skip(if: false) { age: Int breed: String }
 			`)
 	})
+	t.Run("extend object type by interface", func(t *testing.T) {
+		run(extendObjectTypeDefinition, testDefinition, `
+					type Dog {
+						name: String
+					}
+					extend type Dog implements ToyLover {
+						favoriteToy: String
+					}
+					interface ToyLover {
+						favoriteToy: String
+					}
+					 `, `
+					type Dog implements ToyLover {
+						name: String
+						favoriteToy: String
+					}
+					extend type Dog implements ToyLover {
+						favoriteToy: String
+					}
+					interface ToyLover {
+						favoriteToy: String
+					}
+					`)
+	})
+	t.Run("extend object type which implements interface by interface", func(t *testing.T) {
+		run(extendObjectTypeDefinition, testDefinition, `
+					type Dog implements ToyHater {
+						name: String
+						hatedToy: String
+					}
+					extend type Dog implements ToyLover {
+						favoriteToy: String
+					}
+					interface ToyLover {
+						favoriteToy: String
+					}
+					interface ToyHater {
+						hatedToy: String
+					}
+					 `, `
+					type Dog implements ToyHater & ToyLover {
+						name: String
+						hatedToy: String
+						favoriteToy: String
+					}
+					extend type Dog implements ToyLover {
+						favoriteToy: String
+					}
+					interface ToyLover {
+						favoriteToy: String
+					}
+					interface ToyHater {
+						hatedToy: String
+					}
+					`)
+	})
 }


### PR DESCRIPTION
move definition normalization to a separate type
add WithNormalizeDefinition option for OperationNormalizer
include interfaces when extending object type definition