### PR TITLE
add support of comments everywhere

### DIFF
--- a/pkg/ast/ast_selection.go
+++ b/pkg/ast/ast_selection.go
@@ -58,7 +58,7 @@ func (d *Document) SelectionsBeforeField(field int, selectionSet Node) bool {
 	return false
 }
 
-func (d *Document) SelectionsAfterField(field int, selectionSet Node) bool {
+func (d *Document) SelectionsAfter(selectionKind SelectionKind, selectionRef int, selectionSet Node) bool {
 	if selectionSet.Kind != NodeKindSelectionSet {
 		return false
 	}
@@ -68,7 +68,7 @@ func (d *Document) SelectionsAfterField(field int, selectionSet Node) bool {
 	}
 
 	for i, j := range d.SelectionSets[selectionSet.Ref].SelectionRefs {
-		if d.Selections[j].Kind == SelectionKindField && d.Selections[j].Ref == field {
+		if d.Selections[j].Kind == selectionKind && d.Selections[j].Ref == selectionRef {
 			return i != len(d.SelectionSets[selectionSet.Ref].SelectionRefs)-1
 		}
 	}
@@ -76,22 +76,16 @@ func (d *Document) SelectionsAfterField(field int, selectionSet Node) bool {
 	return false
 }
 
+func (d *Document) SelectionsAfterField(field int, selectionSet Node) bool {
+	return d.SelectionsAfter(SelectionKindField, field, selectionSet)
+}
+
 func (d *Document) SelectionsAfterInlineFragment(inlineFragment int, selectionSet Node) bool {
-	if selectionSet.Kind != NodeKindSelectionSet {
-		return false
-	}
+	return d.SelectionsAfter(SelectionKindInlineFragment, inlineFragment, selectionSet)
+}
 
-	if len(d.SelectionSets[selectionSet.Ref].SelectionRefs) == 1 {
-		return false
-	}
-
-	for i, j := range d.SelectionSets[selectionSet.Ref].SelectionRefs {
-		if d.Selections[j].Kind == SelectionKindInlineFragment && d.Selections[j].Ref == inlineFragment {
-			return i != len(d.SelectionSets[selectionSet.Ref].SelectionRefs)-1
-		}
-	}
-
-	return false
+func (d *Document) SelectionsAfterFragmentSpread(fragmentSpread int, selectionSet Node) bool {
+	return d.SelectionsAfter(SelectionKindFragmentSpread, fragmentSpread, selectionSet)
 }
 
 func (d *Document) AddSelectionSet() Node {

--- a/pkg/astparser/errors.go
+++ b/pkg/astparser/errors.go
@@ -1,0 +1,53 @@
+package astparser
+
+import (
+	"fmt"
+
+	"github.com/jensneuse/graphql-go-tools/pkg/lexer/identkeyword"
+	"github.com/jensneuse/graphql-go-tools/pkg/lexer/keyword"
+	"github.com/jensneuse/graphql-go-tools/pkg/lexer/position"
+)
+
+type origin struct {
+	file     string
+	line     int
+	funcName string
+}
+
+// ErrUnexpectedToken is a custom error object containing all necessary information to properly render an unexpected token error
+type ErrUnexpectedToken struct {
+	keyword  keyword.Keyword
+	expected []keyword.Keyword
+	position position.Position
+	literal  string
+	origins  []origin
+}
+
+func (e ErrUnexpectedToken) Error() string {
+
+	origins := ""
+	for _, origin := range e.origins {
+		origins = origins + fmt.Sprintf("\n\t\t%s:%d\n\t\t%s", origin.file, origin.line, origin.funcName)
+	}
+
+	return fmt.Sprintf("unexpected token - keyword: '%s' literal: '%s' - expected: '%s' position: '%s'%s", e.keyword, e.literal, e.expected, e.position, origins)
+}
+
+// ErrUnexpectedIdentKey is a custom error object to properly render an unexpected ident key error
+type ErrUnexpectedIdentKey struct {
+	keyword  identkeyword.IdentKeyword
+	expected []identkeyword.IdentKeyword
+	position position.Position
+	literal  string
+	origins  []origin
+}
+
+func (e ErrUnexpectedIdentKey) Error() string {
+
+	origins := ""
+	for _, origin := range e.origins {
+		origins = origins + fmt.Sprintf("\n\t\t%s:%d\n\t\t%s", origin.file, origin.line, origin.funcName)
+	}
+
+	return fmt.Sprintf("unexpected ident - keyword: '%s' literal: '%s' - expected: '%s' position: '%s'%s", e.keyword, e.literal, e.expected, e.position, origins)
+}

--- a/pkg/astparser/parser.go
+++ b/pkg/astparser/parser.go
@@ -470,7 +470,8 @@ func (p *Parser) parseRootOperationTypeDefinitionList(list *ast.RootOperationTyp
 			if p.shouldIndex {
 				p.indexRootOperationTypeDefinition(rootOperationTypeDefinition)
 			}
-
+		case keyword.COMMENT:
+			p.read()
 		default:
 			p.errUnexpectedToken(p.read())
 			return
@@ -554,6 +555,8 @@ Loop:
 		next := p.peek()
 		switch next {
 		case keyword.IDENT:
+		case keyword.COMMENT:
+			p.read()
 		default:
 			break Loop
 		}
@@ -1102,6 +1105,8 @@ func (p *Parser) parseInputValueDefinitionList(closingKeyword keyword.Keyword) (
 				list.Refs = p.document.Refs[p.document.NextRefIndex()][:0]
 			}
 			list.Refs = append(list.Refs, ref)
+		case keyword.COMMENT:
+			p.read()
 		default:
 			p.errUnexpectedToken(p.read())
 			return
@@ -1351,6 +1356,8 @@ func (p *Parser) parseEnumValueDefinitionList() (list ast.EnumValueDefinitionLis
 		case keyword.RBRACE:
 			list.RBRACE = p.read().TextPosition
 			return
+		case keyword.COMMENT:
+			p.read()
 		default:
 			p.errUnexpectedToken(p.read())
 			return
@@ -1494,6 +1501,8 @@ func (p *Parser) parseSelectionSet() (int, bool) {
 			}
 			ref := p.parseSelection()
 			set.SelectionRefs = append(set.SelectionRefs, ref)
+		case keyword.COMMENT:
+			p.read()
 		default:
 			p.errUnexpectedToken(p.read(), keyword.RBRACE, keyword.IDENT, keyword.SPREAD)
 		}
@@ -1702,6 +1711,8 @@ func (p *Parser) parseVariableDefinitionList() (list ast.VariableDefinitionList)
 				list.Refs = p.document.Refs[p.document.NextRefIndex()][:0]
 			}
 			list.Refs = append(list.Refs, ref)
+		case keyword.COMMENT:
+			p.read()
 		default:
 			p.errUnexpectedToken(p.read(), keyword.RPAREN, keyword.DOLLAR)
 			return

--- a/pkg/astparser/parser.go
+++ b/pkg/astparser/parser.go
@@ -85,8 +85,6 @@ func (p *Parser) parse() {
 			return
 		case keyword.LBRACE:
 			p.parseOperationDefinition()
-		case keyword.COMMENT:
-			p.read()
 		case keyword.STRING, keyword.BLOCKSTRING:
 			p.parseRootDescription()
 		case keyword.IDENT:
@@ -787,8 +785,6 @@ func (p *Parser) parseFieldDefinitionList() (list ast.FieldDefinitionList) {
 				refsInitialized = true
 			}
 			list.Refs = append(list.Refs, ref)
-		case keyword.COMMENT:
-			p.read()
 		default:
 			p.errUnexpectedToken(p.read())
 			return

--- a/pkg/astparser/parser.go
+++ b/pkg/astparser/parser.go
@@ -290,7 +290,7 @@ func (p *Parser) parseRootOperationTypeDefinitionList(list *ast.RootOperationTyp
 			return
 		case keyword.IDENT:
 
-			_, operationType := p.readExpectLiteral(identkeyword.QUERY, identkeyword.MUTATION, identkeyword.SUBSCRIPTION)
+			_, operationType := p.mustReadOneOf(identkeyword.QUERY, identkeyword.MUTATION, identkeyword.SUBSCRIPTION)
 			colon := p.mustRead(keyword.COLON)
 			namedType := p.mustRead(keyword.IDENT)
 

--- a/pkg/astparser/parser.go
+++ b/pkg/astparser/parser.go
@@ -470,8 +470,7 @@ func (p *Parser) parseRootOperationTypeDefinitionList(list *ast.RootOperationTyp
 			if p.shouldIndex {
 				p.indexRootOperationTypeDefinition(rootOperationTypeDefinition)
 			}
-		case keyword.COMMENT:
-			p.read()
+
 		default:
 			p.errUnexpectedToken(p.read())
 			return
@@ -555,8 +554,6 @@ Loop:
 		next := p.peek()
 		switch next {
 		case keyword.IDENT:
-		case keyword.COMMENT:
-			p.read()
 		default:
 			break Loop
 		}
@@ -1105,8 +1102,6 @@ func (p *Parser) parseInputValueDefinitionList(closingKeyword keyword.Keyword) (
 				list.Refs = p.document.Refs[p.document.NextRefIndex()][:0]
 			}
 			list.Refs = append(list.Refs, ref)
-		case keyword.COMMENT:
-			p.read()
 		default:
 			p.errUnexpectedToken(p.read())
 			return
@@ -1356,8 +1351,6 @@ func (p *Parser) parseEnumValueDefinitionList() (list ast.EnumValueDefinitionLis
 		case keyword.RBRACE:
 			list.RBRACE = p.read().TextPosition
 			return
-		case keyword.COMMENT:
-			p.read()
 		default:
 			p.errUnexpectedToken(p.read())
 			return
@@ -1501,8 +1494,6 @@ func (p *Parser) parseSelectionSet() (int, bool) {
 			}
 			ref := p.parseSelection()
 			set.SelectionRefs = append(set.SelectionRefs, ref)
-		case keyword.COMMENT:
-			p.read()
 		default:
 			p.errUnexpectedToken(p.read(), keyword.RBRACE, keyword.IDENT, keyword.SPREAD)
 		}
@@ -1711,8 +1702,6 @@ func (p *Parser) parseVariableDefinitionList() (list ast.VariableDefinitionList)
 				list.Refs = p.document.Refs[p.document.NextRefIndex()][:0]
 			}
 			list.Refs = append(list.Refs, ref)
-		case keyword.COMMENT:
-			p.read()
 		default:
 			p.errUnexpectedToken(p.read(), keyword.RPAREN, keyword.DOLLAR)
 			return

--- a/pkg/astparser/parser_test.go
+++ b/pkg/astparser/parser_test.go
@@ -237,6 +237,164 @@ func TestParser_Parse(t *testing.T) {
 		t.Run("invalid directive without @", func(t *testing.T) {
 			run(`schema foo {}`, parse, true)
 		})
+		t.Run("no report on schema with comments everywhere", func(t *testing.T) {
+			run(`
+				#comment
+				scalar #comment
+				Date #comment
+				
+				schema #comment
+				{ #comment
+				  query#comment
+				  :#comment
+				  #comment
+				  Query#comment
+				  #comment
+				}#comment
+				
+				#comment
+				type#comment
+				Query#comment
+				{#comment
+				  me#comment
+				  :#comment
+				  User#comment
+				  !#comment
+				  user(#comment
+					id#comment
+					:#comment
+					ID#comment
+					!#comment
+				  )#comment
+				  :#comment
+				  User#comment
+				  allUsers#comment
+				  :#comment
+				  [#comment
+					#comment
+					User#comment
+				  ]#comment
+				  search#comment
+				  (#comment
+					term#comment
+					:#comment
+					String#comment
+					!#comment
+				  )#comment
+				  :#comment
+				  [#comment
+					SearchResult#comment
+					!#comment
+				  ]#comment
+				  !#comment
+				  myChats:#comment
+				  [#comment
+					Chat#comment
+					!#comment
+				  ]!#comment
+				}
+				
+				enum#comment
+				Role#comment
+				{#comment
+				  #comment
+				  USER#comment
+				  ,#comment
+				  ADMIN#comment
+				  ,#comment
+				  #comment
+				}#comment
+				
+				interface#comment
+				Node {#comment
+				  id#comment
+				  :#comment
+				  ID#comment
+				  !#comment
+				}#comment
+				
+				union #comment
+				SearchResult#comment
+				=#comment
+				User#comment
+				|#comment
+				Chat#comment
+				|#comment
+				ChatMessage#comment
+				
+				type#comment
+				User#comment
+				implements#comment
+				Node#comment
+				{#comment
+				  id#comment
+				  :#comment
+				  ID#comment
+				  !#comment
+				  username#comment
+				  :#comment
+				  String#comment
+				  !#comment
+				  email#comment
+				  :#comment
+				  String#comment
+				  !#comment
+				  role#comment
+				  :#comment
+				  Role#comment
+				  !#comment
+				}#comment
+				
+				type#comment
+				Chat#comment
+				implements#comment
+				Node#comment
+				{#comment
+				  id#comment
+				  :#comment
+				  ID#comment
+				  !#comment
+				  users#comment
+				  :#comment
+				  [#comment
+					User#comment
+					!#comment
+				  ]!#comment
+				  messages#comment
+				  :#comment
+				  [#comment
+					ChatMessage#comment
+					!#comment
+				  ]#comment
+				  !#comment
+				  #comment
+				}#comment
+				
+				type#comment
+				ChatMessage#comment
+				implements#comment
+				Node#comment
+				{#comment
+				  id#comment
+				  :#comment
+				  ID#comment
+				  !#comment
+				  content#comment
+				  :#comment
+				  String#comment
+				  !#comment
+				  time#comment
+				  :#comment
+				  Date#comment
+				  !#comment
+				  user#comment
+				  :#comment
+				  User#comment
+				  !#comment
+				  #comment
+				}#comment`, parse, false)
+		})
+
 	})
 	t.Run("schema extension", func(t *testing.T) {
 		t.Run("simple", func(t *testing.T) {

--- a/pkg/astparser/parser_test.go
+++ b/pkg/astparser/parser_test.go
@@ -1846,6 +1846,49 @@ func TestParser_Parse(t *testing.T) {
 					}
 				})
 		})
+
+		t.Run("operation with comments everywhere", func(t *testing.T) {
+			run(`
+				query #comment
+				findUser#comment
+				(#comment
+					$userId#comment
+				  :#comment
+				  ID#comment
+				  !#comment
+				  #comment
+					)#comment
+					{#comment
+				  user#comment
+					  (#comment
+					  id#comment
+						:#comment
+					$userId#comment
+					  #comment
+				)#comment
+					  #comment
+				{#comment
+					...#comment
+				  UserFields#comment
+					... #comment
+				  on #comment
+				  User#comment
+				  {#comment
+						email#comment
+					}#comment
+				  }#comment
+				}#comment
+				
+				fragment #comment
+				UserFields #comment
+				on #comment
+				User#comment
+				{#comment
+				  id#comment
+				  #username#comment
+					  role#comment
+					}#comment`, parse, false)
+		})
 	})
 	t.Run("variable definition", func(t *testing.T) {
 		t.Run("simple", func(t *testing.T) {

--- a/pkg/astparser/parser_test.go
+++ b/pkg/astparser/parser_test.go
@@ -2267,8 +2267,8 @@ func BenchmarkParseStarwars(b *testing.B) {
 	b.SetBytes(int64(len(starwarsSchema)))
 
 	for i := 0; i < b.N; i++ {
-		doc.Input.ResetInputBytes(starwarsSchema)
 		doc.Reset()
+		doc.Input.ResetInputBytes(starwarsSchema)
 		report.Reset()
 		parser.Parse(doc, &report)
 		if report.HasErrors() {
@@ -2294,8 +2294,8 @@ func BenchmarkParseGithub(b *testing.B) {
 	b.SetBytes(int64(len(schemaFile)))
 
 	for i := 0; i < b.N; i++ {
-		doc.Input.ResetInputBytes(schemaFile)
 		doc.Reset()
+		doc.Input.ResetInputBytes(schemaFile)
 		parser.Parse(doc, &report)
 		if report.HasErrors() {
 			b.Fatal(report.Error())
@@ -2314,8 +2314,8 @@ func BenchmarkSelectionSet(b *testing.B) {
 	b.SetBytes(int64(len(selectionSet)))
 
 	for i := 0; i < b.N; i++ {
-		doc.Input.ResetInputBytes(selectionSet)
 		doc.Reset()
+		doc.Input.ResetInputBytes(selectionSet)
 		report.Reset()
 		parser.Parse(doc, &report)
 		if report.HasErrors() {
@@ -2335,8 +2335,8 @@ func BenchmarkIntrospectionQuery(b *testing.B) {
 	b.SetBytes(int64(len(introspectionQuery)))
 
 	for i := 0; i < b.N; i++ {
-		doc.Input.ResetInputBytes(introspectionQuery)
 		doc.Reset()
+		doc.Input.ResetInputBytes(introspectionQuery)
 		parser.Parse(doc, &report)
 		if report.HasErrors() {
 			b.Fatal(report.Error())
@@ -2355,8 +2355,8 @@ func BenchmarkKitchenSink(b *testing.B) {
 	b.SetBytes(int64(len(kitchenSinkData)))
 
 	for i := 0; i < b.N; i++ {
-		doc.Input.ResetInputBytes(kitchenSinkData)
 		doc.Reset()
+		doc.Input.ResetInputBytes(kitchenSinkData)
 		report.Reset()
 		parser.Parse(doc, &report)
 	}
@@ -2373,8 +2373,8 @@ func BenchmarkParse(b *testing.B) {
 	b.SetBytes(int64(len(inputBytes)))
 
 	for i := 0; i < b.N; i++ {
-		doc.Input.ResetInputBytes(inputBytes)
 		doc.Reset()
+		doc.Input.ResetInputBytes(inputBytes)
 		parser.Parse(doc, &report)
 		if report.HasErrors() {
 			b.Fatal(report.Error())

--- a/pkg/astparser/parser_test.go
+++ b/pkg/astparser/parser_test.go
@@ -28,7 +28,6 @@ func TestParser_Parse(t *testing.T) {
 		return func(parser *Parser) (interface{}, operationreport.Report) {
 			report := operationreport.Report{}
 			parser.report = &report
-			parser.lexer.SetInput(&parser.document.Input)
 			parser.tokenize()
 			ref := parser.ParseType()
 			return ref, report
@@ -39,7 +38,6 @@ func TestParser_Parse(t *testing.T) {
 		return func(parser *Parser) (interface{}, operationreport.Report) {
 			report := operationreport.Report{}
 			parser.report = &report
-			parser.lexer.SetInput(&parser.document.Input)
 			parser.tokenize()
 			value := parser.ParseValue()
 			return value, report
@@ -50,7 +48,6 @@ func TestParser_Parse(t *testing.T) {
 		return func(parser *Parser) (interface{}, operationreport.Report) {
 			report := operationreport.Report{}
 			parser.report = &report
-			parser.lexer.SetInput(&parser.document.Input)
 			parser.tokenize()
 			set, _ := parser.parseSelectionSet()
 			return set, report
@@ -61,7 +58,6 @@ func TestParser_Parse(t *testing.T) {
 		return func(parser *Parser) (interface{}, operationreport.Report) {
 			report := operationreport.Report{}
 			parser.report = &report
-			parser.lexer.SetInput(&parser.document.Input)
 			parser.tokenize()
 			fragmentSpread := parser.parseFragmentSpread(position.Position{})
 			return parser.document.FragmentSpreads[fragmentSpread], report
@@ -72,7 +68,6 @@ func TestParser_Parse(t *testing.T) {
 		return func(parser *Parser) (interface{}, operationreport.Report) {
 			report := operationreport.Report{}
 			parser.report = &report
-			parser.lexer.SetInput(&parser.document.Input)
 			parser.tokenize()
 			inlineFragment := parser.parseInlineFragment(position.Position{})
 			return parser.document.InlineFragments[inlineFragment], report
@@ -83,7 +78,6 @@ func TestParser_Parse(t *testing.T) {
 		return func(parser *Parser) (interface{}, operationreport.Report) {
 			report := operationreport.Report{}
 			parser.report = &report
-			parser.lexer.SetInput(&parser.document.Input)
 			parser.tokenize()
 			variableDefinitionList := parser.parseVariableDefinitionList()
 			return variableDefinitionList, report
@@ -136,8 +130,6 @@ func TestParser_Parse(t *testing.T) {
 
 		parser := NewParser()
 		parser.document = doc
-		parser.lexer.SetInput(&doc.Input)
-
 		parser.tokenize()
 
 		for i, want := range []keyword.Keyword{

--- a/pkg/astparser/parser_token_helpers.go
+++ b/pkg/astparser/parser_token_helpers.go
@@ -7,21 +7,20 @@ import (
 	"github.com/jensneuse/graphql-go-tools/pkg/lexer/token"
 )
 
-// read - increments currentToken index and return token if hasNextToken
-// otherwise returns keyword.EOF
+// read - reads and returns next token
 func (p *Parser) read() token.Token {
 	return p.tokenizer.Read()
 }
 
-// peek - returns token next to currentToken if hasNextToken
-// otherwise returns keyword.EOF
+// peek - returns token next to currentToken
+// returns keyword.EOF when reached end of document
 func (p *Parser) peek() keyword.Keyword {
 	tok := p.tokenizer.Peek()
 	return tok.Keyword
 }
 
-// peekLiteral - returns token next to currentToken and token name as a ast.ByteSliceReference if hasNextToken
-// otherwise returns keyword.EOF
+// peekLiteral - returns keyword.Keyword and literal ast.ByteSliceReference of token next to currentToken
+// returns keyword.EOF when reached end of document
 func (p *Parser) peekLiteral() (keyword.Keyword, ast.ByteSliceReference) {
 	tok := p.tokenizer.Peek()
 	if tok.Keyword != keyword.EOF {
@@ -30,12 +29,12 @@ func (p *Parser) peekLiteral() (keyword.Keyword, ast.ByteSliceReference) {
 	return keyword.EOF, ast.ByteSliceReference{}
 }
 
-// peekEquals - checks that next token is equal to key
+// peekEquals - checks that next token keyword is equal to key
 func (p *Parser) peekEquals(key keyword.Keyword) bool {
 	return p.peek() == key
 }
 
-// peekEqualsIdentKey - checks that next token is an identifier
+// peekEqualsIdentKey - checks that next token is an identifier of the given key
 func (p *Parser) peekEqualsIdentKey(identKey identkeyword.IdentKeyword) bool {
 	key, literal := p.peekLiteral()
 	if key != keyword.IDENT {

--- a/pkg/astparser/parser_token_helpers.go
+++ b/pkg/astparser/parser_token_helpers.go
@@ -1,0 +1,119 @@
+package astparser
+
+import (
+	"github.com/jensneuse/graphql-go-tools/pkg/ast"
+	"github.com/jensneuse/graphql-go-tools/pkg/lexer/identkeyword"
+	"github.com/jensneuse/graphql-go-tools/pkg/lexer/keyword"
+	"github.com/jensneuse/graphql-go-tools/pkg/lexer/token"
+)
+
+func (p *Parser) next() int {
+	if p.currentToken != p.maxTokens-1 {
+		p.currentToken++
+	}
+	return p.currentToken
+}
+
+func (p *Parser) read() token.Token {
+	p.currentToken++
+	if p.currentToken < p.maxTokens {
+		return p.tokens[p.currentToken]
+	}
+
+	return token.Token{
+		Keyword: keyword.EOF,
+	}
+}
+
+func (p *Parser) readExpectLiteral(expect ...identkeyword.IdentKeyword) (token.Token, identkeyword.IdentKeyword) {
+	p.currentToken++
+	if p.currentToken < p.maxTokens {
+		out := p.tokens[p.currentToken]
+		identKey := p.identKeywordToken(out)
+		for _, expectation := range expect {
+			if identKey == expectation {
+				return out, identKey
+			}
+		}
+		p.errUnexpectedToken(out)
+		return out, identKey
+	}
+
+	return token.Token{
+		Keyword: keyword.EOF,
+	}, identkeyword.UNDEFINED
+}
+
+func (p *Parser) peek() keyword.Keyword {
+	nextIndex := p.currentToken + 1
+	if nextIndex < p.maxTokens {
+		return p.tokens[nextIndex].Keyword
+	}
+	return keyword.EOF
+}
+
+func (p *Parser) peekLiteral() (keyword.Keyword, ast.ByteSliceReference) {
+	nextIndex := p.currentToken + 1
+	if nextIndex < p.maxTokens {
+		return p.tokens[nextIndex].Keyword, p.tokens[nextIndex].Literal
+	}
+	return keyword.EOF, ast.ByteSliceReference{}
+}
+
+func (p *Parser) peekEquals(key keyword.Keyword) bool {
+	return p.peek() == key
+}
+
+func (p *Parser) peekEqualsIdentKey(identKey identkeyword.IdentKeyword) bool {
+	key, literal := p.peekLiteral()
+	if key != keyword.IDENT {
+		return false
+	}
+	actualKey := p.identKeywordSliceRef(literal)
+	return actualKey == identKey
+}
+
+func (p *Parser) mustNext(key keyword.Keyword) int {
+	current := p.currentToken
+	if p.next() == current {
+		p.errUnexpectedToken(p.tokens[p.currentToken], key)
+		return p.currentToken
+	}
+	if p.tokens[p.currentToken].Keyword != key {
+		p.errUnexpectedToken(p.tokens[p.currentToken], key)
+		return p.currentToken
+	}
+	return p.currentToken
+}
+
+func (p *Parser) mustRead(key keyword.Keyword) (next token.Token) {
+	next = p.read()
+	if next.Keyword != key {
+		p.errUnexpectedToken(next, key)
+	}
+	return
+}
+
+func (p *Parser) mustReadIdentKey(key identkeyword.IdentKeyword) (next token.Token) {
+	next = p.read()
+	if next.Keyword != keyword.IDENT {
+		p.errUnexpectedToken(next, keyword.IDENT)
+	}
+	identKey := p.identKeywordToken(next)
+	if identKey != key {
+		p.errUnexpectedIdentKey(next, identKey, key)
+	}
+	return
+}
+
+func (p *Parser) mustReadExceptIdentKey(key identkeyword.IdentKeyword) (next token.Token) {
+	next = p.read()
+	if next.Keyword != keyword.IDENT {
+		p.errUnexpectedToken(next, keyword.IDENT)
+	}
+	identKey := p.identKeywordToken(next)
+	if identKey == key {
+		p.errUnexpectedIdentKey(next, identKey, key)
+	}
+	return
+}

--- a/pkg/astparser/parser_token_helpers.go
+++ b/pkg/astparser/parser_token_helpers.go
@@ -68,19 +68,6 @@ func (p *Parser) peekEqualsIdentKey(identKey identkeyword.IdentKeyword) bool {
 	return actualKey == identKey
 }
 
-func (p *Parser) mustNext(key keyword.Keyword) int {
-	current := p.currentToken
-	if p.next() == current {
-		p.errUnexpectedToken(p.tokens[p.currentToken], key)
-		return p.currentToken
-	}
-	if p.tokens[p.currentToken].Keyword != key {
-		p.errUnexpectedToken(p.tokens[p.currentToken], key)
-		return p.currentToken
-	}
-	return p.currentToken
-}
-
 func (p *Parser) mustRead(key keyword.Keyword) (next token.Token) {
 	next = p.read()
 	if next.Keyword != key {

--- a/pkg/astparser/parser_token_helpers.go
+++ b/pkg/astparser/parser_token_helpers.go
@@ -7,17 +7,25 @@ import (
 	"github.com/jensneuse/graphql-go-tools/pkg/lexer/token"
 )
 
+// hasNextToken - checks that we haven't reached eof
+func (p *Parser) hasNextToken() bool {
+	return p.currentToken+1 < p.maxTokens
+}
+
+// next - increments current token index if hasNextToken
+// otherwise returns current token
 func (p *Parser) next() int {
-	if p.currentToken != p.maxTokens-1 {
+	if p.hasNextToken() {
 		p.currentToken++
 	}
 	return p.currentToken
 }
 
+// read - increments currentToken index and return token if hasNextToken
+// otherwise returns keyword.EOF
 func (p *Parser) read() token.Token {
-	p.currentToken++
-	if p.currentToken < p.maxTokens {
-		return p.tokens[p.currentToken]
+	if p.hasNextToken() {
+		return p.tokens[p.next()]
 	}
 
 	return token.Token{
@@ -25,26 +33,32 @@ func (p *Parser) read() token.Token {
 	}
 }
 
+// peek - returns token next to currentToken if hasNextToken
+// otherwise returns keyword.EOF
 func (p *Parser) peek() keyword.Keyword {
-	nextIndex := p.currentToken + 1
-	if nextIndex < p.maxTokens {
+	if p.hasNextToken() {
+		nextIndex := p.currentToken + 1
 		return p.tokens[nextIndex].Keyword
 	}
 	return keyword.EOF
 }
 
+// peekLiteral - returns token next to currentToken and token name as a ast.ByteSliceReference if hasNextToken
+// otherwise returns keyword.EOF
 func (p *Parser) peekLiteral() (keyword.Keyword, ast.ByteSliceReference) {
-	nextIndex := p.currentToken + 1
-	if nextIndex < p.maxTokens {
+	if p.hasNextToken() {
+		nextIndex := p.currentToken + 1
 		return p.tokens[nextIndex].Keyword, p.tokens[nextIndex].Literal
 	}
 	return keyword.EOF, ast.ByteSliceReference{}
 }
 
+// peekEquals - checks that next token is equal to key
 func (p *Parser) peekEquals(key keyword.Keyword) bool {
 	return p.peek() == key
 }
 
+// peekEqualsIdentKey - checks that next token is an identifier
 func (p *Parser) peekEqualsIdentKey(identKey identkeyword.IdentKeyword) bool {
 	key, literal := p.peekLiteral()
 	if key != keyword.IDENT {

--- a/pkg/astparser/parser_token_helpers.go
+++ b/pkg/astparser/parser_token_helpers.go
@@ -7,50 +7,22 @@ import (
 	"github.com/jensneuse/graphql-go-tools/pkg/lexer/token"
 )
 
-// hasNextToken - checks that we haven't reached eof
-func (p *Parser) hasNextToken() bool {
-	return p.currentToken+1 < p.maxTokens
-}
-
-// next - increments current token index if hasNextToken
-// otherwise returns current token
-func (p *Parser) next() int {
-	if p.hasNextToken() {
-		p.currentToken++
-	}
-	return p.currentToken
-}
-
 // read - increments currentToken index and return token if hasNextToken
 // otherwise returns keyword.EOF
 func (p *Parser) read() token.Token {
-	if p.hasNextToken() {
-		return p.tokens[p.next()]
-	}
-
-	return token.Token{
-		Keyword: keyword.EOF,
-	}
+	return p.tokenizer.Read()
 }
 
 // peek - returns token next to currentToken if hasNextToken
 // otherwise returns keyword.EOF
 func (p *Parser) peek() keyword.Keyword {
-	if p.hasNextToken() {
-		nextIndex := p.currentToken + 1
-		return p.tokens[nextIndex].Keyword
-	}
-	return keyword.EOF
+	return p.tokenizer.Peek()
 }
 
 // peekLiteral - returns token next to currentToken and token name as a ast.ByteSliceReference if hasNextToken
 // otherwise returns keyword.EOF
 func (p *Parser) peekLiteral() (keyword.Keyword, ast.ByteSliceReference) {
-	if p.hasNextToken() {
-		nextIndex := p.currentToken + 1
-		return p.tokens[nextIndex].Keyword, p.tokens[nextIndex].Literal
-	}
-	return keyword.EOF, ast.ByteSliceReference{}
+	return p.tokenizer.PeekLiteral()
 }
 
 // peekEquals - checks that next token is equal to key

--- a/pkg/astparser/parser_token_helpers.go
+++ b/pkg/astparser/parser_token_helpers.go
@@ -16,13 +16,18 @@ func (p *Parser) read() token.Token {
 // peek - returns token next to currentToken if hasNextToken
 // otherwise returns keyword.EOF
 func (p *Parser) peek() keyword.Keyword {
-	return p.tokenizer.Peek()
+	tok := p.tokenizer.Peek()
+	return tok.Keyword
 }
 
 // peekLiteral - returns token next to currentToken and token name as a ast.ByteSliceReference if hasNextToken
 // otherwise returns keyword.EOF
 func (p *Parser) peekLiteral() (keyword.Keyword, ast.ByteSliceReference) {
-	return p.tokenizer.PeekLiteral()
+	tok := p.tokenizer.Peek()
+	if tok.Keyword != keyword.EOF {
+		return tok.Keyword, tok.Literal
+	}
+	return keyword.EOF, ast.ByteSliceReference{}
 }
 
 // peekEquals - checks that next token is equal to key

--- a/pkg/astparser/parser_token_helpers.go
+++ b/pkg/astparser/parser_token_helpers.go
@@ -25,25 +25,6 @@ func (p *Parser) read() token.Token {
 	}
 }
 
-func (p *Parser) readExpectLiteral(expect ...identkeyword.IdentKeyword) (token.Token, identkeyword.IdentKeyword) {
-	p.currentToken++
-	if p.currentToken < p.maxTokens {
-		out := p.tokens[p.currentToken]
-		identKey := p.identKeywordToken(out)
-		for _, expectation := range expect {
-			if identKey == expectation {
-				return out, identKey
-			}
-		}
-		p.errUnexpectedToken(out)
-		return out, identKey
-	}
-
-	return token.Token{
-		Keyword: keyword.EOF,
-	}, identkeyword.UNDEFINED
-}
-
 func (p *Parser) peek() keyword.Keyword {
 	nextIndex := p.currentToken + 1
 	if nextIndex < p.maxTokens {
@@ -116,4 +97,17 @@ func (p *Parser) mustReadExceptIdentKey(key identkeyword.IdentKeyword) (next tok
 		p.errUnexpectedIdentKey(next, identKey, key)
 	}
 	return
+}
+
+func (p *Parser) mustReadOneOf(keys ...identkeyword.IdentKeyword) (token.Token, identkeyword.IdentKeyword) {
+	next := p.read()
+
+	identKey := p.identKeywordToken(next)
+	for _, expectation := range keys {
+		if identKey == expectation {
+			return next, identKey
+		}
+	}
+	p.errUnexpectedToken(next)
+	return next, identKey
 }

--- a/pkg/astparser/tokenizer.go
+++ b/pkg/astparser/tokenizer.go
@@ -7,7 +7,7 @@ import (
 	"github.com/jensneuse/graphql-go-tools/pkg/lexer/token"
 )
 
-// Tokenizer takes a raw input and turns it into an AST
+// Tokenizer takes a raw input and turns it into set of tokens
 type Tokenizer struct {
 	lexer        *lexer.Lexer
 	tokens       []token.Token

--- a/pkg/astparser/tokenizer.go
+++ b/pkg/astparser/tokenizer.go
@@ -1,0 +1,87 @@
+package astparser
+
+import (
+	"github.com/jensneuse/graphql-go-tools/pkg/ast"
+	"github.com/jensneuse/graphql-go-tools/pkg/lexer"
+	"github.com/jensneuse/graphql-go-tools/pkg/lexer/keyword"
+	"github.com/jensneuse/graphql-go-tools/pkg/lexer/token"
+)
+
+// Tokenizer takes a raw input and turns it into an AST
+type Tokenizer struct {
+	lexer        *lexer.Lexer
+	tokens       []token.Token
+	maxTokens    int
+	currentToken int
+	skipComments bool
+}
+
+// NewTokenizer returns a new tokenizer
+func NewTokenizer() *Tokenizer {
+	return &Tokenizer{
+		tokens:       make([]token.Token, 256),
+		lexer:        &lexer.Lexer{},
+		skipComments: true,
+	}
+}
+
+func (p *Tokenizer) Tokenize(input *ast.Input) {
+	p.lexer.SetInput(input)
+	p.tokens = p.tokens[:0]
+
+	for {
+		next := p.lexer.Read()
+		if next.Keyword == keyword.EOF {
+			p.maxTokens = len(p.tokens)
+			p.currentToken = -1
+			return
+		}
+		p.tokens = append(p.tokens, next)
+	}
+}
+
+// hasNextToken - checks that we haven't reached eof
+func (p *Tokenizer) hasNextToken() bool {
+	return p.currentToken+1 < p.maxTokens
+}
+
+// next - increments current token index if hasNextToken
+// otherwise returns current token
+func (p *Tokenizer) next() int {
+	if p.hasNextToken() {
+		p.currentToken++
+	}
+	return p.currentToken
+}
+
+// Read - increments currentToken index and return token if hasNextToken
+// otherwise returns keyword.EOF
+func (p *Tokenizer) Read() token.Token {
+	if p.hasNextToken() {
+		return p.tokens[p.next()]
+	}
+
+	return token.Token{
+		Keyword: keyword.EOF,
+	}
+}
+
+// Peek - returns token next to currentToken if hasNextToken
+// otherwise returns keyword.EOF
+func (p *Tokenizer) Peek() keyword.Keyword {
+	if p.hasNextToken() {
+		nextIndex := p.currentToken + 1
+		return p.tokens[nextIndex].Keyword
+	}
+	return keyword.EOF
+}
+
+// PeekLiteral - returns token next to currentToken and token name as a ast.ByteSliceReference if hasNextToken
+// otherwise returns keyword.EOF
+func (p *Tokenizer) PeekLiteral() (keyword.Keyword, ast.ByteSliceReference) {
+	if p.hasNextToken() {
+		nextIndex := p.currentToken + 1
+		return p.tokens[nextIndex].Keyword, p.tokens[nextIndex].Literal
+	}
+	return keyword.EOF, ast.ByteSliceReference{}
+}

--- a/pkg/astprinter/astprinter.go
+++ b/pkg/astprinter/astprinter.go
@@ -310,7 +310,14 @@ func (p *printVisitor) EnterFragmentSpread(ref int) {
 }
 
 func (p *printVisitor) LeaveFragmentSpread(ref int) {
-
+	ancestor := p.Ancestors[len(p.Ancestors)-1]
+	if p.document.SelectionsAfterFragmentSpread(ref, ancestor) {
+		if p.indent != nil {
+			p.write(literal.LINETERMINATOR)
+		} else {
+			p.write(literal.SPACE)
+		}
+	}
 }
 
 func (p *printVisitor) EnterInlineFragment(ref int) {

--- a/pkg/astprinter/astprinter_test.go
+++ b/pkg/astprinter/astprinter_test.go
@@ -271,6 +271,121 @@ vary: [String]! = []) on QUERY`)
 				}`,
 			`mutation AddToWatchlist($a: Int!, $b: String!){addToWatchlist(movieID: $a, name: $b){id name year}} mutation AddWithInput($a: WatchlistInput!){addToWatchlistWithInput(input: $a){id name year}}`)
 	})
+
+	t.Run("ommit comments", func(t *testing.T) {
+		t.Run("operation", func(t *testing.T) {
+			run(`
+				fragment friendFields on User {#comment
+  					id#comment
+					#commented
+  					name #comment
+				}#comment
+				mutation AddToWatchlist($a: Int!,# comment
+$b: String!#comment
+){ # comment
+					addToWatchlist( #comment
+movieID: $a, #comment
+name: $b){ # comment
+						id # comment
+						# name # commented field
+						year # comment
+					    ...friendFields# comment
+						... on User {# comment
+						  friends {# comment
+							count# comment
+						  }# comment
+						}# comment
+					} # comment
+				}# comment
+`,
+				`fragment friendFields on User {id name} mutation AddToWatchlist($a: Int!, $b: String!){addToWatchlist(movieID: $a, name: $b){id year ...friendFields... on User {friends {count}}}}`)
+		})
+
+		t.Run("definition", func(t *testing.T) {
+			run(`
+# comment
+union SearchResult = Human | Droid | Starship # comment
+union SearchRes = Human | Droid# comment
+# comment
+schema { # comment
+    query: Query# comment
+    mutation: Mutation# comment
+    subscription: Subscription
+	#comment
+}#comment
+# comment
+type Query {#comment
+    hero: Character#comment
+    droid(id: ID!): Droid # comment
+    search(name: String!): SearchResult#comment
+}
+#comment
+#comment
+#comment
+type Mutation {#comment
+#comment
+#comment
+    createReview(#comment
+episode: Episode!,#comment
+review: ReviewInput! #comment
+): Review # comment
+#comment
+}
+
+#comment
+type Subscription {
+#comment
+    remainingJedis: Int!
+}
+
+#comment
+input ReviewInput { # comment
+#comment
+    stars: Int!#comment
+#comment
+    #commentary: String
+}
+
+type Review { # comment
+    id: ID!
+    stars: Int!
+    commentary: String
+}
+
+# comment
+enum Episode { # comment
+    NEWHOPE#comment
+    #EMPIRE #comment
+    JEDI # comment
+}
+
+# comment
+interface Character { # comment
+    name: String! # comment
+    friends: [Character] # comment
+}
+
+# comment
+type Human implements Character { # comment
+    name: String!
+    height: String!
+    friends: [Character] # comment
+}
+
+# comment
+type Droid implements Character {#comment
+    name: String!
+    primaryFunction: String!
+    friends: [Character]
+}#comment
+
+type Starship { # comment
+    name: String!
+    length: Float!
+}`,
+				`union SearchResult = Human | Droid | Starship union SearchRes = Human | Droid schema {query: Query mutation: Mutation subscription: Subscription} type Query {hero: Character droid(id: ID!): Droid search(name: String!): SearchResult} type Mutation {createReview(episode: Episode!, review: ReviewInput!): Review} type Subscription {remainingJedis: Int!} input ReviewInput {stars: Int!} type Review {id: ID! stars: Int! commentary: String} enum Episode {NEWHOPE JEDI} interface Character {name: String! friends: [Character]} type Human implements Character {name: String! height: String! friends: [Character]} type Droid implements Character {name: String! primaryFunction: String! friends: [Character]} type Starship {name: String! length: Float!}`)
+		})
+	})
 }
 
 func TestPrintSchemaDefinition(t *testing.T) {

--- a/pkg/astprinter/astprinter_test.go
+++ b/pkg/astprinter/astprinter_test.go
@@ -272,117 +272,209 @@ vary: [String]! = []) on QUERY`)
 			`mutation AddToWatchlist($a: Int!, $b: String!){addToWatchlist(movieID: $a, name: $b){id name year}} mutation AddWithInput($a: WatchlistInput!){addToWatchlistWithInput(input: $a){id name year}}`)
 	})
 
-	t.Run("ommit comments", func(t *testing.T) {
+	t.Run("ignore comments", func(t *testing.T) {
 		t.Run("operation", func(t *testing.T) {
 			run(`
-				fragment friendFields on User {#comment
-  					id#comment
-					#commented
-  					name #comment
-				}#comment
-				mutation AddToWatchlist($a: Int!,# comment
-$b: String!#comment
-){ # comment
-					addToWatchlist( #comment
-movieID: $a, #comment
-name: $b){ # comment
-						id # comment
-						# name # commented field
-						year # comment
-					    ...friendFields# comment
-						... on User {# comment
-						  friends {# comment
-							count# comment
-						  }# comment
-						}# comment
-					} # comment
-				}# comment
+query #comment
+findUser#comment
+(#comment
+    $userId#comment
+  :#comment
+  ID#comment
+  !#comment
+  #comment
+    )#comment
+    {#comment
+  user#comment
+      (#comment
+      id#comment
+        :#comment
+    $userId#comment
+      #comment
+)#comment
+      #comment
+{#comment
+    ...#comment
+  UserFields#comment
+    ... #comment
+  on #comment
+  User#comment
+  {#comment
+        email#comment
+    }#comment
+  }#comment
+}#comment
+
+fragment #comment
+UserFields #comment
+on #comment
+User#comment
+{#comment
+  id#comment
+  #username#comment
+  role#comment
+}#comment
 `,
-				`fragment friendFields on User {id name} mutation AddToWatchlist($a: Int!, $b: String!){addToWatchlist(movieID: $a, name: $b){id year ...friendFields... on User {friends {count}}}}`)
+				`fragment friendFields on User {id name} mutation AddToWatchlist($a: Int!, $b: String!){addToWatchlist(movieID: $a, name: $b){id year ...friendFields ... on User {friends {count}}}}`)
 		})
 
 		t.Run("definition", func(t *testing.T) {
 			run(`
-# comment
-union SearchResult = Human | Droid | Starship # comment
-union SearchRes = Human | Droid# comment
-# comment
-schema { # comment
-    query: Query# comment
-    mutation: Mutation# comment
-    subscription: Subscription
-	#comment
-}#comment
-# comment
-type Query {#comment
-    hero: Character#comment
-    droid(id: ID!): Droid # comment
-    search(name: String!): SearchResult#comment
-}
 #comment
-#comment
-#comment
-type Mutation {#comment
-#comment
-#comment
-    createReview(#comment
-episode: Episode!,#comment
-review: ReviewInput! #comment
-): Review # comment
-#comment
-}
+scalar #comment
+Date #comment
 
-#comment
-type Subscription {
-#comment
-    remainingJedis: Int!
-}
-
-#comment
-input ReviewInput { # comment
-#comment
-    stars: Int!#comment
-#comment
-    #commentary: String
-}
-
-type Review { # comment
-    id: ID!
-    stars: Int!
-    commentary: String
-}
-
-# comment
-enum Episode { # comment
-    NEWHOPE#comment
-    #EMPIRE #comment
-    JEDI # comment
-}
-
-# comment
-interface Character { # comment
-    name: String! # comment
-    friends: [Character] # comment
-}
-
-# comment
-type Human implements Character { # comment
-    name: String!
-    height: String!
-    friends: [Character] # comment
-}
-
-# comment
-type Droid implements Character {#comment
-    name: String!
-    primaryFunction: String!
-    friends: [Character]
+schema #comment
+{ #comment
+  query#comment
+  :#comment
+  #comment
+  Query#comment
+  #comment
 }#comment
 
-type Starship { # comment
-    name: String!
-    length: Float!
-}`,
+#comment
+type#comment
+Query#comment
+{#comment
+  me#comment
+  :#comment
+  User#comment
+  !#comment
+  user(#comment
+    id#comment
+    :#comment
+    ID#comment
+    !#comment
+  )#comment
+  :#comment
+  User#comment
+  allUsers#comment
+  :#comment
+  [#comment
+    #comment
+    User#comment
+  ]#comment
+  search#comment
+  (#comment
+    term#comment
+    :#comment
+    String#comment
+    !#comment
+  )#comment
+  :#comment
+  [#comment
+    SearchResult#comment
+    !#comment
+  ]#comment
+  !#comment
+  myChats:#comment
+  [#comment
+    Chat#comment
+    !#comment
+  ]!#comment
+}
+
+enum#comment
+Role#comment
+{#comment
+  #comment
+  USER#comment
+  ,#comment
+  ADMIN#comment
+  ,#comment
+  #comment
+}#comment
+
+interface#comment
+Node {#comment
+  id#comment
+  :#comment
+  ID#comment
+  !#comment
+}#comment
+
+union #comment
+SearchResult#comment
+=#comment
+User#comment
+|#comment
+Chat#comment
+|#comment
+ChatMessage#comment
+
+type#comment
+User#comment
+implements#comment
+Node#comment
+{#comment
+  id#comment
+  :#comment
+  ID#comment
+  !#comment
+  username#comment
+  :#comment
+  String#comment
+  !#comment
+  email#comment
+  :#comment
+  String#comment
+  !#comment
+  role#comment
+  :#comment
+  Role#comment
+  !#comment
+}#comment
+
+type#comment
+Chat#comment
+implements#comment
+Node#comment
+{#comment
+  id#comment
+  :#comment
+  ID#comment
+  !#comment
+  users#comment
+  :#comment
+  [#comment
+    User#comment
+    !#comment
+  ]!#comment
+  messages#comment
+  :#comment
+  [#comment
+    ChatMessage#comment
+    !#comment
+  ]#comment
+  !#comment
+  #comment
+}#comment
+
+type#comment
+ChatMessage#comment
+implements#comment
+Node#comment
+{#comment
+  id#comment
+  :#comment
+  ID#comment
+  !#comment
+  content#comment
+  :#comment
+  String#comment
+  !#comment
+  time#comment
+  :#comment
+  Date#comment
+  !#comment
+  user#comment
+  :#comment
+  User#comment
+  !#comment
+  #comment
+}#comment
+`,
 				`union SearchResult = Human | Droid | Starship union SearchRes = Human | Droid schema {query: Query mutation: Mutation subscription: Subscription} type Query {hero: Character droid(id: ID!): Droid search(name: String!): SearchResult} type Mutation {createReview(episode: Episode!, review: ReviewInput!): Review} type Subscription {remainingJedis: Int!} input ReviewInput {stars: Int!} type Review {id: ID! stars: Int! commentary: String} enum Episode {NEWHOPE JEDI} interface Character {name: String! friends: [Character]} type Human implements Character {name: String! height: String! friends: [Character]} type Droid implements Character {name: String! primaryFunction: String! friends: [Character]} type Starship {name: String! length: Float!}`)
 		})
 	})

--- a/pkg/astprinter/astprinter_test.go
+++ b/pkg/astprinter/astprinter_test.go
@@ -276,206 +276,204 @@ vary: [String]! = []) on QUERY`)
 	t.Run("ignore comments", func(t *testing.T) {
 		t.Run("operation", func(t *testing.T) {
 			run(t, `
-query #comment
-findUser#comment
-(#comment
-    $userId#comment
-  :#comment
-  ID#comment
-  !#comment
-  #comment
-    )#comment
-    {#comment
-  user#comment
-      (#comment
-      id#comment
-        :#comment
-    $userId#comment
-      #comment
-)#comment
-      #comment
-{#comment
-    ...#comment
-  UserFields#comment
-    ... #comment
-  on #comment
-  User#comment
-  {#comment
-        email#comment
-    }#comment
-  }#comment
-}#comment
-
-fragment #comment
-UserFields #comment
-on #comment
-User#comment
-{#comment
-  id#comment
-  #username#comment
-  role#comment
-}#comment
-`,
-				`query findUser($userId: ID!){user(id: $userId){...UserFields ... on User {email}}} fragment UserFields on User{id role}`)
+				query #comment
+				findUser#comment
+				(#comment
+					$userId#comment
+				  :#comment
+				  ID#comment
+				  !#comment
+				  #comment
+					)#comment
+					{#comment
+				  user#comment
+					  (#comment
+					  id#comment
+						:#comment
+					$userId#comment
+					  #comment
+				)#comment
+					  #comment
+				{#comment
+					...#comment
+				  UserFields#comment
+					... #comment
+				  on #comment
+				  User#comment
+				  {#comment
+						email#comment
+					}#comment
+				  }#comment
+				}#comment
+				
+				fragment #comment
+				UserFields #comment
+				on #comment
+				User#comment
+				{#comment
+				  id#comment
+				  #username#comment
+				  role#comment
+				}#comment`,
+				`query findUser($userId: ID!){user(id: $userId){...UserFields ... on User {email}}} fragment UserFields on User {id role}`)
 		})
 
 		t.Run("definition", func(t *testing.T) {
 			run(t, `
-#comment
-scalar #comment
-Date #comment
-
-schema #comment
-{ #comment
-  query#comment
-  :#comment
-  #comment
-  Query#comment
-  #comment
-}#comment
-
-#comment
-type#comment
-Query#comment
-{#comment
-  me#comment
-  :#comment
-  User#comment
-  !#comment
-  user(#comment
-    id#comment
-    :#comment
-    ID#comment
-    !#comment
-  )#comment
-  :#comment
-  User#comment
-  allUsers#comment
-  :#comment
-  [#comment
-    #comment
-    User#comment
-  ]#comment
-  search#comment
-  (#comment
-    term#comment
-    :#comment
-    String#comment
-    !#comment
-  )#comment
-  :#comment
-  [#comment
-    SearchResult#comment
-    !#comment
-  ]#comment
-  !#comment
-  myChats:#comment
-  [#comment
-    Chat#comment
-    !#comment
-  ]!#comment
-}
-
-enum#comment
-Role#comment
-{#comment
-  #comment
-  USER#comment
-  ,#comment
-  ADMIN#comment
-  ,#comment
-  #comment
-}#comment
-
-interface#comment
-Node {#comment
-  id#comment
-  :#comment
-  ID#comment
-  !#comment
-}#comment
-
-union #comment
-SearchResult#comment
-=#comment
-User#comment
-|#comment
-Chat#comment
-|#comment
-ChatMessage#comment
-
-type#comment
-User#comment
-implements#comment
-Node#comment
-{#comment
-  id#comment
-  :#comment
-  ID#comment
-  !#comment
-  username#comment
-  :#comment
-  String#comment
-  !#comment
-  email#comment
-  :#comment
-  String#comment
-  !#comment
-  role#comment
-  :#comment
-  Role#comment
-  !#comment
-}#comment
-
-type#comment
-Chat#comment
-implements#comment
-Node#comment
-{#comment
-  id#comment
-  :#comment
-  ID#comment
-  !#comment
-  users#comment
-  :#comment
-  [#comment
-    User#comment
-    !#comment
-  ]!#comment
-  messages#comment
-  :#comment
-  [#comment
-    ChatMessage#comment
-    !#comment
-  ]#comment
-  !#comment
-  #comment
-}#comment
-
-type#comment
-ChatMessage#comment
-implements#comment
-Node#comment
-{#comment
-  id#comment
-  :#comment
-  ID#comment
-  !#comment
-  content#comment
-  :#comment
-  String#comment
-  !#comment
-  time#comment
-  :#comment
-  Date#comment
-  !#comment
-  user#comment
-  :#comment
-  User#comment
-  !#comment
-  #comment
-}#comment
-`,
+				#comment
+				scalar #comment
+				Date #comment
+				
+				schema #comment
+				{ #comment
+				  query#comment
+				  :#comment
+				  #comment
+				  Query#comment
+				  #comment
+				}#comment
+				
+				#comment
+				type#comment
+				Query#comment
+				{#comment
+				  me#comment
+				  :#comment
+				  User#comment
+				  !#comment
+				  user(#comment
+					id#comment
+					:#comment
+					ID#comment
+					!#comment
+				  )#comment
+				  :#comment
+				  User#comment
+				  allUsers#comment
+				  :#comment
+				  [#comment
+					#comment
+					User#comment
+				  ]#comment
+				  search#comment
+				  (#comment
+					term#comment
+					:#comment
+					String#comment
+					!#comment
+				  )#comment
+				  :#comment
+				  [#comment
+					SearchResult#comment
+					!#comment
+				  ]#comment
+				  !#comment
+				  myChats:#comment
+				  [#comment
+					Chat#comment
+					!#comment
+				  ]!#comment
+				}
+				
+				enum#comment
+				Role#comment
+				{#comment
+				  #comment
+				  USER#comment
+				  ,#comment
+				  ADMIN#comment
+				  ,#comment
+				  #comment
+				}#comment
+				
+				interface#comment
+				Node {#comment
+				  id#comment
+				  :#comment
+				  ID#comment
+				  !#comment
+				}#comment
+				
+				union #comment
+				SearchResult#comment
+				=#comment
+				User#comment
+				|#comment
+				Chat#comment
+				|#comment
+				ChatMessage#comment
+				
+				type#comment
+				User#comment
+				implements#comment
+				Node#comment
+				{#comment
+				  id#comment
+				  :#comment
+				  ID#comment
+				  !#comment
+				  username#comment
+				  :#comment
+				  String#comment
+				  !#comment
+				  email#comment
+				  :#comment
+				  String#comment
+				  !#comment
+				  role#comment
+				  :#comment
+				  Role#comment
+				  !#comment
+				}#comment
+				
+				type#comment
+				Chat#comment
+				implements#comment
+				Node#comment
+				{#comment
+				  id#comment
+				  :#comment
+				  ID#comment
+				  !#comment
+				  users#comment
+				  :#comment
+				  [#comment
+					User#comment
+					!#comment
+				  ]!#comment
+				  messages#comment
+				  :#comment
+				  [#comment
+					ChatMessage#comment
+					!#comment
+				  ]#comment
+				  !#comment
+				  #comment
+				}#comment
+				
+				type#comment
+				ChatMessage#comment
+				implements#comment
+				Node#comment
+				{#comment
+				  id#comment
+				  :#comment
+				  ID#comment
+				  !#comment
+				  content#comment
+				  :#comment
+				  String#comment
+				  !#comment
+				  time#comment
+				  :#comment
+				  Date#comment
+				  !#comment
+				  user#comment
+				  :#comment
+				  User#comment
+				  !#comment
+				  #comment
+				}#comment`,
 				`scalar Date schema {query: Query} type Query {me: User! user(id: ID!): User allUsers: [User] search(term: String!): [SearchResult!]! myChats: [Chat!]!} enum Role {USER ADMIN} interface Node {id: ID!} union SearchResult = User | Chat | ChatMessage type User implements Node {id: ID! username: String! email: String! role: Role!} type Chat implements Node {id: ID! users: [User!]! messages: [ChatMessage!]!} type ChatMessage implements Node {id: ID! content: String! time: Date! user: User!}`)
 		})
 	})


### PR DESCRIPTION
Benchmark results:

On master:
```
goos: darwin
goarch: arm64
pkg: github.com/jensneuse/graphql-go-tools/pkg/astparser
BenchmarkParseStarwars
BenchmarkParseStarwars-8        	   22077	     47744 ns/op	 237.24 MB/s	    1210 B/op	      37 allocs/op
BenchmarkParseGithub
BenchmarkParseGithub-8          	     511	   2349871 ns/op	 250.10 MB/s	   84210 B/op	     971 allocs/op
BenchmarkSelectionSet
BenchmarkSelectionSet-8         	  991680	      1157 ns/op	 234.30 MB/s	       0 B/op	       0 allocs/op
BenchmarkIntrospectionQuery
BenchmarkIntrospectionQuery-8   	  205233	      5857 ns/op	 222.64 MB/s	       0 B/op	       0 allocs/op
BenchmarkKitchenSink
BenchmarkKitchenSink-8          	  247881	      4865 ns/op	 209.67 MB/s	       0 B/op	       0 allocs/op
BenchmarkParse
BenchmarkParse-8                	  201710	      5800 ns/op	 230.16 MB/s	     160 B/op	       9 allocs/op
PASS
```

On this PR:
```
goos: darwin
goarch: arm64
pkg: github.com/jensneuse/graphql-go-tools/pkg/astparser
BenchmarkParseStarwars
BenchmarkParseStarwars-8        	   21216	     55375 ns/op	 204.55 MB/s	    1212 B/op	      37 allocs/op
BenchmarkParseGithub
BenchmarkParseGithub-8          	     450	   2583312 ns/op	 227.50 MB/s	   87275 B/op	     971 allocs/op
BenchmarkSelectionSet
BenchmarkSelectionSet-8         	  683020	      1617 ns/op	 167.62 MB/s	       0 B/op	       0 allocs/op
BenchmarkIntrospectionQuery
BenchmarkIntrospectionQuery-8   	  145411	      8040 ns/op	 162.20 MB/s	       0 B/op	       0 allocs/op
BenchmarkKitchenSink
BenchmarkKitchenSink-8          	  176130	      6686 ns/op	 152.56 MB/s	       0 B/op	       0 allocs/op
BenchmarkParse
BenchmarkParse-8                	  158084	      7345 ns/op	 181.75 MB/s	     160 B/op	       9 allocs/op
PASS
```