### PR TITLE
disable websocket deduplication

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/gobuffalo/packr v1.30.1
 	github.com/gobwas/ws v1.0.4
 	github.com/golang/mock v1.4.1
+	github.com/google/uuid v1.1.1
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/iancoleman/strcase v0.0.0-20191112232945-16388991a334
 	github.com/jensneuse/abstractlogger v0.0.4

--- a/pkg/engine/datasource/graphql_datasource/graphql_subscription_client.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_subscription_client.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/OneOfOne/xxhash"
 	"github.com/buger/jsonparser"
+	"github.com/google/uuid"
 	"github.com/jensneuse/abstractlogger"
 	"nhooyr.io/websocket"
 )
@@ -34,7 +35,8 @@ type WebSocketGraphQLSubscriptionClient struct {
 	ctx        context.Context
 	log        abstractlogger.Logger
 	hashPool   sync.Pool
-	handlers   map[uint64]*connectionHandler
+	/*handlers   map[uint64]*connectionHandler // deduplication implementation */
+	handlers   map[string]*connectionHandler
 	handlersMu sync.Mutex
 
 	readTimeout time.Duration
@@ -68,9 +70,10 @@ func NewWebSocketGraphQLSubscriptionClient(httpClient *http.Client, ctx context.
 		option(op)
 	}
 	return &WebSocketGraphQLSubscriptionClient{
-		httpClient:  httpClient,
-		ctx:         ctx,
-		handlers:    map[uint64]*connectionHandler{},
+		httpClient: httpClient,
+		ctx:        ctx,
+		/*handlers:    map[uint64]*connectionHandler{}, // deduplication implementation */
+		handlers:    map[string]*connectionHandler{},
 		log:         op.log,
 		readTimeout: op.readTimeout,
 		hashPool: sync.Pool{
@@ -87,7 +90,8 @@ func NewWebSocketGraphQLSubscriptionClient(httpClient *http.Client, ctx context.
 // If no connection exists, the client initiates a new one and sends the "init" and "connection ack" messages
 func (c *WebSocketGraphQLSubscriptionClient) Subscribe(ctx context.Context, options GraphQLSubscriptionOptions, next chan<- []byte) error {
 
-	handlerID, err := c.generateHandlerIDHash(options)
+	/* handlerID, err := c.generateHandlerIDHash(options) // deduplication implementation */
+	handlerID, err := c.generateNonDeduplicationID()
 	if err != nil {
 		return err
 	}
@@ -150,7 +154,14 @@ func (c *WebSocketGraphQLSubscriptionClient) Subscribe(ctx context.Context, opti
 	handler = newConnectionHandler(c.ctx, conn, c.readTimeout, c.log)
 	c.handlers[handlerID] = handler
 
-	go func(handlerID uint64) {
+	/* go func(handlerID uint64) {
+		handler.startBlocking(sub)
+		c.handlersMu.Lock()
+		delete(c.handlers, handlerID)
+		c.handlersMu.Unlock()
+	}(handlerID) // deduplication implementation */
+
+	go func(handlerID string) {
 		handler.startBlocking(sub)
 		c.handlersMu.Lock()
 		delete(c.handlers, handlerID)
@@ -161,7 +172,7 @@ func (c *WebSocketGraphQLSubscriptionClient) Subscribe(ctx context.Context, opti
 }
 
 // generateHandlerIDHash generates a Hash based on: URL, Headers, Body to uniquely identify Upgrade Requests
-func (c *WebSocketGraphQLSubscriptionClient) generateHandlerIDHash(options GraphQLSubscriptionOptions) (uint64, error) {
+/*func (c *WebSocketGraphQLSubscriptionClient) generateHandlerIDHash(options GraphQLSubscriptionOptions) (uint64, error) {
 	var (
 		err error
 	)
@@ -179,6 +190,20 @@ func (c *WebSocketGraphQLSubscriptionClient) generateHandlerIDHash(options Graph
 	}
 
 	return xxh.Sum64(), nil
+} // deduplication implementation */
+
+func (c *WebSocketGraphQLSubscriptionClient) generateNonDeduplicationID() (string, error) {
+	for {
+		u, err := uuid.NewRandom()
+		if err != nil {
+			return "", err
+		}
+
+		uuidString := u.String()
+		if _, ok := c.handlers[uuidString]; !ok {
+			return uuidString, nil
+		}
+	}
 }
 
 func newConnectionHandler(ctx context.Context, conn *websocket.Conn, readTimeout time.Duration, log abstractlogger.Logger) *connectionHandler {

--- a/pkg/engine/datasource/graphql_datasource/graphql_subscription_client_test.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_subscription_client_test.go
@@ -2,16 +2,12 @@ package graphql_datasource
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"strconv"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
-	"github.com/buger/jsonparser"
 	ll "github.com/jensneuse/abstractlogger"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/atomic"
@@ -146,7 +142,7 @@ func TestWebsocketSubscriptionClientWithServerDisconnect(t *testing.T) {
 		err = conn.Write(r.Context(), websocket.MessageText, []byte(`{"type":"data","id":"1","payload":{"data":{"messageAdded":{"text":"third"}}}}`))
 		assert.NoError(t, err)
 
-		_,_, err = conn.Read(ctx)
+		_, _, err = conn.Read(ctx)
 		assert.Error(t, err)
 		close(serverDone)
 	}))
@@ -288,6 +284,7 @@ func TestWebsocketSubscriptionClientErrorObject(t *testing.T) {
 	}, time.Second, time.Millisecond*10, "server did not close")
 }
 
+/* deduplication implementation
 func TestWebsocketSubscriptionClientDeDuplication(t *testing.T) {
 	serverDone := &sync.WaitGroup{}
 	connectedClients := atomic.NewInt64(0)
@@ -420,3 +417,4 @@ func TestWebsocketSubscriptionClientDeDuplication(t *testing.T) {
 		return connectedClients.Load() == 0
 	}, time.Second, time.Millisecond, "clients not 0")
 }
+*/


### PR DESCRIPTION
This is a temporary "fix" to disable deduplication which does not work with the current state of the planner.