### PR TITLE
[TT-5328] Add a test tool for transactional producer API

### DIFF
--- a/examples/kafka_pubsub/transactional_producer/README.md
+++ b/examples/kafka_pubsub/transactional_producer/README.md
@@ -1,0 +1,93 @@
+# transactional_producer
+
+transactional_producer is a simple test tool to utilize transactional producer API of Apache Kafka.
+
+
+### Build
+
+This program uses [confluentinc/confluent-kafka-go/kafka](https://github.com/confluentinc/confluent-kafka-go/kafka) which needs
+[librdkafka](https://github.com/edenhill/librdkafka). You can install librdkafka via a package manager:
+
+macOS:
+
+```
+brew install openssl zstd pkg-config librdkafka
+```
+
+Build the tool:
+
+```
+export PKG_CONFIG_PATH="/opt/homebrew/opt/librdkafka/lib/pkgconfig:/opt/homebrew/opt/openssl@3/lib/pkgconfig"
+go build -tags dynamic main.go
+```
+
+### Run
+
+`transactional_producer` produces 10 messages and then quits.
+
+Sample message body:
+
+```json
+{
+	"stock": {
+		"name": "product2",
+		"price": 3843,
+		"in_stock": 673
+	}
+}
+```
+
+### Setup Kafka Data Source in Tyk Gateway
+
+You can see the full example in [kafka_pubsub/README.md](../README.md).
+
+### Enable transactional producer API
+
+```
+./main --product=product2 --enable-transaction
+```
+
+In Tyk Gateway, you need to add `"isolation_level": "ReadCommitted"` to the Kafka data source config. This prevents reading
+dirty writes, and your program will only receive the committed messages.
+
+```json
+{
+            "kind": "Kafka",
+            "name": "kafka-consumer-group",
+            "internal": false,
+            "root_fields": [
+              {
+                "type": "Subscription",
+                "fields": [
+                  "stock"
+                ]
+              }
+            ],
+            "config": {
+              "broker_addr": "localhost:9092",
+              "topic": "test.topic.{{.arguments.name}}",
+              "group_id": "test.group",
+              "client_id": "tyk-kafka-integration-{{.arguments.name}}",
+              "isolation_level": "ReadCommitted"
+            }
+          }
+```
+
+#### Abort an initialized transaction
+
+```
+./main --product=product2 --enable-transaction --abort-transaction
+```
+
+With `--abort-transaction`, the initialized transaction will be aborted. If the isolation level is `ReadCommitted`, you do not receive
+messages in the aborted transaction.
+
+If the isolation level is `ReadUncommitted`, you will receive messages in the aborted transaction.
+
+#### Disable transactional API
+
+```
+./main --product=product2
+```
+
+If you disable the transactional producer API, you will always receive published messages. 

--- a/examples/kafka_pubsub/transactional_producer/go.mod
+++ b/examples/kafka_pubsub/transactional_producer/go.mod
@@ -1,0 +1,5 @@
+module github.com/TykTechnologies/graphql-go-tools/examples/kafka_pubsub/transactional_producer
+
+go 1.18
+
+require github.com/confluentinc/confluent-kafka-go v1.8.2

--- a/examples/kafka_pubsub/transactional_producer/go.sum
+++ b/examples/kafka_pubsub/transactional_producer/go.sum
@@ -1,0 +1,2 @@
+github.com/confluentinc/confluent-kafka-go v1.8.2 h1:PBdbvYpyOdFLehj8j+9ba7FL4c4Moxn79gy9cYKxG5E=
+github.com/confluentinc/confluent-kafka-go v1.8.2/go.mod h1:u2zNLny2xq+5rWeTQjFHbDzzNuba4P1vo31r9r4uAdg=

--- a/examples/kafka_pubsub/transactional_producer/main.go
+++ b/examples/kafka_pubsub/transactional_producer/main.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"math/rand"
+	"os"
+	"time"
+
+	"github.com/confluentinc/confluent-kafka-go/kafka"
+)
+
+type arguments struct {
+	enableTransaction bool
+	abortTransaction  bool
+	product           string
+	broker            string
+	help              bool
+}
+
+func usage() {
+	var msg = `Usage: kafka_pubsub [options] ...
+
+Simple test tool to generate test data
+
+Options:
+  -h, --help     Print this message and exit.
+  -b  --broker   Apache Kafka broker to connect (default: localhost:9092).
+  -p, --product Comma seperated list of product.
+`
+	_, err := fmt.Fprintf(os.Stdout, msg)
+	if err != nil {
+		panic(err)
+	}
+}
+
+type Stock struct {
+	Stock Product `json:"stock"`
+}
+
+type Product struct {
+	Name    string `json:"name"`
+	Price   int    `json:"price"`
+	InStock int    `json:"in_stock"`
+}
+
+func main() {
+
+	args := &arguments{}
+	log.SetFlags(0)
+
+	// Parse command line parameters
+	f := flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+	f.SetOutput(ioutil.Discard)
+	f.BoolVar(&args.help, "h", false, "")
+	f.BoolVar(&args.help, "help", false, "")
+	f.BoolVar(&args.enableTransaction, "enable-transaction", false, "")
+	f.BoolVar(&args.abortTransaction, "abort-transaction", false, "")
+	f.StringVar(&args.product, "p", "", "")
+	f.StringVar(&args.product, "product", "", "")
+	f.StringVar(&args.broker, "b", "", "")
+	f.StringVar(&args.broker, "broker", "", "")
+
+	if err := f.Parse(os.Args[1:]); err != nil {
+		log.Fatalf("Failed to parse flags: %v", err)
+	}
+
+	if args.help {
+		usage()
+		return
+	}
+
+	if args.broker == "" {
+		args.broker = "localhost:9092"
+	}
+
+	rand.Seed(time.Now().UnixNano())
+
+	producerConfig := &kafka.ConfigMap{
+		"client.id":         fmt.Sprintf("tyk-transactional-producer-%d", rand.Intn(10000)),
+		"bootstrap.servers": args.broker,
+	}
+
+	if args.enableTransaction {
+		producerConfig.SetKey("transactional.id", fmt.Sprintf("tyk-transactional-producer-%d", rand.Intn(10000)))
+		producerConfig.SetKey("enable.idempotence", true)
+	}
+
+	producer, err := kafka.NewProducer(producerConfig)
+	if err != nil {
+		log.Fatalf("Failed to create a new Producer instance: %s", err)
+	}
+
+	defer producer.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	if args.enableTransaction {
+		err = producer.InitTransactions(ctx)
+		if err != nil {
+			log.Fatalf("Failed to initalize a new transaction: %s", err)
+		}
+
+		err = producer.BeginTransaction()
+		if err != nil {
+			log.Fatalf("Failed to begin a new transaction: %s", err)
+		}
+		log.Printf("Transaction has been initalized")
+	}
+
+	topic := fmt.Sprintf("test.topic.%s", args.product)
+
+	for i := 0; i < 10; i++ {
+		stock := Stock{
+			Stock: Product{
+				Name:    args.product,
+				Price:   rand.Intn(10000),
+				InStock: rand.Intn(1000),
+			},
+		}
+
+		data, err := json.Marshal(stock)
+		if err != nil {
+			log.Fatalf("Failed to encode the message: %s", err)
+		}
+
+		log.Printf("Enqueued message to %s: %s", topic, string(data))
+
+		err = producer.Produce(&kafka.Message{
+			TopicPartition: kafka.TopicPartition{Topic: &topic, Partition: kafka.PartitionAny},
+			Value:          data},
+			nil,
+		)
+		if err != nil {
+			log.Fatalf("Failed to produce message: %s", err)
+		}
+		<-time.After(time.Second)
+	}
+
+	if args.enableTransaction {
+		if args.abortTransaction {
+			err = producer.AbortTransaction(ctx)
+			if err != nil {
+				log.Fatalf("Failed to abort the transaction: %s", err)
+			}
+			log.Printf("Transaction has been aborted")
+			return
+		}
+
+		err = producer.CommitTransaction(ctx)
+		if err != nil {
+			log.Fatalf("Failed to commit produced messages: %s", err)
+		}
+		log.Printf("Produced messages have been committed")
+	}
+}

--- a/examples/kafka_pubsub/transactional_producer/main.go
+++ b/examples/kafka_pubsub/transactional_producer/main.go
@@ -23,14 +23,16 @@ type arguments struct {
 }
 
 func usage() {
-	var msg = `Usage: kafka_pubsub [options] ...
+	var msg = `Usage: transactional_producer [options] ...
 
-Simple test tool to generate test data
+Simple test tool to utilize transactional producer API
 
 Options:
-  -h, --help     Print this message and exit.
-  -b  --broker   Apache Kafka broker to connect (default: localhost:9092).
-  -p, --product Comma seperated list of product.
+  -h, --help               Print this message and exit.
+  -b  --broker             Apache Kafka broker to connect (default: localhost:9092).
+  -p, --product            Comma seperated list of product.
+      --enable-transaction Enable transactional producer and commit after producing 10 messages.
+      --abort-transaction  Abort the initialized transaction.
 `
 	_, err := fmt.Fprintf(os.Stdout, msg)
 	if err != nil {
@@ -74,8 +76,16 @@ func main() {
 		return
 	}
 
+	if args.product == "" {
+		log.Fatalf("product cannot be empty")
+	}
+
 	if args.broker == "" {
 		args.broker = "localhost:9092"
+	}
+
+	if !args.enableTransaction && args.abortTransaction {
+		log.Fatalf("invalid configuration: abort-transaction=true")
 	}
 
 	rand.Seed(time.Now().UnixNano())
@@ -110,7 +120,7 @@ func main() {
 		if err != nil {
 			log.Fatalf("Failed to begin a new transaction: %s", err)
 		}
-		log.Printf("Transaction has been initalized")
+		log.Printf("\nTransaction has been initialized\n\n")
 	}
 
 	topic := fmt.Sprintf("test.topic.%s", args.product)
@@ -148,7 +158,7 @@ func main() {
 			if err != nil {
 				log.Fatalf("Failed to abort the transaction: %s", err)
 			}
-			log.Printf("Transaction has been aborted")
+			log.Printf("\nTransaction has been aborted\n")
 			return
 		}
 
@@ -156,6 +166,6 @@ func main() {
 		if err != nil {
 			log.Fatalf("Failed to commit produced messages: %s", err)
 		}
-		log.Printf("Produced messages have been committed")
+		log.Printf("\nProduced messages have been committed\n")
 	}
 }


### PR DESCRIPTION
This PR adds a test tool for transactional producer API. 

Unfortunately, [shopify/sarama](https://github.com/Shopify/sarama) and [segment-io/kafka](https://github.com/segmentio/kafka-go) don't support transactional producer API. Because of that, we need to use [confluentinc/confluent-kafka-go/kafka](https://github.com/confluentinc/confluent-kafka-go/kafka).

We don't need to update the library commit hash in Tyk gateway and its siblings. This PR only includes a test tool.