### PR TITLE
[TT-5115] Improve Kafka data source documents

### DIFF
--- a/examples/kafka_pubsub/README.md
+++ b/examples/kafka_pubsub/README.md
@@ -84,7 +84,7 @@ Here is a sample data source configuration. It is a part of `examples/kafka_pubs
     ]
   }],
   "config": {
-    "broker_addr": "localhost:9092",
+    "broker_addresses": ["localhost:9092"],
     "topic": "test.topic.{{.arguments.name}}",
     "group_id": "test.group",
     "client_id": "tyk-kafka-integration-{{.arguments.name}}"
@@ -152,7 +152,7 @@ On the API definition side,
 
 ```json
 {
-  "broker_addr": "localhost:9092",
+  "broker_addresses": ["localhost:9092"],
   "topic": "test.topic.product2",
   "group_id": "test.group",
   "client_id": "tyk-kafka-integration-{{.arguments.name}}",

--- a/examples/kafka_pubsub/transactional_producer/README.md
+++ b/examples/kafka_pubsub/transactional_producer/README.md
@@ -64,7 +64,7 @@ dirty writes, and your program will only receive the committed messages.
               }
             ],
             "config": {
-              "broker_addr": "localhost:9092",
+              "broker_addresses": ["localhost:9092"],
               "topic": "test.topic.{{.arguments.name}}",
               "group_id": "test.group",
               "client_id": "tyk-kafka-integration-{{.arguments.name}}",

--- a/examples/kafka_pubsub/tyk-api-definition.json
+++ b/examples/kafka_pubsub/tyk-api-definition.json
@@ -481,7 +481,7 @@
             }
           ],
           "config": {
-            "broker_addr": "localhost:9092",
+            "broker_addresses": ["localhost:9092"],
             "topic": "test.topic.{{.arguments.name}}",
             "group_id": "test.group",
             "client_id": "tyk-kafka-integration-{{.arguments.name}}"

--- a/pkg/engine/datasource/kafka_datasource/config_test.go
+++ b/pkg/engine/datasource/kafka_datasource/config_test.go
@@ -24,7 +24,7 @@ func TestConfig_GraphQLSubscriptionOptions(t *testing.T) {
 		require.Equal(t, DefaultKafkaVersion, g.KafkaVersion)
 	})
 
-	t.Run("Empty broker_addr not allowed", func(t *testing.T) {
+	t.Run("Empty broker_addresses not allowed", func(t *testing.T) {
 		g := &GraphQLSubscriptionOptions{
 			Topic:    "foobar",
 			GroupID:  "groupid",

--- a/pkg/engine/datasource/kafka_datasource/kafka_datasource_test.go
+++ b/pkg/engine/datasource/kafka_datasource/kafka_datasource_test.go
@@ -8,11 +8,11 @@ import (
 	"testing"
 
 	"github.com/Shopify/sarama"
-	"github.com/buger/jsonparser"
-	"github.com/jensneuse/abstractlogger"
 	"github.com/TykTechnologies/graphql-go-tools/pkg/engine/datasourcetesting"
 	"github.com/TykTechnologies/graphql-go-tools/pkg/engine/plan"
 	"github.com/TykTechnologies/graphql-go-tools/pkg/engine/resolve"
+	"github.com/buger/jsonparser"
+	"github.com/jensneuse/abstractlogger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -227,7 +227,7 @@ func TestKafkaDataSource_Subscription_Start(t *testing.T) {
 
 	t.Run("should return error when input is invalid", func(t *testing.T) {
 		source := SubscriptionSource{client: FailingSubscriptionClient{}}
-		err := source.Start(context.Background(), []byte(`{"broker_addr":"",topic":"","group_id":""}`), nil)
+		err := source.Start(context.Background(), []byte(`{"broker_addresses":"",topic":"","group_id":""}`), nil)
 		assert.Error(t, err)
 	})
 


### PR DESCRIPTION
I have updated the documents to cover multiple broker addresses improvement. This PR doesn't require a library update in Tyk and its siblings.