### PR TITLE
fix _entities queries validation for federation schemas

### DIFF
--- a/pkg/astvalidation/astvalidation.go
+++ b/pkg/astvalidation/astvalidation.go
@@ -845,14 +845,14 @@ func (v *valuesVisitor) valueSatisfiesEnum(value ast.Value, node ast.Node) bool 
 		if v.Ancestors[0].Kind != ast.NodeKindOperationDefinition {
 			return false
 		}
-		definition,ok := v.operation.VariableDefinitionByNameAndOperation(v.Ancestors[0].Ref,name)
+		definition, ok := v.operation.VariableDefinitionByNameAndOperation(v.Ancestors[0].Ref, name)
 		if !ok {
 			return false
 		}
 		variableType := v.operation.VariableDefinitions[definition].Type
 		actualTypeName := v.operation.ResolveTypeNameBytes(variableType)
 		expectedTypeName := node.NameBytes(v.definition)
-		return bytes.Equal(actualTypeName,expectedTypeName)
+		return bytes.Equal(actualTypeName, expectedTypeName)
 	}
 	if value.Kind != ast.ValueKindEnum {
 		return false
@@ -868,14 +868,14 @@ func (v *valuesVisitor) valueSatisfiesInputObjectTypeDefinition(value ast.Value,
 		if v.Ancestors[0].Kind != ast.NodeKindOperationDefinition {
 			return false
 		}
-		definition,ok := v.operation.VariableDefinitionByNameAndOperation(v.Ancestors[0].Ref,name)
+		definition, ok := v.operation.VariableDefinitionByNameAndOperation(v.Ancestors[0].Ref, name)
 		if !ok {
 			return false
 		}
 		variableType := v.operation.VariableDefinitions[definition].Type
 		actualTypeName := v.operation.ResolveTypeNameBytes(variableType)
 		expectedTypeName := v.definition.InputObjectTypeDefinitionNameBytes(inputObjectTypeDefinition)
-		return bytes.Equal(actualTypeName,expectedTypeName)
+		return bytes.Equal(actualTypeName, expectedTypeName)
 	}
 
 	if value.Kind != ast.ValueKindObject {
@@ -1098,7 +1098,7 @@ func (f *fragmentsVisitor) EnterInlineFragment(ref int) {
 
 	typeName := f.operation.InlineFragmentTypeConditionName(ref)
 
-	node, exists := f.definition.Index.FirstNodeByNameBytes(typeName)
+	node, exists := f.definition.Index.FirstNonExtensionNodeByNameBytes(typeName)
 	if !exists {
 		f.StopWithExternalErr(operationreport.ErrTypeUndefined(typeName))
 		return

--- a/pkg/astvalidation/astvalidation_test.go
+++ b/pkg/astvalidation/astvalidation_test.go
@@ -3647,24 +3647,37 @@ func TestExecutionValidation(t *testing.T) {
 	})
 }
 
-func TestValidationWithTypeName(t *testing.T) {
-	operation := `
-		query getApi($id: String!) {
-		  api(id: $id) {
-			__typename
-			... on Api {
-			  __typename
-			  id
-			  name
+func TestValidationEdgeCases(t *testing.T) {
+	run := func(definition, operation string, withNormalization bool) func(t *testing.T) {
+		return func(t *testing.T) {
+			op := unsafeparser.ParseGraphqlDocumentString(operation)
+			def := unsafeparser.ParseGraphqlDocumentString(definition)
+
+			if withNormalization {
+				report := operationreport.Report{}
+				normalizer := astnormalization.NewWithOpts(
+					astnormalization.WithExtractVariables(),
+					astnormalization.WithRemoveFragmentDefinitions(),
+					astnormalization.WithRemoveUnusedVariables(),
+					astnormalization.WithNormalizeDefinition(),
+				)
+				normalizer.NormalizeOperation(&op, &def, &report)
+				if report.HasErrors() {
+					panic(report.Error())
+				}
 			}
-			... on RequestResult {
-			  __typename
-			  status
-			  message
-			}  
-		  }
-		}`
-	definition := `
+
+			validator := DefaultOperationValidator()
+			var report operationreport.Report
+			validator.Validate(&op, &def, &report)
+			if report.HasErrors() {
+				t.Fatal(report.Error())
+			}
+		}
+	}
+
+	t.Run("validation with variables", run(
+		`
 		schema {
 			query: Query
 		}
@@ -3681,15 +3694,51 @@ func TestValidationWithTypeName(t *testing.T) {
 			message: String
 		}
 		scalar String
-	`
-	op := unsafeparser.ParseGraphqlDocumentString(operation)
-	def := unsafeparser.ParseGraphqlDocumentString(definition)
-	validator := DefaultOperationValidator()
-	var report operationreport.Report
-	validator.Validate(&op, &def, &report)
-	if report.HasErrors() {
-		t.Fatal(report.Error())
-	}
+	`,
+		`
+		query getApi($id: String!) {
+		  api(id: $id) {
+			__typename
+			... on Api {
+			  __typename
+			  id
+			  name
+			}
+			... on RequestResult {
+			  __typename
+			  status
+			  message
+			}  
+		  }
+		}`, false,
+	))
+
+	t.Run("validation for normalized federation schema", run(
+		`
+		scalar _Any
+		scalar String
+		union _Entity = User
+		
+		extend type Query {
+			_entities(representations: [_Any!]!): [_Entity]!
+		}
+
+		extend type Query {
+			me: User!
+		}
+
+		extend type User {
+			name: String!
+		}`,
+		`
+		query($representations: [_Any!]!) {
+			_entities(representations: $representations) {
+				... on User { 
+					name 
+				}
+			}
+		}`, true,
+	))
 }
 
 func BenchmarkValidation(b *testing.B) {

--- a/pkg/astvalidation/astvalidation_test.go
+++ b/pkg/astvalidation/astvalidation_test.go
@@ -3676,7 +3676,7 @@ func TestValidationEdgeCases(t *testing.T) {
 		}
 	}
 
-	t.Run("validation with variables", run(
+	t.Run("validation with typename", run(
 		`
 		schema {
 			query: Query


### PR DESCRIPTION
This PR fixes a problem where validation failed when using inline fragments for a federation schema