### PR TITLE
fix accessing nested fields on context variables

### DIFF
--- a/pkg/engine/datasource/rest_datasource/rest_datasource_test.go
+++ b/pkg/engine/datasource/rest_datasource/rest_datasource_test.go
@@ -33,6 +33,14 @@ const (
 			withArrayArguments(names: [String]): Friend
 		}
 
+		input InputFriend {
+			name: String!
+		}
+
+		type Mutation {
+			createFriend(friend: InputFriend!): Friend
+		}
+
 		type Friend {
 			name: String
 			pet: Pet
@@ -110,6 +118,14 @@ const (
 			}
 		}
 	`
+
+	createFriendOperation = `
+		mutation CreateFriend($friendVariable: InputFriend!) {
+			createFriend(friend: $friendVariable) {
+				name
+			}
+		}
+	`
 )
 
 func TestFastHttpJsonDataSourcePlanning(t *testing.T) {
@@ -122,7 +138,7 @@ func TestFastHttpJsonDataSourcePlanning(t *testing.T) {
 						Input:                `{"method":"GET","url":"https://example.com/friend"}`,
 						DataSource:           &Source{},
 						DataSourceIdentifier: []byte("rest_datasource.Source"),
-						DisableDataLoader: true,
+						DisableDataLoader:    true,
 					},
 					Fields: []*resolve.Field{
 						{
@@ -142,8 +158,7 @@ func TestFastHttpJsonDataSourcePlanning(t *testing.T) {
 										},
 									),
 									DataSourceIdentifier: []byte("rest_datasource.Source"),
-									DisableDataLoader: true,
-
+									DisableDataLoader:    true,
 								},
 								Fields: []*resolve.Field{
 									{
@@ -251,7 +266,7 @@ func TestFastHttpJsonDataSourcePlanning(t *testing.T) {
 							},
 						),
 						DataSourceIdentifier: []byte("rest_datasource.Source"),
-						DisableDataLoader: true,
+						DisableDataLoader:    true,
 					},
 					Fields: []*resolve.Field{
 						{
@@ -303,6 +318,75 @@ func TestFastHttpJsonDataSourcePlanning(t *testing.T) {
 			DisableResolveFieldPositions: true,
 		},
 	))
+	t.Run("mutation with nested argument", datasourcetesting.RunTest(schema, createFriendOperation, "CreateFriend",
+		&plan.SynchronousResponsePlan{
+			Response: &resolve.GraphQLResponse{
+				Data: &resolve.Object{
+					Fetch: &resolve.SingleFetch{
+						BufferId:   0,
+						Input:      `{"body":"{"friend":{"name":"$$0$$"}}","method":"POST","url":"https://example.com/$$0$$"}`,
+						DataSource: &Source{},
+						Variables: resolve.NewVariables(
+							&resolve.ContextVariable{
+								Path:     []string{"friend", "name"},
+								Renderer: resolve.NewPlainVariableRendererWithValidation(`{"type":["string"]}`),
+							},
+						),
+						DisallowSingleFlight: true,
+						DisableDataLoader:    true,
+						DataSourceIdentifier: []byte("rest_datasource.Source"),
+					},
+					Fields: []*resolve.Field{
+						{
+							BufferID:  0,
+							HasBuffer: true,
+							Name:      []byte("createFriend"),
+							Value: &resolve.Object{
+								Nullable: true,
+								Fields: []*resolve.Field{
+									{
+										Name: []byte("name"),
+										Value: &resolve.String{
+											Path:     []string{"name"},
+											Nullable: true,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		plan.Configuration{
+			DataSources: []plan.DataSourceConfiguration{
+				{
+					RootNodes: []plan.TypeField{
+						{
+							TypeName:   "Mutation",
+							FieldNames: []string{"createFriend"},
+						},
+					},
+					Custom: ConfigJSON(Configuration{
+						Fetch: FetchConfiguration{
+							URL:    "https://example.com/{{ .arguments.friend.name }}",
+							Method: "POST",
+							Body:   "{\"friend\":{\"name\":\"{{ .arguments.friend.name }}\"}}",
+						},
+					}),
+					Factory: &Factory{},
+				},
+			},
+			Fields: []plan.FieldConfiguration{
+				{
+					TypeName:              "Mutation",
+					FieldName:             "createFriend",
+					DisableDefaultMapping: true,
+				},
+			},
+			DisableResolveFieldPositions: true,
+		},
+	))
 	t.Run("post request with nested JSON body", datasourcetesting.RunTest(authSchema, `
 		mutation Login ($phoneNumber: String! $a: String) {
 			Login: postPasswordlessStart(
@@ -334,7 +418,7 @@ func TestFastHttpJsonDataSourcePlanning(t *testing.T) {
 						),
 						DataSourceIdentifier: []byte("rest_datasource.Source"),
 						DisallowSingleFlight: true,
-						DisableDataLoader: true,
+						DisableDataLoader:    true,
 					},
 					Fields: []*resolve.Field{
 						{
@@ -408,7 +492,7 @@ func TestFastHttpJsonDataSourcePlanning(t *testing.T) {
 									},
 								),
 								DataSourceIdentifier: []byte("rest_datasource.Source"),
-								DisableDataLoader: true,
+								DisableDataLoader:    true,
 							},
 							&resolve.SingleFetch{
 								BufferId:   3,
@@ -425,7 +509,7 @@ func TestFastHttpJsonDataSourcePlanning(t *testing.T) {
 									},
 								),
 								DataSourceIdentifier: []byte("rest_datasource.Source"),
-								DisableDataLoader: true,
+								DisableDataLoader:    true,
 							},
 						},
 					},
