### PR TITLE
[TT-5279] Fixed typo causing bug in setting of NodeKind.

### DIFF
--- a/pkg/astvalidation/rule_unique_field_definition_names.go
+++ b/pkg/astvalidation/rule_unique_field_definition_names.go
@@ -99,7 +99,7 @@ func (u *uniqueFieldDefinitionNamesVisitor) LeaveInterfaceTypeExtension(_ int) {
 
 func (u *uniqueFieldDefinitionNamesVisitor) EnterInputObjectTypeDefinition(ref int) {
 	typeName := u.definition.InputObjectTypeDefinitionNameBytes(ref)
-	u.setCurrentTypeName(typeName, ast.NodeKindObjectTypeDefinition)
+	u.setCurrentTypeName(typeName, ast.NodeKindInputObjectTypeDefinition)
 }
 
 func (u *uniqueFieldDefinitionNamesVisitor) LeaveInputObjectTypeDefinition(_ int) {

--- a/pkg/astvalidation/rule_unique_field_definition_names_test.go
+++ b/pkg/astvalidation/rule_unique_field_definition_names_test.go
@@ -203,5 +203,45 @@ func TestUniqueFieldDefinitionNames(t *testing.T) {
 				`, Invalid, UniqueFieldDefinitionNames(),
 			)
 		})
+
+		t.Run("Duplicate input fields are invalid", func(t *testing.T) {
+			runDefinitionValidation(t, `
+         input SomeInputObject {
+            foo: String
+			bar: String
+         }
+         extend input SomeInputObject {
+            foo: String
+			bar: String
+         }
+      `, Invalid, UniqueFieldDefinitionNames(),
+			)
+		})
+
+		t.Run("Duplicate object fields are invalid", func(t *testing.T) {
+			runDefinitionValidation(t, `
+         type SomeObject {
+            foo: String
+         }
+         extend type SomeObject {
+            foo: String
+			bar: String
+         }
+      `, Invalid, UniqueFieldDefinitionNames(),
+			)
+		})
+
+		t.Run("Duplicate interface fields are invalid", func(t *testing.T) {
+			runDefinitionValidation(t, `
+         interface SomeInterface {
+            foo: String
+         }
+         extend interface SomeInterface {
+            foo: String
+			bar: String
+         }
+      `, Invalid, UniqueFieldDefinitionNames(),
+			)
+		})
 	})
 }


### PR DESCRIPTION
[changelog]
internal: Changed NodeKindObjectTypeDefinition to NodeKindInputObjectTypeDefinition for Input validation.