### PR TITLE
[TT-5115] Implement multiple broker adds config in Sarama

### DIFF
--- a/examples/kafka_pubsub/README.md
+++ b/examples/kafka_pubsub/README.md
@@ -186,3 +186,64 @@ If password/user is wrong:
   "message": "kafka: client has run out of available brokers to talk to (Is your cluster reachable?)"
 }
 ```
+
+## Creating an Apache Kafka cluster
+
+Simply run the following command to create an Apache Kafka cluster with 3 nodes:
+
+```
+docker-compose --file docker-compose-cluster.yml up
+```
+
+Cluster members:
+
+* localhost:9092
+* localhost:9093
+* localhost:9094
+
+**Important Note**: `kafka-topics` command is a part of Apache Kafka installation. You can choose to install Apache Kafka on your system or
+execute it in the container.
+
+### Creating a topic with a replication factor
+
+```
+kafka-topics --create --bootstrap-server localhost:9092 --topic test.topic.product1 --partitions 3 --replication-factor 3
+```
+
+This command creates `test.topic.product1` on the Kafka cluster. It spans over 3 partitions and has 3 replicas.
+
+You can use `describe` command to inspect the topic:
+
+```
+kafka-topics --describe --bootstrap-server localhost:9092 --topic test.topic.product1
+```
+
+Sample result:
+
+```
+Topic: test.topic.product1	TopicId: MNfDKrvQQV6WZM2SQjI0og	PartitionCount: 3	ReplicationFactor: 3	Configs: segment.bytes=1073741824
+	Topic: test.topic.product1	Partition: 0	Leader: 2	Replicas: 2,0,1	Isr: 2,0,1
+	Topic: test.topic.product1	Partition: 1	Leader: 1	Replicas: 1,2,0	Isr: 1,2,0
+	Topic: test.topic.product1	Partition: 2	Leader: 0	Replicas: 0,1,2	Isr: 0,1,2
+```
+
+### Deleting a topic
+
+If you want to delete a topic and drop all messages, you can run the following command:
+
+```
+kafka-topics --describe --bootstrap-server localhost:9092 --topic test.topic.product1
+```
+
+### Publishing messages with multiple broker addresses
+
+```
+go run main.go --brokers=localhost:9092,localhost:9093,localhost:9094 --products=product1
+```
+
+Sample result:
+
+```
+Enqueued message to test.topic.product1: {"stock":{"name":"product1","price":8162,"in_stock":89}}
+Enqueued message to test.topic.product1: {"stock":{"name":"product1","price":8287,"in_stock":888}}
+```

--- a/examples/kafka_pubsub/docker-compose-cluster.yml
+++ b/examples/kafka_pubsub/docker-compose-cluster.yml
@@ -1,0 +1,72 @@
+version: "2"
+
+services:
+  zookeeper:
+    image: docker.io/bitnami/zookeeper:3.8
+    ports:
+      - "2181:2181"
+    volumes:
+      - "zookeeper_data:/bitnami"
+    environment:
+      - ALLOW_ANONYMOUS_LOGIN=yes
+  kafka-0:
+    image: docker.io/bitnami/kafka:3.1
+    ports:
+      - "9082"
+      - "9092:9092"
+    environment:
+      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
+      - KAFKA_CFG_BROKER_ID=0
+      - ALLOW_PLAINTEXT_LISTENER=yes
+      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=INSIDE:PLAINTEXT,OUTSIDE:PLAINTEXT
+      - KAFKA_INTER_BROKER_LISTENER_NAME=INSIDE
+      - KAFKA_ADVERTISED_LISTENERS=INSIDE://kafka-0:9082,OUTSIDE://localhost:9092
+      - KAFKA_LISTENERS=INSIDE://0.0.0.0:9082,OUTSIDE://0.0.0.0:9092
+    volumes:
+      - kafka_0_data:/bitnami/kafka
+    depends_on:
+      - zookeeper
+  kafka-1:
+    image: docker.io/bitnami/kafka:3.1
+    ports:
+      - "9082"
+      - "9093:9092"
+    environment:
+      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
+      - KAFKA_CFG_BROKER_ID=1
+      - ALLOW_PLAINTEXT_LISTENER=yes
+      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=INSIDE:PLAINTEXT,OUTSIDE:PLAINTEXT
+      - KAFKA_INTER_BROKER_LISTENER_NAME=INSIDE
+      - KAFKA_ADVERTISED_LISTENERS=INSIDE://kafka-1:9082,OUTSIDE://localhost:9093
+      - KAFKA_LISTENERS=INSIDE://0.0.0.0:9082,OUTSIDE://0.0.0.0:9092
+    volumes:
+      - kafka_1_data:/bitnami/kafka
+    depends_on:
+      - zookeeper
+  kafka-2:
+    image: docker.io/bitnami/kafka:3.1
+    ports:
+      - "9082"
+      - "9094:9092"
+    environment:
+      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
+      - KAFKA_CFG_BROKER_ID=2
+      - ALLOW_PLAINTEXT_LISTENER=yes
+      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=INSIDE:PLAINTEXT,OUTSIDE:PLAINTEXT
+      - KAFKA_INTER_BROKER_LISTENER_NAME=INSIDE
+      - KAFKA_ADVERTISED_LISTENERS=INSIDE://kafka-2:9082,OUTSIDE://localhost:9094
+      - KAFKA_LISTENERS=INSIDE://0.0.0.0:9082,OUTSIDE://0.0.0.0:9092
+    volumes:
+      - kafka_2_data:/bitnami/kafka
+    depends_on:
+      - zookeeper
+
+volumes:
+  zookeeper_data:
+    driver: local
+  kafka_0_data:
+    driver: local
+  kafka_1_data:
+    driver: local
+  kafka_2_data:
+    driver: local

--- a/examples/kafka_pubsub/main.go
+++ b/examples/kafka_pubsub/main.go
@@ -21,7 +21,7 @@ var wg sync.WaitGroup
 
 type arguments struct {
 	products     string
-	broker       string
+	brokers      string
 	help         bool
 	enableSASL   bool
 	saslUser     string
@@ -35,7 +35,7 @@ Simple test tool to generate test data
 
 Options:
   -h, --help          Print this message and exit.
-  -b  --broker        Apache Kafka broker to connect (default: localhost:9092).
+  -b  --brokers       Comma seperated list of broker addresses (default: localhost:9092).
   -p, --products      Comma seperated list of products.
       --enable-sasl   Enable Simple Authentication and Security Layer (SASL)
       --sasl-user     User for SASL
@@ -101,8 +101,8 @@ func main() {
 	f.BoolVar(&args.help, "help", false, "")
 	f.StringVar(&args.products, "p", "", "")
 	f.StringVar(&args.products, "products", "", "")
-	f.StringVar(&args.broker, "b", "", "")
-	f.StringVar(&args.broker, "broker", "", "")
+	f.StringVar(&args.brokers, "b", "", "")
+	f.StringVar(&args.brokers, "brokers", "", "")
 	f.BoolVar(&args.enableSASL, "enable-sasl", false, "")
 	f.StringVar(&args.saslUser, "sasl-user", "", "")
 	f.StringVar(&args.saslPassword, "sasl-password", "", "")
@@ -116,8 +116,8 @@ func main() {
 		return
 	}
 
-	if args.broker == "" {
-		args.broker = "localhost:9092"
+	if args.brokers == "" {
+		args.brokers = "localhost:9092"
 	}
 
 	if args.products == "" {
@@ -140,7 +140,8 @@ func main() {
 		config.Net.SASL.Password = args.saslPassword
 	}
 
-	asyncProducer, err := sarama.NewAsyncProducer([]string{args.broker}, config)
+	brokers := strings.Split(args.brokers, ",")
+	asyncProducer, err := sarama.NewAsyncProducer(brokers, config)
 	if err != nil {
 		log.Fatalf("failed to create a new AsyncProducer: %v", err)
 	}

--- a/pkg/engine/datasource/kafka_datasource/config.go
+++ b/pkg/engine/datasource/kafka_datasource/config.go
@@ -57,15 +57,15 @@ type SASL struct {
 }
 
 type GraphQLSubscriptionOptions struct {
-	BrokerAddr           string `json:"broker_addr"`
-	Topic                string `json:"topic"`
-	GroupID              string `json:"group_id"`
-	ClientID             string `json:"client_id"`
-	KafkaVersion         string `json:"kafka_version"`
-	StartConsumingLatest bool   `json:"start_consuming_latest"`
-	BalanceStrategy      string `json:"balance_strategy"`
-	IsolationLevel       string `json:"isolation_level"`
-	SASL                 SASL   `json:"sasl"`
+	BrokerAddresses      []string `json:"broker_addresses"`
+	Topic                string   `json:"topic"`
+	GroupID              string   `json:"group_id"`
+	ClientID             string   `json:"client_id"`
+	KafkaVersion         string   `json:"kafka_version"`
+	StartConsumingLatest bool     `json:"start_consuming_latest"`
+	BalanceStrategy      string   `json:"balance_strategy"`
+	IsolationLevel       string   `json:"isolation_level"`
+	SASL                 SASL     `json:"sasl"`
 	startedCallback      func()
 }
 
@@ -86,8 +86,8 @@ func (g *GraphQLSubscriptionOptions) Sanitize() {
 
 func (g *GraphQLSubscriptionOptions) Validate() error {
 	switch {
-	case g.BrokerAddr == "":
-		return fmt.Errorf("broker_addr cannot be empty")
+	case len(g.BrokerAddresses) == 0:
+		return fmt.Errorf("broker_addresses cannot be empty")
 	case g.Topic == "":
 		return fmt.Errorf("topic cannot be empty")
 	case g.GroupID == "":
@@ -125,15 +125,15 @@ func (g *GraphQLSubscriptionOptions) Validate() error {
 }
 
 type SubscriptionConfiguration struct {
-	BrokerAddr           string `json:"broker_addr"`
-	Topic                string `json:"topic"`
-	GroupID              string `json:"group_id"`
-	ClientID             string `json:"client_id"`
-	KafkaVersion         string `json:"kafka_version"`
-	StartConsumingLatest bool   `json:"start_consuming_latest"`
-	BalanceStrategy      string `json:"balance_strategy"`
-	IsolationLevel       string `json:"isolation_level"`
-	SASL                 SASL   `json:"sasl"`
+	BrokerAddresses      []string `json:"broker_addresses"`
+	Topic                string   `json:"topic"`
+	GroupID              string   `json:"group_id"`
+	ClientID             string   `json:"client_id"`
+	KafkaVersion         string   `json:"kafka_version"`
+	StartConsumingLatest bool     `json:"start_consuming_latest"`
+	BalanceStrategy      string   `json:"balance_strategy"`
+	IsolationLevel       string   `json:"isolation_level"`
+	SASL                 SASL     `json:"sasl"`
 }
 
 type Configuration struct {

--- a/pkg/engine/datasource/kafka_datasource/config_test.go
+++ b/pkg/engine/datasource/kafka_datasource/config_test.go
@@ -32,14 +32,14 @@ func TestConfig_GraphQLSubscriptionOptions(t *testing.T) {
 		}
 		g.Sanitize()
 		err := g.Validate()
-		require.Equal(t, err.Error(), "broker_addr cannot be empty")
+		require.Equal(t, err.Error(), "broker_addresses cannot be empty")
 	})
 
 	t.Run("Empty topic not allowed", func(t *testing.T) {
 		g := &GraphQLSubscriptionOptions{
-			BrokerAddr: "localhost:9092",
-			GroupID:    "groupid",
-			ClientID:   "clientid",
+			BrokerAddresses: []string{"localhost:9092"},
+			GroupID:         "groupid",
+			ClientID:        "clientid",
 		}
 		g.Sanitize()
 		err := g.Validate()
@@ -48,9 +48,9 @@ func TestConfig_GraphQLSubscriptionOptions(t *testing.T) {
 
 	t.Run("Empty client_id not allowed", func(t *testing.T) {
 		g := &GraphQLSubscriptionOptions{
-			BrokerAddr: "localhost:9092",
-			Topic:      "foobar",
-			GroupID:    "groupid",
+			BrokerAddresses: []string{"localhost:9092"},
+			Topic:           "foobar",
+			GroupID:         "groupid",
 		}
 		g.Sanitize()
 		err := g.Validate()
@@ -59,11 +59,11 @@ func TestConfig_GraphQLSubscriptionOptions(t *testing.T) {
 
 	t.Run("Invalid Kafka version", func(t *testing.T) {
 		g := &GraphQLSubscriptionOptions{
-			BrokerAddr:   "localhost:9092",
-			Topic:        "foobar",
-			GroupID:      "groupid",
-			ClientID:     "clientid",
-			KafkaVersion: "1.3.5",
+			BrokerAddresses: []string{"localhost:9092"},
+			Topic:           "foobar",
+			GroupID:         "groupid",
+			ClientID:        "clientid",
+			KafkaVersion:    "1.3.5",
 		}
 		g.Sanitize()
 		err := g.Validate()
@@ -72,11 +72,11 @@ func TestConfig_GraphQLSubscriptionOptions(t *testing.T) {
 
 	t.Run("Invalid SASL configuration - SASL nil", func(t *testing.T) {
 		g := &GraphQLSubscriptionOptions{
-			BrokerAddr: "localhost:9092",
-			Topic:      "foobar",
-			GroupID:    "groupid",
-			ClientID:   "clientid",
-			SASL:       SASL{},
+			BrokerAddresses: []string{"localhost:9092"},
+			Topic:           "foobar",
+			GroupID:         "groupid",
+			ClientID:        "clientid",
+			SASL:            SASL{},
 		}
 		g.Sanitize()
 		err := g.Validate()
@@ -85,10 +85,10 @@ func TestConfig_GraphQLSubscriptionOptions(t *testing.T) {
 
 	t.Run("Invalid SASL configuration - auth disabled", func(t *testing.T) {
 		g := &GraphQLSubscriptionOptions{
-			BrokerAddr: "localhost:9092",
-			Topic:      "foobar",
-			GroupID:    "groupid",
-			ClientID:   "clientid",
+			BrokerAddresses: []string{"localhost:9092"},
+			Topic:           "foobar",
+			GroupID:         "groupid",
+			ClientID:        "clientid",
 			SASL: SASL{
 				Enable: false,
 			},
@@ -100,10 +100,10 @@ func TestConfig_GraphQLSubscriptionOptions(t *testing.T) {
 
 	t.Run("Invalid SASL configuration - user cannot be empty", func(t *testing.T) {
 		g := &GraphQLSubscriptionOptions{
-			BrokerAddr: "localhost:9092",
-			Topic:      "foobar",
-			GroupID:    "groupid",
-			ClientID:   "clientid",
+			BrokerAddresses: []string{"localhost:9092"},
+			Topic:           "foobar",
+			GroupID:         "groupid",
+			ClientID:        "clientid",
 			SASL: SASL{
 				Enable: true,
 			},
@@ -115,10 +115,10 @@ func TestConfig_GraphQLSubscriptionOptions(t *testing.T) {
 
 	t.Run("Invalid SASL configuration - password cannot be empty", func(t *testing.T) {
 		g := &GraphQLSubscriptionOptions{
-			BrokerAddr: "localhost:9092",
-			Topic:      "foobar",
-			GroupID:    "groupid",
-			ClientID:   "clientid",
+			BrokerAddresses: []string{"localhost:9092"},
+			Topic:           "foobar",
+			GroupID:         "groupid",
+			ClientID:        "clientid",
 			SASL: SASL{
 				Enable: true,
 				User:   "foobar",
@@ -131,10 +131,10 @@ func TestConfig_GraphQLSubscriptionOptions(t *testing.T) {
 
 	t.Run("Valid SASL configuration", func(t *testing.T) {
 		g := &GraphQLSubscriptionOptions{
-			BrokerAddr: "localhost:9092",
-			Topic:      "foobar",
-			GroupID:    "groupid",
-			ClientID:   "clientid",
+			BrokerAddresses: []string{"localhost:9092"},
+			Topic:           "foobar",
+			GroupID:         "groupid",
+			ClientID:        "clientid",
 			SASL: SASL{
 				Enable:   true,
 				User:     "foobar",

--- a/pkg/engine/datasource/kafka_datasource/kafka_consumer_group.go
+++ b/pkg/engine/datasource/kafka_datasource/kafka_consumer_group.go
@@ -94,7 +94,7 @@ func (k *kafkaConsumerGroupHandler) ConsumeClaim(session sarama.ConsumerGroupSes
 // NewKafkaConsumerGroup creates a new sarama.ConsumerGroup and returns a new
 // *KafkaConsumerGroup instance.
 func NewKafkaConsumerGroup(log log.Logger, saramaConfig *sarama.Config, options *GraphQLSubscriptionOptions) (*KafkaConsumerGroup, error) {
-	cg, err := sarama.NewConsumerGroup([]string{options.BrokerAddr}, options.GroupID, saramaConfig)
+	cg, err := sarama.NewConsumerGroup(options.BrokerAddresses, options.GroupID, saramaConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/engine/datasource/kafka_datasource/kafka_consumer_group_test.go
+++ b/pkg/engine/datasource/kafka_datasource/kafka_consumer_group_test.go
@@ -211,11 +211,11 @@ func TestKafkaConsumerGroup_StartConsuming_And_Stop(t *testing.T) {
 	fr.AddMessage(topic, defaultPartition, testMessageKey, testMessageValue, 0)
 
 	options := GraphQLSubscriptionOptions{
-		BrokerAddr:   mockBroker.Addr(),
-		Topic:        topic,
-		GroupID:      consumerGroup,
-		ClientID:     "graphql-go-tools-test",
-		KafkaVersion: testMockKafkaVersion,
+		BrokerAddresses: []string{mockBroker.Addr()},
+		Topic:           topic,
+		GroupID:         consumerGroup,
+		ClientID:        "graphql-go-tools-test",
+		KafkaVersion:    testMockKafkaVersion,
 	}
 	options.Sanitize()
 	require.NoError(t, options.Validate())

--- a/pkg/engine/datasource/kafka_datasource/kafka_datasource_test.go
+++ b/pkg/engine/datasource/kafka_datasource/kafka_datasource_test.go
@@ -45,7 +45,7 @@ func runTestOnTestDefinition(operation, operationName string, expectedPlan plan.
 				},
 				Custom: ConfigJSON(Configuration{
 					Subscription: SubscriptionConfiguration{
-						BrokerAddr:      "localhost:9092",
+						BrokerAddresses: []string{"localhost:9092"},
 						Topic:           "test.topic",
 						GroupID:         "test.consumer.group",
 						ClientID:        "test.client.id",
@@ -91,7 +91,7 @@ func TestKafkaDataSource(t *testing.T) {
 	`, "RemainingJedis", &plan.SubscriptionResponsePlan{
 		Response: &resolve.GraphQLSubscription{
 			Trigger: resolve.GraphQLSubscriptionTrigger{
-				Input: []byte(fmt.Sprintf(`{"broker_addr":"localhost:9092","topic":"test.topic","group_id":"test.consumer.group","client_id":"test.client.id","kafka_version":"%s","start_consuming_latest":false,"balance_strategy":"%s","isolation_level":"%s","sasl":{"enable":true,"user":"%s","password":"%s"}}`,
+				Input: []byte(fmt.Sprintf(`{"broker_addresses":["localhost:9092"],"topic":"test.topic","group_id":"test.consumer.group","client_id":"test.client.id","kafka_version":"%s","start_consuming_latest":false,"balance_strategy":"%s","isolation_level":"%s","sasl":{"enable":true,"user":"%s","password":"%s"}}`,
 					testMockKafkaVersion,
 					DefaultBalanceStrategy,
 					DefaultIsolationLevel,
@@ -133,7 +133,7 @@ func TestKafkaDataSource(t *testing.T) {
 	`, "SubscriptionWithVariables", &plan.SubscriptionResponsePlan{
 		Response: &resolve.GraphQLSubscription{
 			Trigger: resolve.GraphQLSubscriptionTrigger{
-				Input: []byte(fmt.Sprintf(`{"broker_addr":"localhost:9092","topic":"test.topic.$$0$$","group_id":"test.consumer.group","client_id":"test.client.id","kafka_version":"%s","start_consuming_latest":false,"balance_strategy":"%s","isolation_level":"%s","sasl":{"enable":true,"user":"%s","password":"%s"}}`,
+				Input: []byte(fmt.Sprintf(`{"broker_addresses":["localhost:9092"],"topic":"test.topic.$$0$$","group_id":"test.consumer.group","client_id":"test.client.id","kafka_version":"%s","start_consuming_latest":false,"balance_strategy":"%s","isolation_level":"%s","sasl":{"enable":true,"user":"%s","password":"%s"}}`,
 					testMockKafkaVersion,
 					DefaultBalanceStrategy,
 					DefaultIsolationLevel,
@@ -179,7 +179,7 @@ func TestKafkaDataSource(t *testing.T) {
 				},
 				Custom: ConfigJSON(Configuration{
 					Subscription: SubscriptionConfiguration{
-						BrokerAddr:      "localhost:9092",
+						BrokerAddresses: []string{"localhost:9092"},
 						Topic:           "test.topic.{{.arguments.bar}}",
 						GroupID:         "test.consumer.group",
 						ClientID:        "test.client.id",
@@ -246,11 +246,11 @@ func TestKafkaDataSource_Subscription_Start(t *testing.T) {
 		defer mockBroker.Close()
 
 		options := GraphQLSubscriptionOptions{
-			BrokerAddr:   mockBroker.Addr(),
-			Topic:        topic,
-			GroupID:      groupID,
-			ClientID:     "graphql-go-tools.test.groupid",
-			KafkaVersion: testMockKafkaVersion,
+			BrokerAddresses: []string{mockBroker.Addr()},
+			Topic:           topic,
+			GroupID:         groupID,
+			ClientID:        "graphql-go-tools.test.groupid",
+			KafkaVersion:    testMockKafkaVersion,
 		}
 		optionsBytes, err := json.Marshal(options)
 		require.NoError(t, err)
@@ -293,11 +293,11 @@ func TestKafkaConsumerGroupBridge_Subscribe(t *testing.T) {
 	cg := NewKafkaConsumerGroupBridge(ctx, logger()) // use abstractlogger.NoopLogger if there is no available logger.
 
 	options := GraphQLSubscriptionOptions{
-		BrokerAddr:   mockBroker.Addr(),
-		Topic:        topic,
-		GroupID:      consumerGroup,
-		ClientID:     "graphql-go-tools-test",
-		KafkaVersion: testMockKafkaVersion,
+		BrokerAddresses: []string{mockBroker.Addr()},
+		Topic:           topic,
+		GroupID:         consumerGroup,
+		ClientID:        "graphql-go-tools-test",
+		KafkaVersion:    testMockKafkaVersion,
 	}
 
 	next := make(chan []byte)

--- a/pkg/engine/datasource/kafka_datasource/sarama_config_parameters_test.go
+++ b/pkg/engine/datasource/kafka_datasource/sarama_config_parameters_test.go
@@ -234,7 +234,7 @@ func testAsyncProducer(t *testing.T, options *GraphQLSubscriptionOptions, start,
 		config.Net.SASL.Password = options.SASL.Password
 	}
 
-	asyncProducer, err := sarama.NewAsyncProducer([]string{options.BrokerAddr}, config)
+	asyncProducer, err := sarama.NewAsyncProducer(options.BrokerAddresses, config)
 	require.NoError(t, err)
 
 	for i := start; i < end; i++ {
@@ -320,7 +320,7 @@ func TestSarama_StartConsumingLatest_True(t *testing.T) {
 	brokerAddr := broker.GetHostPort(kafkaPort)
 
 	options := &GraphQLSubscriptionOptions{
-		BrokerAddr:           brokerAddr,
+		BrokerAddresses:      []string{brokerAddr},
 		Topic:                testTopic,
 		GroupID:              testConsumerGroup,
 		ClientID:             "graphql-go-tools-test",
@@ -401,7 +401,7 @@ func TestSarama_StartConsuming_And_Restart(t *testing.T) {
 	brokerAddr := broker.GetHostPort(kafkaPort)
 
 	options := &GraphQLSubscriptionOptions{
-		BrokerAddr:           brokerAddr,
+		BrokerAddresses:      []string{brokerAddr},
 		Topic:                testTopic,
 		GroupID:              testConsumerGroup,
 		ClientID:             "graphql-go-tools-test",
@@ -481,7 +481,7 @@ func TestSarama_ConsumerGroup_SASL_Authentication(t *testing.T) {
 	brokerAddr := broker.GetHostPort(kafkaPort)
 
 	options := &GraphQLSubscriptionOptions{
-		BrokerAddr:           brokerAddr,
+		BrokerAddresses:      []string{brokerAddr},
 		Topic:                testTopic,
 		GroupID:              testConsumerGroup,
 		ClientID:             "graphql-go-tools-test",
@@ -527,7 +527,7 @@ func TestSarama_Balance_Strategy(t *testing.T) {
 
 	for strategy, name := range strategies {
 		options := &GraphQLSubscriptionOptions{
-			BrokerAddr:      testBrokerAddr,
+			BrokerAddresses: []string{testBrokerAddr},
 			Topic:           testTopic,
 			GroupID:         testConsumerGroup,
 			ClientID:        testClientID,
@@ -558,11 +558,11 @@ func TestSarama_Isolation_Level(t *testing.T) {
 
 	for isolationLevel, value := range strategies {
 		options := &GraphQLSubscriptionOptions{
-			BrokerAddr:     testBrokerAddr,
-			Topic:          testTopic,
-			GroupID:        testConsumerGroup,
-			ClientID:       testClientID,
-			IsolationLevel: isolationLevel,
+			BrokerAddresses: []string{testBrokerAddr},
+			Topic:           testTopic,
+			GroupID:         testConsumerGroup,
+			ClientID:        testClientID,
+			IsolationLevel:  isolationLevel,
 		}
 		options.Sanitize()
 		require.NoError(t, options.Validate())
@@ -581,10 +581,10 @@ func TestSarama_Isolation_Level(t *testing.T) {
 
 func TestSarama_Config_SASL_Authentication(t *testing.T) {
 	options := &GraphQLSubscriptionOptions{
-		BrokerAddr: testBrokerAddr,
-		Topic:      testTopic,
-		GroupID:    testConsumerGroup,
-		ClientID:   testClientID,
+		BrokerAddresses: []string{testBrokerAddr},
+		Topic:           testTopic,
+		GroupID:         testConsumerGroup,
+		ClientID:        testClientID,
 		SASL: SASL{
 			Enable:   true,
 			User:     "foobar",

--- a/pkg/engine/datasource/kafka_datasource/sarama_config_parameters_test.go
+++ b/pkg/engine/datasource/kafka_datasource/sarama_config_parameters_test.go
@@ -248,7 +248,7 @@ func (k *kafkaCluster) start(t *testing.T, numMembers int, options ...kafkaClust
 	k.startZooKeeper(t)
 
 	resources := make(map[string]*dockertest.Resource)
-	var port = 9092
+	var port = 9092 // Initial port
 	for i := 0; i < numMembers; i++ {
 		var envVars []string
 		for _, envVar := range k.kafkaRunOptions.envVars {
@@ -256,6 +256,17 @@ func (k *kafkaCluster) start(t *testing.T, numMembers int, options ...kafkaClust
 		}
 		portID := getPortID(port)
 		resources[portID] = k.startKafka(t, port, envVars)
+
+		// Increase the port numbers. Every member uses different a hostname and port numbers.
+		// It was good for debugging:
+		//
+		// Member 1:
+		// 9092 - INSIDE
+		// 9093 - OUTSIDE
+		//
+		// Member 2:
+		// 9094 - INSIDE
+		// 9095 - OUTSIDE
 		port = port + 2
 	}
 	require.NotEmpty(t, resources)

--- a/pkg/engine/datasource/kafka_datasource/sarama_config_parameters_test.go
+++ b/pkg/engine/datasource/kafka_datasource/sarama_config_parameters_test.go
@@ -153,7 +153,7 @@ func (k *kafkaCluster) startKafka(t *testing.T, port int, envVars []string) *doc
 		},
 		ExposedPorts: []string{portID},
 	}, func(config *docker.HostConfig) {
-		config.AutoRemove = false
+		config.AutoRemove = true
 		if k.kafkaRunOptions.saslAuth {
 			wd, _ := os.Getwd()
 			config.Mounts = []docker.HostMount{{
@@ -166,7 +166,8 @@ func (k *kafkaCluster) startKafka(t *testing.T, port int, envVars []string) *doc
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		if err := k.pool.Purge(resource); err != nil {
+		err := k.pool.Purge(resource)
+		if err != nil {
 			err = errors.Unwrap(errors.Unwrap(err))
 			_, ok := err.(*docker.NoSuchContainer)
 			if ok {
@@ -251,9 +252,7 @@ func (k *kafkaCluster) start(t *testing.T, numMembers int, options ...kafkaClust
 	var port = 9092 // Initial port
 	for i := 0; i < numMembers; i++ {
 		var envVars []string
-		for _, envVar := range k.kafkaRunOptions.envVars {
-			envVars = append(envVars, envVar)
-		}
+		envVars = append(envVars, k.kafkaRunOptions.envVars...)
 		portID := getPortID(port)
 		resources[portID] = k.startKafka(t, port, envVars)
 

--- a/pkg/engine/datasource/kafka_datasource/sarama_config_parameters_test.go
+++ b/pkg/engine/datasource/kafka_datasource/sarama_config_parameters_test.go
@@ -22,12 +22,11 @@ import (
 // Solution: docker network prune
 
 const (
-	messageTemplate   = "message-%d"
-	kafkaPort         = "9092/tcp"
 	testBrokerAddr    = "localhost:9092"
+	testClientID      = "graphql-go-tools-test"
+	messageTemplate   = "message-%d"
 	testTopic         = "start-consuming-latest-test"
 	testConsumerGroup = "start-consuming-latest-cg"
-	testClientID      = "graphql-go-tools-test"
 	testSASLUser      = "admin"
 	testSASLPassword  = "admin-secret"
 )
@@ -36,19 +35,23 @@ var defaultZooKeeperEnvVars = []string{
 	"ALLOW_ANONYMOUS_LOGIN=yes",
 }
 
+// See the following blogpost to understand how Kafka listeners works:
+// https://www.confluent.io/blog/kafka-listeners-explained/
+
 var defaultKafkaEnvVars = []string{
 	"KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181",
 	"ALLOW_PLAINTEXT_LISTENER=yes",
-	fmt.Sprintf("KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://%s", testBrokerAddr),
+	"KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=INSIDE:PLAINTEXT,OUTSIDE:PLAINTEXT",
+	"KAFKA_INTER_BROKER_LISTENER_NAME=INSIDE",
 }
 
-type kafkaBroker struct {
+type kafkaCluster struct {
 	pool            *dockertest.Pool
 	network         *docker.Network
-	kafkaRunOptions kafkaRunOptions
+	kafkaRunOptions kafkaClusterOptions
 }
 
-func newKafkaBroker(t *testing.T) *kafkaBroker {
+func newKafkaCluster(t *testing.T) *kafkaCluster {
 	pool, err := dockertest.NewPool("")
 	require.NoError(t, err)
 
@@ -57,13 +60,17 @@ func newKafkaBroker(t *testing.T) *kafkaBroker {
 	network, err := pool.Client.CreateNetwork(docker.CreateNetworkOptions{Name: "zookeeper_kafka_network"})
 	require.NoError(t, err)
 
-	return &kafkaBroker{
+	return &kafkaCluster{
 		pool:    pool,
 		network: network,
 	}
 }
 
-func (k *kafkaBroker) startZooKeeper(t *testing.T) {
+func getPortID(port int) string {
+	return fmt.Sprintf("%d/tcp", port)
+}
+
+func (k *kafkaCluster) startZooKeeper(t *testing.T) {
 	t.Log("Trying to run ZooKeeper")
 
 	resource, err := k.pool.RunWithOptions(&dockertest.RunOptions{
@@ -74,6 +81,8 @@ func (k *kafkaBroker) startZooKeeper(t *testing.T) {
 		Hostname:     "zookeeper",
 		ExposedPorts: []string{"2181"},
 		Env:          defaultZooKeeperEnvVars,
+	}, func(config *docker.HostConfig) {
+		config.AutoRemove = true
 	})
 	require.NoError(t, err)
 
@@ -101,42 +110,50 @@ func (k *kafkaBroker) startZooKeeper(t *testing.T) {
 	t.Log("ZooKeeper has been started")
 }
 
-type kafkaRunOption func(k *kafkaRunOptions)
+type kafkaClusterOption func(k *kafkaClusterOptions)
 
-type kafkaRunOptions struct {
+type kafkaClusterOptions struct {
 	envVars  []string
 	saslAuth bool
 }
 
-func withKafkaEnvVars(envVars []string) kafkaRunOption {
-	return func(k *kafkaRunOptions) {
+func withKafkaEnvVars(envVars []string) kafkaClusterOption {
+	return func(k *kafkaClusterOptions) {
 		k.envVars = envVars
 	}
 }
 
-func withKafkaSASLAuth() kafkaRunOption {
-	return func(k *kafkaRunOptions) {
+func withKafkaSASLAuth() kafkaClusterOption {
+	return func(k *kafkaClusterOptions) {
 		k.saslAuth = true
 	}
 }
 
-func (k *kafkaBroker) startKafka(t *testing.T) *dockertest.Resource {
-	t.Log("Trying to run Kafka")
+func (k *kafkaCluster) startKafka(t *testing.T, port int, envVars []string) *dockertest.Resource {
+	t.Logf("Trying to run Kafka on %d", port)
 
+	internalPort := port + 1
+	hostname := fmt.Sprintf("kafka%d", port)
+
+	envVars = append(envVars, fmt.Sprintf("KAFKA_ADVERTISED_LISTENERS=INSIDE://%s:%d,OUTSIDE://localhost:%d", hostname, internalPort, port))
+	envVars = append(envVars, fmt.Sprintf("KAFKA_LISTENERS=INSIDE://0.0.0.0:%d,OUTSIDE://0.0.0.0:%d", internalPort, port))
+
+	portID := getPortID(port)
+
+	// Name and Hostname have to be unique
 	resource, err := k.pool.RunWithOptions(&dockertest.RunOptions{
-		Name:       "kafka-tyk-graphql",
+		Name:       fmt.Sprintf("kafka-tyk-graphql-%d", port),
 		Repository: "bitnami/kafka",
 		Tag:        "3.0.1",
 		NetworkID:  k.network.ID,
-		Hostname:   "kafka",
-		Env:        k.kafkaRunOptions.envVars,
+		Hostname:   hostname,
+		Env:        envVars,
 		PortBindings: map[docker.Port][]docker.PortBinding{
-			kafkaPort: {{HostIP: "localhost", HostPort: kafkaPort}},
+			docker.Port(portID): {{HostIP: "localhost", HostPort: portID}},
 		},
-		ExposedPorts: []string{kafkaPort},
+		ExposedPorts: []string{portID},
 	}, func(config *docker.HostConfig) {
-		config.AutoRemove = true
-
+		config.AutoRemove = false
 		if k.kafkaRunOptions.saslAuth {
 			wd, _ := os.Getwd()
 			config.Mounts = []docker.HostMount{{
@@ -161,7 +178,8 @@ func (k *kafkaBroker) startKafka(t *testing.T) *dockertest.Resource {
 			config.Net.SASL.User = testSASLUser
 			config.Net.SASL.Password = testSASLPassword
 		}
-		brokerAddr := fmt.Sprintf("localhost:%s", resource.GetPort(kafkaPort))
+
+		brokerAddr := resource.GetHostPort(portID)
 		asyncProducer, err := sarama.NewAsyncProducer([]string{brokerAddr}, config)
 		if err != nil {
 			return err
@@ -190,8 +208,6 @@ func (k *kafkaBroker) startKafka(t *testing.T) *dockertest.Resource {
 				// kafka server: In the middle of a leadership election, there is currently no leader for this
 				// partition and hence it is unavailable for writes.
 				continue loop
-			case <-time.After(time.Second):
-				continue loop
 			case <-asyncProducer.Successes():
 				break loop
 			}
@@ -205,11 +221,11 @@ func (k *kafkaBroker) startKafka(t *testing.T) *dockertest.Resource {
 	}
 	require.NoError(t, k.pool.Retry(retryFn))
 
-	t.Log("Kafka is ready to accept connections")
+	t.Logf("Kafka is ready to accept connections on %d", port)
 	return resource
 }
 
-func (k *kafkaBroker) start(t *testing.T, options ...kafkaRunOption) *dockertest.Resource {
+func (k *kafkaCluster) start(t *testing.T, numMembers int, options ...kafkaClusterOption) map[string]*dockertest.Resource {
 	for _, opt := range options {
 		opt(&k.kafkaRunOptions)
 	}
@@ -223,7 +239,19 @@ func (k *kafkaBroker) start(t *testing.T, options ...kafkaRunOption) *dockertest
 
 	k.startZooKeeper(t)
 
-	return k.startKafka(t)
+	resources := make(map[string]*dockertest.Resource)
+	var port = 9092
+	for i := 0; i < numMembers; i++ {
+		var envVars []string
+		for _, envVar := range k.kafkaRunOptions.envVars {
+			envVars = append(envVars, envVar)
+		}
+		portID := getPortID(port)
+		resources[portID] = k.startKafka(t, port, envVars)
+		port = port + 2
+	}
+	require.NotEmpty(t, resources)
+	return resources
 }
 
 func testAsyncProducer(t *testing.T, options *GraphQLSubscriptionOptions, start, end int) {
@@ -293,6 +321,13 @@ func testStartConsumer(t *testing.T, options *GraphQLSubscriptionOptions) (*Kafk
 	return cg, messages
 }
 
+func getBrokerAddresses(brokers map[string]*dockertest.Resource) (brokerAddresses []string) {
+	for portID, broker := range brokers {
+		brokerAddresses = append(brokerAddresses, broker.GetHostPort(portID))
+	}
+	return brokerAddresses
+}
+
 func TestSarama_StartConsumingLatest_True(t *testing.T) {
 	// Test scenario:
 	//
@@ -310,17 +345,16 @@ func TestSarama_StartConsumingLatest_True(t *testing.T) {
 	// config.Consumer.Offsets.Initial only takes effect when offsets are not committed to Kafka/Zookeeper.
 	// If the consumer group already has offsets committed, the consumer will resume from the committed offset.
 
-	k := newKafkaBroker(t)
-	broker := k.start(t)
+	k := newKafkaCluster(t)
+	brokers := k.start(t, 1)
 
 	const (
 		testTopic         = "start-consuming-latest-test"
 		testConsumerGroup = "start-consuming-latest-cg"
 	)
-	brokerAddr := broker.GetHostPort(kafkaPort)
 
 	options := &GraphQLSubscriptionOptions{
-		BrokerAddresses:      []string{brokerAddr},
+		BrokerAddresses:      getBrokerAddresses(brokers),
 		Topic:                testTopic,
 		GroupID:              testConsumerGroup,
 		ClientID:             "graphql-go-tools-test",
@@ -395,13 +429,11 @@ func TestSarama_StartConsuming_And_Restart(t *testing.T) {
 	// 7- Produce more messages
 	// 8- Consumer will consume all messages.
 
-	k := newKafkaBroker(t)
-	broker := k.start(t)
-
-	brokerAddr := broker.GetHostPort(kafkaPort)
+	k := newKafkaCluster(t)
+	brokers := k.start(t, 3)
 
 	options := &GraphQLSubscriptionOptions{
-		BrokerAddresses:      []string{brokerAddr},
+		BrokerAddresses:      getBrokerAddresses(brokers),
 		Topic:                testTopic,
 		GroupID:              testConsumerGroup,
 		ClientID:             "graphql-go-tools-test",
@@ -467,21 +499,18 @@ func TestSarama_StartConsuming_And_Restart(t *testing.T) {
 func TestSarama_ConsumerGroup_SASL_Authentication(t *testing.T) {
 	kafkaEnvVars := []string{
 		"ALLOW_PLAINTEXT_LISTENER=yes",
-		"KAFKA_OPTS=-Djava.security.auth.login.config=/opt/bitnami/kafka/conf/kafka_jaas.conf",
+		"KAFKA_OPTS=-Djava.security.auth.login.config=/opt/bitnami/kafka/config/kafka_jaas.conf",
 		"KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181",
+		"KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=INSIDE:PLAINTEXT,OUTSIDE:SASL_PLAINTEXT",
 		"KAFKA_CFG_SASL_ENABLED_MECHANISMS=PLAIN",
 		"KAFKA_CFG_SASL_MECHANISM_INTER_BROKER_PROTOCOL=PLAIN",
-		"KAFKA_CFG_LISTENERS=SASL_PLAINTEXT://:9092",
-		fmt.Sprintf("KAFKA_CFG_ADVERTISED_LISTENERS=SASL_PLAINTEXT://%s", testBrokerAddr),
-		"KAFKA_CFG_INTER_BROKER_LISTENER_NAME=SASL_PLAINTEXT",
+		"KAFKA_CFG_INTER_BROKER_LISTENER_NAME=INSIDE",
 	}
-	k := newKafkaBroker(t)
-	broker := k.start(t, withKafkaEnvVars(kafkaEnvVars), withKafkaSASLAuth())
-
-	brokerAddr := broker.GetHostPort(kafkaPort)
+	k := newKafkaCluster(t)
+	brokers := k.start(t, 1, withKafkaEnvVars(kafkaEnvVars), withKafkaSASLAuth())
 
 	options := &GraphQLSubscriptionOptions{
-		BrokerAddresses:      []string{brokerAddr},
+		BrokerAddresses:      getBrokerAddresses(brokers),
 		Topic:                testTopic,
 		GroupID:              testConsumerGroup,
 		ClientID:             "graphql-go-tools-test",


### PR DESCRIPTION
We now support multiple broker addresses in the Kafka data source. The integration test suite was modified to support Kafka clusters instead of a standalone broker. Now it's easy to create a Kafka cluster with a few lines of code:

```go
k := newKafkaCluster(t)
brokers := k.start(t, 3)
```

This simple snippet creates a Kafka cluster with three nodes.  See `pkg/engine/datasource/kafka_datasource/sarama_config_parameters_test.go` file for details. 

I also updated the documentation. See **Creating an Apache Kafka cluster** section in `examples/kafka_pubsub/README.md` file
