### PR TITLE
add test cases to existing functionality (TT-4535)

### DIFF
--- a/pkg/astvalidation/rule_implement_transitive_interfaces.go
+++ b/pkg/astvalidation/rule_implement_transitive_interfaces.go
@@ -80,6 +80,10 @@ func (v *implementTransitiveInterfacesVisitor) EnterInterfaceTypeExtension(ref i
 	}
 
 	interfaceName := v.definition.InterfaceTypeExtensionNameString(ref)
+	fieldDefinitionRefs := v.definition.InterfaceTypeExtensions[ref].FieldsDefinition.Refs
+	if len(fieldDefinitionRefs) == 0 {
+		v.Report.AddExternalError(operationreport.ErrTransitiveInterfaceExtensionImplementingWithoutBody([]byte(interfaceName)))
+	}
 	v.collectImplementedInterfaces(interfaceName, v.definition.InterfaceTypeExtensions[ref].ImplementsInterfaces.Refs)
 }
 

--- a/pkg/astvalidation/rule_implement_transitive_interfaces_test.go
+++ b/pkg/astvalidation/rule_implement_transitive_interfaces_test.go
@@ -218,5 +218,40 @@ func TestImplementTransitiveInterfaces(t *testing.T) {
 				`, Invalid, ImplementTransitiveInterfaces(),
 			)
 		})
+
+		t.Run("Interface extension implementing interface which also already implements same interface", func(t *testing.T) {
+			runDefinitionValidation(t, `
+					interface IDType {
+					  id: ID!
+					}
+					
+					interface SoftDelete implements IDType {
+					  id: ID!
+					  deleted: Boolean!
+					}
+					
+					extend interface SoftDelete implements IDType {
+					  canBeRecovered: Boolean!
+					}
+				`, Valid, ImplementTransitiveInterfaces(),
+			)
+		})
+
+		t.Run("Interface extension implementing interface without body", func(t *testing.T) {
+			runDefinitionValidation(t, `
+					interface IDType {
+					  id: ID!
+					}
+					
+					interface SoftDelete {
+					  id: ID!
+					  deleted: Boolean!
+					}
+					
+					extend interface SoftDelete implements IDType
+				`, Invalid, ImplementTransitiveInterfaces(),
+			)
+		})
+
 	})
 }

--- a/pkg/operationreport/externalerror.go
+++ b/pkg/operationreport/externalerror.go
@@ -248,3 +248,8 @@ func ErrTransitiveInterfaceNotImplemented(typeName, transitiveInterfaceName ast.
 	err.Message = fmt.Sprintf("type %s does not implement transitive interface %s", typeName, transitiveInterfaceName)
 	return err
 }
+
+func ErrTransitiveInterfaceExtensionImplementingWithoutBody(interfaceExtensionName ast.ByteSlice) (err ExternalError) {
+	err.Message = fmt.Sprintf("interface extension %s implementing interface without body", interfaceExtensionName)
+	return err
+}


### PR DESCRIPTION
This PR adds new test cases for validating transitive interfaces and interface extensions. Basically, I added a new control block to `EnterInterfaceTypeExtension`. If the interface extension has no fields, it adds an error to the report.

Related issue on Jira: [TT-4535](https://tyktech.atlassian.net/jira/software/c/projects/TT/boards/26?modal=detail&selectedIssue=TT-4535)