### PR TITLE
[TT-5192] Kafka - allow user to configure which messages are the first to read

### DIFF
--- a/pkg/engine/datasource/kafka_datasource/kafka_consumer_group.go
+++ b/pkg/engine/datasource/kafka_datasource/kafka_consumer_group.go
@@ -179,6 +179,10 @@ func (c *KafkaConsumerGroupBridge) Subscribe(ctx context.Context, options GraphQ
 	saramaConfig := sarama.NewConfig()
 	saramaConfig.Version = SaramaSupportedKafkaVersions[options.KafkaVersion]
 	saramaConfig.ClientID = options.ClientID
+	if options.StartConsumingLatest {
+		// Start consuming from the latest offset after a client restart
+		saramaConfig.Consumer.Offsets.Initial = sarama.OffsetNewest
+	}
 
 	cg, err := NewKafkaConsumerGroup(c.log, saramaConfig, &options)
 	if err != nil {

--- a/pkg/engine/datasource/kafka_datasource/kafka_datasource.go
+++ b/pkg/engine/datasource/kafka_datasource/kafka_datasource.go
@@ -35,11 +35,12 @@ var (
 )
 
 type GraphQLSubscriptionOptions struct {
-	BrokerAddr   string `json:"broker_addr"`
-	Topic        string `json:"topic"`
-	GroupID      string `json:"group_id"`
-	ClientID     string `json:"client_id"`
-	KafkaVersion string `json:"kafka_version"`
+	BrokerAddr           string `json:"broker_addr"`
+	Topic                string `json:"topic"`
+	GroupID              string `json:"group_id"`
+	ClientID             string `json:"client_id"`
+	KafkaVersion         string `json:"kafka_version"`
+	StartConsumingLatest bool   `json:"start_consuming_latest"`
 }
 
 func (g *GraphQLSubscriptionOptions) Sanitize() {
@@ -73,11 +74,12 @@ func (g *GraphQLSubscriptionOptions) Validate() error {
 }
 
 type SubscriptionConfiguration struct {
-	BrokerAddr   string `json:"broker_addr"`
-	Topic        string `json:"topic"`
-	GroupID      string `json:"group_id"`
-	ClientID     string `json:"client_id"`
-	KafkaVersion string `json:"kafka_version"`
+	BrokerAddr           string `json:"broker_addr"`
+	Topic                string `json:"topic"`
+	GroupID              string `json:"group_id"`
+	ClientID             string `json:"client_id"`
+	KafkaVersion         string `json:"kafka_version"`
+	StartConsumingLatest bool   `json:"start_consuming_latest"`
 }
 
 type Configuration struct {

--- a/pkg/engine/datasource/kafka_datasource/kafka_datasource_test.go
+++ b/pkg/engine/datasource/kafka_datasource/kafka_datasource_test.go
@@ -84,7 +84,7 @@ func TestKafkaDataSource(t *testing.T) {
 	`, "RemainingJedis", &plan.SubscriptionResponsePlan{
 		Response: &resolve.GraphQLSubscription{
 			Trigger: resolve.GraphQLSubscriptionTrigger{
-				Input: []byte(fmt.Sprintf(`{"broker_addr":"localhost:9092","topic":"test.topic","group_id":"test.consumer.group","client_id":"test.client.id","kafka_version":"%s"}`, testMockKafkaVersion)),
+				Input: []byte(fmt.Sprintf(`{"broker_addr":"localhost:9092","topic":"test.topic","group_id":"test.consumer.group","client_id":"test.client.id","kafka_version":"%s","start_consuming_latest":false}`, testMockKafkaVersion)),
 				Source: &SubscriptionSource{
 					client: NewKafkaConsumerGroupBridge(ctx, logger()),
 				},
@@ -120,7 +120,7 @@ func TestKafkaDataSource(t *testing.T) {
 	`, "SubscriptionWithVariables", &plan.SubscriptionResponsePlan{
 		Response: &resolve.GraphQLSubscription{
 			Trigger: resolve.GraphQLSubscriptionTrigger{
-				Input: []byte(fmt.Sprintf(`{"broker_addr":"localhost:9092","topic":"test.topic.$$0$$","group_id":"test.consumer.group","client_id":"test.client.id","kafka_version":"%s"}`, testMockKafkaVersion)),
+				Input: []byte(fmt.Sprintf(`{"broker_addr":"localhost:9092","topic":"test.topic.$$0$$","group_id":"test.consumer.group","client_id":"test.client.id","kafka_version":"%s","start_consuming_latest":false}`, testMockKafkaVersion)),
 				Variables: resolve.NewVariables(
 					&resolve.ContextVariable{
 						Path:     []string{"bar"},


### PR DESCRIPTION
Here is the PR for [TT-5192](https://tyktech.atlassian.net/browse/TT-5192).

I added a new configuration option to start consuming from the latest offset after a client restart. Here is the basic flow:

* Set `sarama.OffsetNewest` to `sarama.Config.Consumer.Offsets.Initial`.
* Reset the offset before starting to consume. 
* Do not commit the current offset when consuming a new message.

Unfortunately, it's not possible to test this improvement via `sarama.MockBroker`. I assume that Sarama implements `ResetOffset` correctly and Kafka process that command without any flaw, and I decided to implement tests by observing the behavior of our business logic. Basically, I provided mock implementations of `sarama.ConsumerGroupClaim` and `sarama.ConsumerGroupSession` interfaces to observe the effects of setting `StartConsumingLatest` to `true`.

I manually tested the feature and its behavior many times, but if we want to implement proper end-to-end tests for Kafka configuration options, it's probably a good idea to run Kafka and ZooKeeper via testcontainers or dockertest. What do you think?