### PR TITLE
TT-2669 explicit extend keyword on subgraph major object type

### DIFF
--- a/pkg/ast/ast_node.go
+++ b/pkg/ast/ast_node.go
@@ -70,9 +70,9 @@ func (n Node) NameString(definition *Document) string {
 	return unsafebytes.BytesToString(definition.NodeNameBytes(n))
 }
 
-func (d *Document) UpdateRootNode(ref int, newRef int, newKind NodeKind) {
-	d.RootNodes[ref].Kind = newKind
-	d.RootNodes[ref].Ref = newRef
+func (d *Document) UpdateRootNode(ref int, newNodeRef int, newNodeKind NodeKind) {
+	d.RootNodes[ref].Kind = newNodeKind
+	d.RootNodes[ref].Ref = newNodeRef
 }
 
 // TODO: we could use node name directly

--- a/pkg/ast/ast_node.go
+++ b/pkg/ast/ast_node.go
@@ -70,6 +70,11 @@ func (n Node) NameString(definition *Document) string {
 	return unsafebytes.BytesToString(definition.NodeNameBytes(n))
 }
 
+func (d *Document) UpdateRootNode(ref int, newRef int, newKind NodeKind) {
+	d.RootNodes[ref].Kind = newKind
+	d.RootNodes[ref].Ref = newRef
+}
+
 // TODO: we could use node name directly
 func (d *Document) NodeNameUnsafeString(node Node) string {
 	return unsafebytes.BytesToString(d.NodeNameBytes(node))

--- a/pkg/ast/ast_object_type_extension.go
+++ b/pkg/ast/ast_object_type_extension.go
@@ -68,3 +68,8 @@ func (d *Document) ImportAndExtendObjectTypeDefinitionByObjectTypeExtension(obje
 	)
 	d.Index.MergedTypeExtensions = append(d.Index.MergedTypeExtensions, Node{Ref: objectTypeExtensionRef, Kind: NodeKindObjectTypeExtension})
 }
+
+func (d *Document) AddObjectTypeDefinitionExtension(extension ObjectTypeExtension) (ref int) {
+	d.ObjectTypeExtensions = append(d.ObjectTypeExtensions, extension)
+	return len(d.ObjectTypeExtensions) - 1
+}

--- a/pkg/astnormalization/implicit_extend_root_operation.go
+++ b/pkg/astnormalization/implicit_extend_root_operation.go
@@ -1,0 +1,54 @@
+package astnormalization
+
+import (
+	"github.com/jensneuse/graphql-go-tools/pkg/ast"
+	"github.com/jensneuse/graphql-go-tools/pkg/astvisitor"
+)
+
+/*
+type Query {...}
+type Mutation {...}
+type Subscription {...}
+
+will be,
+
+extend type Query {...}
+extend type Mutation {...}
+extend type Subscription {...}
+
+this also works if root types are defined in schema{...} with other names.
+root types are left unmodified if they have no fields, directives or implements any interface.
+*/
+type implicitExtendRootOperationVisitor struct {
+	operation *ast.Document
+}
+
+func implicitExtendRootOperation(walker *astvisitor.Walker) {
+	v := &implicitExtendRootOperationVisitor{}
+	walker.RegisterEnterDocumentVisitor(v)
+	walker.RegisterEnterObjectTypeDefinitionVisitor(v)
+}
+
+func (v *implicitExtendRootOperationVisitor) EnterDocument(operation, _ *ast.Document) {
+	v.operation = operation
+}
+
+func (v *implicitExtendRootOperationVisitor) EnterObjectTypeDefinition(ref int) {
+	node := v.operation.ObjectTypeDefinitions[ref]
+	if !(node.HasFieldDefinitions || node.HasDirectives) {
+		return
+	}
+	switch v.operation.ObjectTypeDefinitionNameString(ref) {
+	case implicitQueryTypeName, implicitMutationTypeName, implicitSubscriptionTypeName,
+		v.operation.Index.QueryTypeName.String(), v.operation.Index.MutationTypeName.String(), v.operation.Index.SubscriptionTypeName.String():
+		for i := range v.operation.RootNodes {
+			if v.operation.RootNodes[i].Ref == ref && v.operation.RootNodes[i].Kind == ast.NodeKindObjectTypeDefinition {
+				// give this node a new NodeKind of ObjectTypeExtension
+				newRef := v.operation.AddObjectTypeDefinitionExtension(ast.ObjectTypeExtension{ObjectTypeDefinition: node})
+				// reflect changes inside the root nodes
+				v.operation.UpdateRootNode(i, newRef, ast.NodeKindObjectTypeExtension)
+				break
+			}
+		}
+	}
+}

--- a/pkg/astnormalization/subgraph_sdl_normalization.go
+++ b/pkg/astnormalization/subgraph_sdl_normalization.go
@@ -1,0 +1,31 @@
+package astnormalization
+
+import (
+	"github.com/jensneuse/graphql-go-tools/pkg/ast"
+	"github.com/jensneuse/graphql-go-tools/pkg/astvisitor"
+	"github.com/jensneuse/graphql-go-tools/pkg/operationreport"
+)
+
+func NormalizeSubgraphSDL(definition *ast.Document, report *operationreport.Report) {
+	NewSubgraphSDLNormalizer().NormalizeSubgraphSDL(definition, report)
+}
+
+type SubgraphSDLNormalizer struct {
+	walker *astvisitor.Walker
+}
+
+func NewSubgraphSDLNormalizer() *SubgraphSDLNormalizer {
+	normalizer := &SubgraphSDLNormalizer{}
+	normalizer.setupWalkers()
+	return normalizer
+}
+
+func (s *SubgraphSDLNormalizer) setupWalkers() {
+	walker := astvisitor.NewWalker(48)
+	implicitExtendRootOperation(&walker)
+	s.walker = &walker
+}
+
+func (s *SubgraphSDLNormalizer) NormalizeSubgraphSDL(definition *ast.Document, report *operationreport.Report) {
+	s.walker.Walk(definition, nil, report)
+}

--- a/pkg/astnormalization/subgraph_sdl_normalization.go
+++ b/pkg/astnormalization/subgraph_sdl_normalization.go
@@ -7,7 +7,8 @@ import (
 )
 
 func NormalizeSubgraphSDL(definition *ast.Document, report *operationreport.Report) {
-	NewSubgraphSDLNormalizer().NormalizeSubgraphSDL(definition, report)
+	normalizer := NewSubgraphSDLNormalizer()
+	normalizer.NormalizeSubgraphSDL(definition, report)
 }
 
 type SubgraphSDLNormalizer struct {

--- a/pkg/astnormalization/subgraph_sdl_normalization_test.go
+++ b/pkg/astnormalization/subgraph_sdl_normalization_test.go
@@ -1,0 +1,81 @@
+package astnormalization
+
+import (
+	"testing"
+
+	"github.com/jensneuse/graphql-go-tools/pkg/astparser"
+	"github.com/jensneuse/graphql-go-tools/pkg/astprinter"
+	"github.com/jensneuse/graphql-go-tools/pkg/astvisitor"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeSubgraphSDL(t *testing.T) {
+	run := func(name, input, expectedOutput string, norm registerNormalizeFunc) {
+		inDoc, _ := astparser.ParseGraphqlDocumentString(input)
+		outDoc, _ := astparser.ParseGraphqlDocumentString(expectedOutput)
+		expectedOutput, _ = astprinter.PrintString(&outDoc, nil)
+		walker := astvisitor.NewWalker(48)
+		norm(&walker)
+		walker.Walk(&inDoc, nil, nil)
+		input, _ = astprinter.PrintString(&inDoc, nil)
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, input, expectedOutput)
+		})
+	}
+	run("implicit extend root operation from schema",
+		`schema {
+			query: QueryName
+			mutation: MutationName
+		}
+		type QueryName @hello {
+		}
+		type MutationName {
+			field: String!
+		}
+		scalar String
+		`,
+		`
+		schema { query: QueryName mutation: MutationName }
+		extend type QueryName @hello{}
+		extend type MutationName { field: String! }
+		scalar String
+	`, registerNormalizeFunc(implicitExtendRootOperation))
+	run("don't implicitly extend empty schema root operation",
+		`schema {
+			query: QueryName
+		}
+		type QueryName {
+		}
+		`,
+		`
+		schema { query: QueryName }
+		type QueryName {}
+	`, registerNormalizeFunc(implicitExtendRootOperation))
+	run("don't implicitly extend empty object root operation",
+		`type Query {}
+		type Mutation {
+			field: String!
+		}
+		type Subscription @directive {
+		}
+		`,
+		`
+		type Query {}
+		extend type Mutation { field: String! }
+		extend type Subscription @directive {}
+	`, registerNormalizeFunc(implicitExtendRootOperation))
+	run("implicitly extend object root operation with definitions and directives",
+		`type Query {}
+		type Mutation {
+			field: String!
+		}
+		type Subscription @directive {
+			newUser: ID!
+		}
+		`,
+		`
+		type Query {}
+		extend type Mutation { field: String! }
+		extend type Subscription @directive { newUser: ID! }
+	`, registerNormalizeFunc(implicitExtendRootOperation))
+}

