### PR TITLE
Testing on graphql-go-tools repository (TT-4588)

### DIFF
--- a/pkg/playground/files/playground.html
+++ b/pkg/playground/files/playground.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en" xml:lang="en">
 
 <head>
     <meta charset=utf-8/>


### PR DESCRIPTION
PR for [TT-4588](https://tyktech.atlassian.net/jira/software/c/projects/TT/boards/26?modal=detail&selectedIssue=TT-4588)

This bug is spotted on SonarCloud. Here is the explanation:

> **Add "lang" and/or "xml:lang" attributes to this "<html>" element**
>
> The <html> element should provide the lang and/or xml:lang attribute in order to identify the default language of a document.
> 
> It enables assistive technologies, such as screen readers, to provide a comfortable reading experience by adapting the pronunciation and accent to the language. It also helps braille translation software, telling it to switch the control codes for accented characters for instance.
> 
> Other benefits of marking the language include:
> 
> assisting user agents in providing dictionary definitions or helping users benefit from translation tools.
> improving [search engine ranking](https://blogs.bing.com/webmaster/2011/03/01/how-to-tell-bing-your-websites-country-and-language/).
> Both the lang and the xml:lang attributes can take only one value.