### PR TITLE
[TT 4815] Remove duplicated scalars from federated schemas

### DIFF
--- a/pkg/federation/sdlmerge/remove_scalar_duplicates.go
+++ b/pkg/federation/sdlmerge/remove_scalar_duplicates.go
@@ -6,7 +6,7 @@ import (
 )
 
 type removeDuplicateScalarTypeDefinitionVisitor struct {
-	operation     *ast.Document
+	document      *ast.Document
 	scalarSet     map[string]bool
 	nodesToRemove []ast.Node
 	lastRef       int
@@ -17,20 +17,20 @@ func newRemoveDuplicateScalarTypeDefinitionVistior() *removeDuplicateScalarTypeD
 		nil,
 		make(map[string]bool),
 		make([]ast.Node, 0),
-		-1,
+		ast.InvalidRef,
 	}
 }
 
 func (r *removeDuplicateScalarTypeDefinitionVisitor) EnterDocument(operation, definition *ast.Document) {
-	r.operation = operation
+	r.document = operation
 }
 
 func (r *removeDuplicateScalarTypeDefinitionVisitor) EnterScalarTypeDefinition(ref int) {
 	if ref <= r.lastRef {
 		return
 	}
-	name := r.operation.ScalarTypeDefinitionNameString(ref)
-	if ok := r.scalarSet[name]; ok {
+	name := r.document.ScalarTypeDefinitionNameString(ref)
+	if r.scalarSet[name] {
 		r.nodesToRemove = append(r.nodesToRemove, ast.Node{Kind: ast.NodeKindScalarTypeDefinition, Ref: ref})
 	} else {
 		r.scalarSet[name] = true
@@ -42,7 +42,7 @@ func (r *removeDuplicateScalarTypeDefinitionVisitor) LeaveDocument(operation, de
 	if len(r.nodesToRemove) < 1 {
 		return
 	}
-	r.operation.DeleteRootNodes(r.nodesToRemove)
+	r.document.DeleteRootNodes(r.nodesToRemove)
 }
 
 func (r *removeDuplicateScalarTypeDefinitionVisitor) Register(walker *astvisitor.Walker) {

--- a/pkg/federation/sdlmerge/remove_scalar_duplicates.go
+++ b/pkg/federation/sdlmerge/remove_scalar_duplicates.go
@@ -1,0 +1,52 @@
+package sdlmerge
+
+import (
+	"github.com/jensneuse/graphql-go-tools/pkg/ast"
+	"github.com/jensneuse/graphql-go-tools/pkg/astvisitor"
+)
+
+type removeDuplicateScalarTypeDefinitionVisitor struct {
+	operation     *ast.Document
+	scalarSet     map[string]bool
+	nodesToRemove []ast.Node
+	lastRef       int
+}
+
+func newRemoveDuplicateScalarTypeDefinitionVistior() *removeDuplicateScalarTypeDefinitionVisitor {
+	return &removeDuplicateScalarTypeDefinitionVisitor{
+		nil,
+		make(map[string]bool),
+		make([]ast.Node, 0),
+		-1,
+	}
+}
+
+func (r *removeDuplicateScalarTypeDefinitionVisitor) EnterDocument(operation, definition *ast.Document) {
+	r.operation = operation
+}
+
+func (r *removeDuplicateScalarTypeDefinitionVisitor) EnterScalarTypeDefinition(ref int) {
+	if ref <= r.lastRef {
+		return
+	}
+	name := r.operation.ScalarTypeDefinitionNameString(ref)
+	if ok := r.scalarSet[name]; ok {
+		r.nodesToRemove = append(r.nodesToRemove, ast.Node{Kind: ast.NodeKindScalarTypeDefinition, Ref: ref})
+	} else {
+		r.scalarSet[name] = true
+	}
+	r.lastRef = ref
+}
+
+func (r *removeDuplicateScalarTypeDefinitionVisitor) LeaveDocument(operation, definition *ast.Document) {
+	if len(r.nodesToRemove) < 1 {
+		return
+	}
+	r.operation.DeleteRootNodes(r.nodesToRemove)
+}
+
+func (r *removeDuplicateScalarTypeDefinitionVisitor) Register(walker *astvisitor.Walker) {
+	walker.RegisterEnterDocumentVisitor(r)
+	walker.RegisterLeaveDocumentVisitor(r)
+	walker.RegisterEnterScalarTypeDefinitionVisitor(r)
+}

--- a/pkg/federation/sdlmerge/sdlmerge.go
+++ b/pkg/federation/sdlmerge/sdlmerge.go
@@ -76,6 +76,7 @@ func (m *normalizer) setupWalkers() {
 			newRemoveInterfaceDefinitionDirective("key"),
 			newRemoveObjectTypeDefinitionDirective("key"),
 			newRemoveFieldDefinitionDirective("provides", "requires"),
+			newRemoveDuplicateScalarTypeDefinitionVistior(),
 		},
 	}
 

--- a/pkg/federation/sdlmerge/sdlmerge_test.go
+++ b/pkg/federation/sdlmerge/sdlmerge_test.go
@@ -89,39 +89,56 @@ const (
 		extend type Query {
 			me: User
 		}
+
+		scalar DateTime
+
+		scalar CustomScalar
 	
 		type User @key(fields: "id") {
 			id: ID!
 			username: String!
+			created: DateTime!
+			reputation: CustomScalar!
 		}
 	`
+
 	productSchema = `
+		scalar CustomScalar
+
 		extend type Query {
 			topProducts(first: Int = 5): [Product]
 		}
+
+		scalar BigInt
 		
 		type Product @key(fields: "upc") {
 			upc: String!
 			name: String!
 			price: Int!
+			worth: BigInt!
+			reputation: CustomScalar!
 		}
 	`
 	reviewSchema = `
+		scalar DateTime
+
 		type Review {
 			body: String!
 			author: User! @provides(fields: "username")
 			product: Product!
+			created: DateTime!
 		}
 		
 		extend type User @key(fields: "id") {
 			id: ID! @external
 			reviews: [Review]
 		}
-		
+
 		extend type Product @key(fields: "upc") {
 			upc: String! @external
 			name: String! @external
 			reviews: [Review] @requires(fields: "name")
+			sales: BigInt!
 		}
 
 		extend type Subscription {
@@ -129,10 +146,13 @@ const (
 		}
 	`
 	likeSchema = `
+		scalar DateTime
+
 		type Like @key(fields: "id") {
 			id: ID!
 			productId: ID!
 			userId: ID!
+			date: DateTime!
 		}
 		type Query {
 			likesCount(productID: ID!): Int!
@@ -151,19 +171,31 @@ const (
 		}
 	`
 	onlinePaymentSchema = `
+		scalar DateTime
+
+		scalar BigInt
+
 		interface PaymentType @extends {
 			email: String!
+			date: DateTime!
+			amount: BigInt!
 		}
 	`
 	classicPaymentSchema = `
+		scalar CustomScalar
+
 		extend interface PaymentType {
 			number: String!
+			reputation: CustomScalar!
 		}
 	`
 	extendsDirectivesSchema = `
+		scalar DateTime
+
 		type Comment {
 			body: String!
 			author: User!
+			created: DateTime!
 		}
 
 		type User @extends @key(fields: "id") {
@@ -186,36 +218,52 @@ const (
 		type Subscription {
 			review: Review!
 		}
+
+		scalar DateTime
+
+		scalar CustomScalar
 		
 		type User {
 			id: ID!
 			username: String!
+			created: DateTime!
+			reputation: CustomScalar!
 			reviews: [Review]
 		}
+		
+		scalar BigInt
 		
 		type Product {
 			upc: String!
 			name: String!
 			price: Int!
+			worth: BigInt!
+			reputation: CustomScalar!
 			reviews: [Review]
+			sales: BigInt!
 		}
 		
 		type Review {
 			body: String!
 			author: User!
 			product: Product!
+			created: DateTime!
 		}
 		type Like {
 			id: ID!
 			productId: ID!
 			userId: ID!
+			date: DateTime!
 			isDislike: Boolean!
 		}
 
 		interface PaymentType {
 			name: String!
 			email: String!
+			date: DateTime!
+			amount: BigInt!
 			number: String!
+			reputation: CustomScalar!
 		}
 	`
 
@@ -228,17 +276,27 @@ const (
 			review: Review!
 		}
 		
+		scalar CustomScalar
+		
+		scalar BigInt
+
 		type Product {
 			upc: String!
 			name: String!
 			price: Int!
+			worth: BigInt!
+			reputation: CustomScalar!
 			reviews: [Review]
+			sales: BigInt!
 		}
+		
+		scalar DateTime
 
 		type Review {
 			body: String!
 			author: User!
 			product: Product!
+			created: DateTime!
 		}
 		
 		extend type User @key(fields: "id") {
@@ -251,16 +309,25 @@ const (
 		type Query {
 			topProducts(first: Int = 5): [Product]
 		}
+
+		scalar CustomScalar
+
+		scalar BigInt
 		
 		type Product {
 			upc: String!
 			name: String!
 			price: Int!
+			worth: BigInt!
+			reputation: CustomScalar!
 		}
+
+	scalar DateTime
 
 		type Comment {
 			body: String!
 			author: User!
+			created: DateTime!
 		}
 
 		extend type User @key(fields: "id") {


### PR DESCRIPTION
[changelog]
internal: Duplicated scalars among merged schemas will be removed so only one of that scalar name will exist within the federated schema.