@@ -449,7 +533,7 @@ func TestFastHttpJsonDataSourcePlanning(t *testing.T) {
 												},
 											),
 											DataSourceIdentifier: []byte("rest_datasource.Source"),
-											DisableDataLoader: true,
+											DisableDataLoader:    true,
 										},
 										&resolve.SingleFetch{
 											BufferId:   2,
@@ -462,7 +546,7 @@ func TestFastHttpJsonDataSourcePlanning(t *testing.T) {
 												},
 											),
 											DataSourceIdentifier: []byte("rest_datasource.Source"),
-											DisableDataLoader: true,
+											DisableDataLoader:    true,
 										},
 									},
 								},
@@ -581,7 +665,7 @@ func TestFastHttpJsonDataSourcePlanning(t *testing.T) {
 							},
 						),
 						DataSourceIdentifier: []byte("rest_datasource.Source"),
-						DisableDataLoader: true,
+						DisableDataLoader:    true,
 					},
 					Fields: []*resolve.Field{
 						{
@@ -711,7 +795,7 @@ func TestFastHttpJsonDataSourcePlanning(t *testing.T) {
 						DataSource:           &Source{},
 						DisallowSingleFlight: true,
 						DataSourceIdentifier: []byte("rest_datasource.Source"),
-						DisableDataLoader: true,
+						DisableDataLoader:    true,
 					},
 					Fields: []*resolve.Field{
 						{
@@ -778,7 +862,7 @@ func TestFastHttpJsonDataSourcePlanning(t *testing.T) {
 							},
 						},
 						DataSourceIdentifier: []byte("rest_datasource.Source"),
-						DisableDataLoader: true,
+						DisableDataLoader:    true,
 					},
 					Fields: []*resolve.Field{
 						{
@@ -855,7 +939,7 @@ func TestFastHttpJsonDataSourcePlanning(t *testing.T) {
 							},
 						),
 						DataSourceIdentifier: []byte("rest_datasource.Source"),
-						DisableDataLoader: true,
+						DisableDataLoader:    true,
 					},
 					Fields: []*resolve.Field{
 						{
@@ -944,7 +1028,7 @@ func TestFastHttpJsonDataSourcePlanning(t *testing.T) {
 							},
 						),
 						DataSourceIdentifier: []byte("rest_datasource.Source"),
-						DisableDataLoader: true,
+						DisableDataLoader:    true,
 					},
 					Fields: []*resolve.Field{
 						{
@@ -1017,7 +1101,7 @@ func TestFastHttpJsonDataSourcePlanning(t *testing.T) {
 							},
 						),
 						DataSourceIdentifier: []byte("rest_datasource.Source"),
-						DisableDataLoader: true,
+						DisableDataLoader:    true,
 					},
 					Fields: []*resolve.Field{
 						{

--- a/pkg/engine/resolve/variable.go
+++ b/pkg/engine/resolve/variable.go
@@ -117,8 +117,14 @@ func NewPlainVariableRendererWithValidation(jsonSchema string) *PlainVariableRen
 
 // NewPlainVariableRendererWithValidationFromTypeRef creates a new PlainVariableRenderer
 // The argument typeRef must exist on the operation ast.Document, otherwise it will panic!
-func NewPlainVariableRendererWithValidationFromTypeRef(operation, definition *ast.Document, variableTypeRef int) (*PlainVariableRenderer, error) {
-	jsonSchema := graphqljsonschema.FromTypeRef(operation, definition, variableTypeRef)
+func NewPlainVariableRendererWithValidationFromTypeRef(operation, definition *ast.Document, variableTypeRef int, variablePath ...string) (*PlainVariableRenderer, error) {
+	var jsonSchema graphqljsonschema.JsonSchema
+	if len(variablePath) > 1 {
+		jsonSchema = graphqljsonschema.FromTypeRef(operation, definition, variableTypeRef, graphqljsonschema.WithPath(variablePath[1:]))
+	} else {
+		jsonSchema = graphqljsonschema.FromTypeRef(operation, definition, variableTypeRef)
+	}
+
 	validator, err := graphqljsonschema.NewValidatorFromSchema(jsonSchema)
 	if err != nil {
 		return nil, err
@@ -187,7 +193,7 @@ func NewGraphQLVariableRendererFromTypeRef(operation, definition *ast.Document, 
 }
 
 func NewGraphQLVariableRendererFromTypeRefWithOverrides(operation, definition *ast.Document, variableTypeRef int, overrides map[string]graphqljsonschema.JsonSchema) (*GraphQLVariableRenderer, error) {
-	jsonSchema := graphqljsonschema.FromTypeRefWithOverrides(operation, definition, variableTypeRef, overrides)
+	jsonSchema := graphqljsonschema.FromTypeRef(operation, definition, variableTypeRef, graphqljsonschema.WithOverrides(overrides))
 	validator, err := graphqljsonschema.NewValidatorFromSchema(jsonSchema)
 	if err != nil {
 		return nil, err

--- a/pkg/graphql/execution_engine_v2_test.go
+++ b/pkg/graphql/execution_engine_v2_test.go
@@ -476,7 +476,7 @@ func TestExecutionEngineV2_Execute(t *testing.T) {
 							expectedHost:     "petstore.swagger.io",
 							expectedPath:     "/v2/pet/1",
 							expectedBody:     "",
-							sendResponseBody: `{"id":1,"category":{"id":1,"name":"string"},"name":"doggie"}`,
+							sendResponseBody: `{"id":1,"category":{"id":1,"name":"dog"},"name":"doggie"}`,
 							sendStatusCode:   200,
 						}),
 					},
@@ -497,7 +497,7 @@ func TestExecutionEngineV2_Execute(t *testing.T) {
 					Factory: &rest_datasource.Factory{
 						Client: testNetHttpClient(t, roundTripperTestCase{
 							expectedHost:     "rest-countries.example.com",
-							expectedPath:     "/name/doggie",
+							expectedPath:     "/type/dog/name/doggie",
 							expectedBody:     "",
 							sendResponseBody: `{"name":"Germany"}`,
 							sendStatusCode:   200,
@@ -505,7 +505,7 @@ func TestExecutionEngineV2_Execute(t *testing.T) {
 					},
 					Custom: rest_datasource.ConfigJSON(rest_datasource.Configuration{
 						Fetch: rest_datasource.FetchConfiguration{
-							URL:    "https://rest-countries.example.com/name/{{.object.name}}",
+							URL:    "https://rest-countries.example.com/type/{{.object.category.name}}/name/{{.object.name}}",
 							Method: "POST",
 						},
 					}),

--- a/pkg/graphqljsonschema/jsonschema.go
+++ b/pkg/graphqljsonschema/jsonschema.go
@@ -52,43 +52,6 @@ func FromTypeRef(operation, definition *ast.Document, typeRef int, opts ...Optio
 	return resolveJsonSchemaPath(jsonSchema, appliedOptions.path)
 }
 
-/*
-func FromTypeRefWithOverrides(operation, definition *ast.Document, typeRef int, overrides map[string]JsonSchema) JsonSchema {
-	resolver := &fromTypeRefResolver{
-		overrides: overrides,
-	}
-	return resolver.fromTypeRef(operation, definition, typeRef)
-}
-
-func FromTypeRefWithPath(operation, definition *ast.Document, typeRef int, path []string) JsonSchema {
-	jsonSchema := FromTypeRef(operation, definition, typeRef)
-	if len(path) == 0 {
-		return jsonSchema
-	}
-
-	switch typedJsonSchema := jsonSchema.(type) {
-	case Object:
-		for i := 0; i < len(path); i++ {
-			propertyJsonSchema, exists := typedJsonSchema.Properties[path[i]]
-			if !exists {
-				return jsonSchema
-			}
-			jsonSchema = propertyJsonSchema
-		}
-	}
-
-	return jsonSchema
-}
-
-func FromTypeRefWithPathAndOverrides(operation, definition *ast.Document, typeRef int, path []string, overrides map[string]JsonSchema) JsonSchema {
-	jsonSchema := FromTypeRefWithOverrides(operation, definition, typeRef, overrides)
-	if len(path) == 0 {
-		return jsonSchema
-	}
-
-	return resolveJsonSchemaPath(jsonSchema, path)
-}*/
-
 func resolveJsonSchemaPath(jsonSchema JsonSchema, path []string) JsonSchema {
 	switch typedJsonSchema := jsonSchema.(type) {
 	case Object:

--- a/pkg/graphqljsonschema/jsonschema_test.go
+++ b/pkg/graphqljsonschema/jsonschema_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/jensneuse/graphql-go-tools/internal/pkg/unsafeparser"
 )
 
-func runTest(schema, operation, expectedJsonSchema string, valid []string, invalid []string, overrides map[string]JsonSchema) func(t *testing.T) {
+func runTest(schema, operation, expectedJsonSchema string, valid []string, invalid []string, opts ...Option) func(t *testing.T) {
 	return func(t *testing.T) {
 		definition := unsafeparser.ParseGraphqlDocumentString(schema)
 		operationDoc := unsafeparser.ParseGraphqlDocumentString(operation)
@@ -18,11 +18,7 @@ func runTest(schema, operation, expectedJsonSchema string, valid []string, inval
 		variableDefinition := operationDoc.OperationDefinitions[0].VariableDefinitions.Refs[0]
 		varType := operationDoc.VariableDefinitions[variableDefinition].Type
 
-		if overrides == nil {
-			overrides = map[string]JsonSchema{}
-		}
-
-		jsonSchemaDefinition := FromTypeRefWithOverrides(&operationDoc, &definition, varType, overrides)
+		jsonSchemaDefinition := FromTypeRef(&operationDoc, &definition, varType, opts...)
 		actualSchema, err := json.Marshal(jsonSchemaDefinition)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedJsonSchema, string(actualSchema))
@@ -52,7 +48,6 @@ func TestJsonSchema(t *testing.T) {
 		[]string{
 			`{"str":true}`,
 		},
-		nil,
 	))
 	t.Run("string", runTest(
 		`scalar String input Test { str: String }`,
@@ -67,7 +62,6 @@ func TestJsonSchema(t *testing.T) {
 			`true`,
 			`nope`,
 		},
-		nil,
 	))
 	t.Run("id", runTest(
 		`scalar ID input Test { str: String }`,
@@ -82,7 +76,6 @@ func TestJsonSchema(t *testing.T) {
 			`true`,
 			`nope`,
 		},
-		nil,
 	))
 	t.Run("array", runTest(
 		`scalar String`,
@@ -99,7 +92,6 @@ func TestJsonSchema(t *testing.T) {
 			`"validString"`,
 			`false`,
 		},
-		nil,
 	))
 	t.Run("input object array", runTest(
 		`scalar String input StringInput { str: String }`,
@@ -116,7 +108,6 @@ func TestJsonSchema(t *testing.T) {
 			`"validString"`,
 			`false`,
 		},
-		nil,
 	))
 	t.Run("required array", runTest(
 		`scalar String`,
@@ -133,7 +124,6 @@ func TestJsonSchema(t *testing.T) {
 			`false`,
 			`null`,
 		},
-		nil,
 	))
 	t.Run("required array element", runTest(
 		`scalar String`,
@@ -151,7 +141,6 @@ func TestJsonSchema(t *testing.T) {
 			`"validString"`,
 			`false`,
 		},
-		nil,
 	))
 	t.Run("nested object", runTest(
 		`scalar String scalar Boolean input Test { str: String! nested: Nested } input Nested { boo: Boolean }`,
@@ -171,7 +160,6 @@ func TestJsonSchema(t *testing.T) {
 			`{"nested":{"boo":true}}`,
 			`{"str":"validString","nested":{"boo":123}}`,
 		},
-		nil,
 	))
 	t.Run("nested object with override", runTest(
 		`scalar String scalar Boolean input Test { str: String! override: Override } input Override { boo: Boolean }`,
@@ -189,9 +177,9 @@ func TestJsonSchema(t *testing.T) {
 			`{"override":{"boo":true}}`,
 			`{"str":"validString","override":{"boo":123}}`,
 		},
-		map[string]JsonSchema{
+		WithOverrides(map[string]JsonSchema{
 			"Override": NewString(false),
-		},
+		}),
 	))
 	t.Run("recursive object", runTest(
 		`scalar String scalar Boolean input Test { str: String! nested: Nested } input Nested { boo: Boolean recursive: Test }`,
@@ -208,7 +196,6 @@ func TestJsonSchema(t *testing.T) {
 			`{"nested":{"boo":true}}`,
 			`{"str":"validString","nested":{"boo":123}}`,
 		},
-		nil,
 	))
 	t.Run("recursive object with multiple branches", runTest(
 		`scalar String scalar Boolean input Root { test: Test another: Another } input Test { str: String! nested: Nested } input Nested { boo: Boolean recursive: Test another: Another } input Another { boo: Boolean }`,
@@ -223,7 +210,6 @@ func TestJsonSchema(t *testing.T) {
 			`{"test":{"nested":{"boo":true}}}`,
 			`{"test":{"str":"validString","nested":{"boo":123}}}`,
 		},
-		nil,
 	))
 	t.Run("complex recursive schema", runTest(
 		complexRecursiveSchema,
@@ -231,7 +217,31 @@ func TestJsonSchema(t *testing.T) {
 		`{"type":["object","null"],"properties":{"AND":{"$ref":"#/$defs/db_messagesWhereInput"},"NOT":{"$ref":"#/$defs/db_messagesWhereInput"},"OR":{"type":["array","null"],"items":{"$ref":"#/$defs/db_messagesWhereInput"}},"id":{"$ref":"#/$defs/db_IntFilter"},"message":{"$ref":"#/$defs/db_StringFilter"},"payload":{"$ref":"#/$defs/db_JsonFilter"},"user_id":{"$ref":"#/$defs/db_IntFilter"},"users":{"$ref":"#/$defs/db_UsersRelationFilter"}},"additionalProperties":false,"$defs":{"db_DateTimeFilter":{"type":["object","null"],"properties":{"equals":{},"gt":{},"gte":{},"in":{"type":["array","null"],"items":{}},"lt":{},"lte":{},"not":{"$ref":"#/$defs/db_NestedDateTimeFilter"},"notIn":{"type":["array","null"],"items":{}}},"additionalProperties":false},"db_IntFilter":{"type":["object","null"],"properties":{"equals":null,"gt":null,"gte":null,"in":{"type":["array","null"],"items":null},"lt":null,"lte":null,"not":{"$ref":"#/$defs/db_NestedIntFilter"},"notIn":{"type":["array","null"],"items":null}},"additionalProperties":false},"db_JsonFilter":{"type":["object","null"],"properties":{"equals":{"type":["string","null"]},"not":{"type":["string","null"]}},"additionalProperties":false},"db_MessagesListRelationFilter":{"type":["object","null"],"properties":{"every":{"$ref":"#/$defs/db_messagesWhereInput"},"none":{"$ref":"#/$defs/db_messagesWhereInput"},"some":{"$ref":"#/$defs/db_messagesWhereInput"}},"additionalProperties":false},"db_NestedDateTimeFilter":{"type":["object","null"],"properties":{"equals":{},"gt":{},"gte":{},"in":{"type":["array","null"],"items":{}},"lt":{},"lte":{},"not":{"$ref":"#/$defs/db_NestedDateTimeFilter"},"notIn":{"type":["array","null"],"items":{}}},"additionalProperties":false},"db_NestedIntFilter":{"type":["object","null"],"properties":{"equals":null,"gt":null,"gte":null,"in":{"type":["array","null"],"items":null},"lt":null,"lte":null,"not":{"$ref":"#/$defs/db_NestedIntFilter"},"notIn":{"type":["array","null"],"items":null}},"additionalProperties":false},"db_NestedStringFilter":{"type":["object","null"],"properties":{"contains":null,"endsWith":null,"equals":null,"gt":null,"gte":null,"in":{"type":["array","null"],"items":null},"lt":null,"lte":null,"not":{"$ref":"#/$defs/db_NestedStringFilter"},"notIn":{"type":["array","null"],"items":null},"startsWith":null},"additionalProperties":false},"db_StringFilter":{"type":["object","null"],"properties":{"contains":null,"endsWith":null,"equals":null,"gt":null,"gte":null,"in":{"type":["array","null"],"items":null},"lt":null,"lte":null,"mode":{"type":["string","null"]},"not":{"$ref":"#/$defs/db_NestedStringFilter"},"notIn":{"type":["array","null"],"items":null},"startsWith":null},"additionalProperties":false},"db_UsersRelationFilter":{"type":["object","null"],"properties":{"is":{"$ref":"#/$defs/db_usersWhereInput"},"isNot":{"$ref":"#/$defs/db_usersWhereInput"}},"additionalProperties":false},"db_messagesWhereInput":{"type":["object","null"],"properties":{"AND":{"$ref":"#/$defs/db_messagesWhereInput"},"NOT":{"$ref":"#/$defs/db_messagesWhereInput"},"OR":{"type":["array","null"],"items":{"$ref":"#/$defs/db_messagesWhereInput"}},"id":{"$ref":"#/$defs/db_IntFilter"},"message":{"$ref":"#/$defs/db_StringFilter"},"payload":{"$ref":"#/$defs/db_JsonFilter"},"user_id":{"$ref":"#/$defs/db_IntFilter"},"users":{"$ref":"#/$defs/db_UsersRelationFilter"}},"additionalProperties":false},"db_usersWhereInput":{"type":["object","null"],"properties":{"AND":{"$ref":"#/$defs/db_usersWhereInput"},"NOT":{"$ref":"#/$defs/db_usersWhereInput"},"OR":{"type":["array","null"],"items":{"$ref":"#/$defs/db_usersWhereInput"}},"email":{"$ref":"#/$defs/db_StringFilter"},"id":{"$ref":"#/$defs/db_IntFilter"},"lastlogin":{"$ref":"#/$defs/db_DateTimeFilter"},"messages":{"$ref":"#/$defs/db_MessagesListRelationFilter"},"name":{"$ref":"#/$defs/db_StringFilter"},"pet":{"$ref":"#/$defs/db_StringFilter"},"updatedat":{"$ref":"#/$defs/db_DateTimeFilter"}},"additionalProperties":false}}}`,
 		[]string{},
 		[]string{},
-		nil,
+	))
+	t.Run("one level deep sub path", runTest(
+		"input Human { name: String! } scalar String",
+		"query ($human: Human!) { }",
+		`{"type":["string"]}`,
+		[]string{
+			`"John Doe"`,
+		},
+		[]string{
+			`{"name":"John Doe"}`,
+		},
+		WithPath([]string{"name"}),
+	))
+	t.Run("multi level deep sub path", runTest(
+		"input Human { name: String! pet: Animal } scalar String type Animal { name: String! }",
+		"query ($human: Human!) { }",
+		`{"type":["string"]}`,
+		[]string{
+			`"Doggie"`,
+		},
+		[]string{
+			`{"name":"Doggie"}`,
+			`{"pet":{"name":"Doggie"}}`,
+		},
+		WithPath([]string{"pet", "name"}),
 	))
 }
 


### PR DESCRIPTION
This PR is based on https://github.com/TykTechnologies/graphql-go-tools/pull/221 from @buraksezer 

It fixes the issue of not being able to access nested fields on context variables (including json schema validation):
`{{.object.pet.name}}`