--- a/pkg/federation/sdlmerge/sdlmerge.go
+++ b/pkg/federation/sdlmerge/sdlmerge.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/jensneuse/graphql-go-tools/pkg/ast"
+	"github.com/jensneuse/graphql-go-tools/pkg/astnormalization"
 	"github.com/jensneuse/graphql-go-tools/pkg/astparser"
 	"github.com/jensneuse/graphql-go-tools/pkg/astprinter"
 	"github.com/jensneuse/graphql-go-tools/pkg/astvisitor"
@@ -37,7 +38,8 @@ func MergeSDLs(SDLs ...string) (string, error) {
 	if report.HasErrors() {
 		return "", fmt.Errorf("parse graphql document string: %s", report.Error())
 	}
-
+	// we don't expect this normalization to return error if none was returned above
+	astnormalization.NormalizeSubgraphSDL(&doc, &report)
 	if err := MergeAST(&doc); err != nil {
 		return "", fmt.Errorf("merge ast: %s", err.Error())
 	}

--- a/pkg/federation/sdlmerge/sdlmerge_test.go
+++ b/pkg/federation/sdlmerge/sdlmerge_test.go
@@ -108,11 +108,11 @@ const (
 		}
 	`
 	likeSchema = `
-	    type Like @key(fields: "id") {
-		    id: ID!
-		    productId: ID!
-		    userId: ID!
-	    }
+		type Like @key(fields: "id") {
+			id: ID!
+			productId: ID!
+			userId: ID!
+		}
 		type Query {
 			likesCount(productID: ID!): Int!
 			likes(productID: ID!): [Like]!

--- a/pkg/federation/sdlmerge/sdlmerge_test.go
+++ b/pkg/federation/sdlmerge/sdlmerge_test.go
@@ -52,7 +52,7 @@ func mustString(str string, err error) string {
 }
 
 func TestMergeSDLs(t *testing.T) {
-	got, err := MergeSDLs(accountSchema, productSchema, reviewSchema)
+	got, err := MergeSDLs(accountSchema, productSchema, reviewSchema, likeSchema)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -107,10 +107,23 @@ const (
 			review: Review!
 		}
 	`
+	likeSchema = `
+	    type Like @key(fields: "id") {
+		    id: ID!
+		    productId: ID!
+		    userId: ID!
+	    }
+		type Query {
+			likesCount(productID: ID!): Int!
+			likes(productID: ID!): [Like]!
+		}
+	`
 	federatedSchema = `
 		type Query {
 			me: User
 			topProducts(first: Int = 5): [Product]
+			likesCount(productID: ID!): Int!
+			likes(productID: ID!): [Like]!
 		}
 		
 		type Subscription {
@@ -134,6 +147,11 @@ const (
 			body: String!
 			author: User!
 			product: Product!
+		}
+		type Like {
+			id: ID!
+			productId: ID!
+			userId: ID!
 		}
 	`
 )


### PR DESCRIPTION
An elaborate description can be found here https://tyktech.atlassian.net/browse/TT-2669
before running any visitors of `sdlmerge`, we run a helper that modifies ObjectTypeDefinition with fields to be ObjectTypeExtension