### PR TITLE
[TT-4369] Kafka Consumer Group implementation

### DIFF
--- a/pkg/engine/datasource/kafka_datasource/kafka_consumer_group.go
+++ b/pkg/engine/datasource/kafka_datasource/kafka_consumer_group.go
@@ -154,6 +154,16 @@ func (k *KafkaConsumerGroup) WaitUntilConsumerStop() {
 	k.wg.Wait()
 }
 
+func NewKafkaConsumerGroupBridge(ctx context.Context, logger log.Logger) *KafkaConsumerGroupBridge {
+	if logger == nil {
+		logger = log.NoopLogger
+	}
+	return &KafkaConsumerGroupBridge{
+		ctx: ctx,
+		log: logger,
+	}
+}
+
 // Subscribe creates a new consumer group with given config and streams messages via next channel.
 func (c *KafkaConsumerGroupBridge) Subscribe(ctx context.Context, options GraphQLSubscriptionOptions, next chan<- []byte) error {
 	cg, err := NewKafkaConsumerGroup(c.log, &options)

--- a/pkg/engine/datasource/kafka_datasource/kafka_consumer_group.go
+++ b/pkg/engine/datasource/kafka_datasource/kafka_consumer_group.go
@@ -1,0 +1,117 @@
+package kafka_datasource
+
+import (
+	"context"
+	"time"
+
+	"github.com/Shopify/sarama"
+	log "github.com/jensneuse/abstractlogger"
+)
+
+type KafkaConsumerGroup struct {
+	log           log.Logger
+	consumerGroup sarama.ConsumerGroup
+	ctx           context.Context
+}
+
+type kafkaConsumerGroupHandler struct {
+	log      log.Logger
+	options  *GraphQLSubscriptionOptions
+	messages chan *sarama.ConsumerMessage
+	ctx      context.Context
+}
+
+func (k *kafkaConsumerGroupHandler) Setup(_ sarama.ConsumerGroupSession) error {
+	k.log.Debug("kafkaConsumerGroupHandler.Setup", log.String("topic", k.options.Topic))
+	return nil
+}
+
+func (k *kafkaConsumerGroupHandler) Cleanup(_ sarama.ConsumerGroupSession) error {
+	k.log.Debug("kafkaConsumerGroupHandler.Cleanup", log.String("topic", k.options.Topic))
+	close(k.messages)
+	return nil
+}
+
+func (k *kafkaConsumerGroupHandler) ConsumeClaim(session sarama.ConsumerGroupSession, claim sarama.ConsumerGroupClaim) error {
+	for msg := range claim.Messages() {
+		ctx, cancel := context.WithTimeout(k.ctx, time.Second*5)
+		select {
+		case k.messages <- msg:
+			cancel()
+			session.MarkMessage(msg, "") // Commit the message and advance the offset.
+		case <-ctx.Done():
+			cancel()
+		case <-k.ctx.Done():
+			cancel()
+			return nil
+		}
+	}
+	k.log.Debug("kafkaConsumerGroupHandler.ConsumeClaim is gone")
+	return nil
+}
+
+func (c *KafkaConsumerGroup) newConsumerGroup(options *GraphQLSubscriptionOptions) (sarama.ConsumerGroup, error) {
+	sc := sarama.NewConfig()
+	sc.Version = sarama.V2_7_0_0
+	sc.ClientID = options.ClientID
+	return sarama.NewConsumerGroup([]string{options.BrokerAddr}, options.GroupID, sc)
+}
+
+func (c *KafkaConsumerGroup) stopConsuming(ctx context.Context, cg sarama.ConsumerGroup) {
+	select {
+	case <-ctx.Done():
+	case <-c.ctx.Done():
+	}
+
+	err := cg.Close()
+	if err != nil {
+		c.log.Error("KafkaConsumerGroup.stopConsuming", log.Error(err))
+	}
+}
+
+func (c *KafkaConsumerGroup) startConsuming(ctx context.Context, cg sarama.ConsumerGroup, messages chan *sarama.ConsumerMessage, options *GraphQLSubscriptionOptions) {
+	handler := &kafkaConsumerGroupHandler{
+		log:      c.log,
+		options:  options,
+		messages: messages,
+		ctx:      ctx,
+	}
+
+	go c.stopConsuming(ctx, cg)
+
+	err := cg.Consume(ctx, []string{options.Topic}, handler)
+	if err != nil {
+		c.log.Error("KafkaConsumerGroup.startConsuming", log.Error(err))
+	}
+}
+
+func (c *KafkaConsumerGroup) Subscribe(ctx context.Context, options GraphQLSubscriptionOptions, next chan<- []byte) error {
+	cg, err := c.newConsumerGroup(&options)
+	if err != nil {
+		return err
+	}
+
+	messages := make(chan *sarama.ConsumerMessage)
+	go c.startConsuming(ctx, cg, messages, &options)
+
+	go func() {
+		for {
+			select {
+			case <-c.ctx.Done():
+				return
+			case <-ctx.Done():
+				return
+			case msg, ok := <-messages:
+				if !ok {
+					return
+				}
+				// TODO: What about msg.Key and msg.Headers?
+				next <- msg.Value
+			}
+		}
+	}()
+
+	return nil
+}
+
+//var _ GraphQLSubscriptionClient = (*KafkaConsumerGroup)(nil)

--- a/pkg/engine/datasource/kafka_datasource/kafka_consumer_group_test.go
+++ b/pkg/engine/datasource/kafka_datasource/kafka_consumer_group_test.go
@@ -183,7 +183,6 @@ func TestKafkaMockBroker(t *testing.T) {
 }
 
 // It's just a simple example of graphql federation gateway server, it's NOT a production ready code.
-//
 func logger() log.Logger {
 	logger, err := zap.NewDevelopmentConfig().Build()
 	if err != nil {
@@ -210,10 +209,8 @@ func TestKafkaConsumerGroupBridge_Subscribe(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	cg := &KafkaConsumerGroupBridge{
-		log: logger(),
-		ctx: ctx,
-	}
+
+	cg := NewKafkaConsumerGroupBridge(ctx, logger()) // use abstractlogger.NoopLogger if there is no available logger.
 
 	sc := sarama.NewConfig()
 	sc.Version = sarama.V2_7_0_0

--- a/pkg/engine/datasource/kafka_datasource/kafka_datasource.go
+++ b/pkg/engine/datasource/kafka_datasource/kafka_datasource.go
@@ -1,8 +1,11 @@
 package kafka_datasource
 
+import "github.com/Shopify/sarama"
+
 type GraphQLSubscriptionOptions struct {
-	BrokerAddr string `json:"BrokerAddr"`
-	Topic      string `json:"Topic"`
-	GroupID    string `json:"GroupID"`
-	ClientID   string `json:"ClientID"`
+	BrokerAddr   string `json:"BrokerAddr"`
+	Topic        string `json:"Topic"`
+	GroupID      string `json:"GroupID"`
+	ClientID     string `json:"ClientID"`
+	saramaConfig *sarama.Config
 }

--- a/pkg/engine/datasource/kafka_datasource/kafka_datasource.go
+++ b/pkg/engine/datasource/kafka_datasource/kafka_datasource.go
@@ -1,0 +1,8 @@
+package kafka_datasource
+
+type GraphQLSubscriptionOptions struct {
+	BrokerAddr string `json:"BrokerAddr"`
+	Topic      string `json:"Topic"`
+	GroupID    string `json:"GroupID"`
+	ClientID   string `json:"ClientID"`
+}


### PR DESCRIPTION
This PR([TT-4369](https://tyktech.atlassian.net/jira/software/c/projects/TT/boards/26?selectedIssue=TT-4369)) implements the Kafka consumer group. It's an internal part of the Kafka data source. Basically, it starts a new consumer with the given config and it maintains the consumer during the subscription's life cycle. 

The data source implementation will use `Subscribe` function to subscribe to a topic with the given config. If the consumer quits in any way, it will close the `next` channel. I extracted the flow from `WebSocketGraphQLSubscriptionClient`. Please note that it implements `graphql-ws` protocol to communicate with the other GraphQL services. We don't need this with Kafka. 

graphql-ws: https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md

Here is the initial version of the data source configuration.

```go
type GraphQLSubscriptionOptions struct {
	BrokerAddr   string `json:"BrokerAddr"`
	Topic        string `json:"Topic"`
	GroupID      string `json:"GroupID"`
	ClientID     string `json:"ClientID"`
}
```