### PR TITLE
[TT-5704] Gateway crashing when running a wrongly written subscription with WSS in Postman

### DIFF
--- a/pkg/graphql/request.go
+++ b/pkg/graphql/request.go
@@ -103,8 +103,13 @@ func (r *Request) parseQueryOnce() (report operationreport.Report) {
 		return report
 	}
 
-	r.isParsed = true
 	r.document, report = astparser.ParseGraphqlDocumentString(r.Query)
+	if !report.HasErrors() {
+		// If the given query has problems, and we failed to parse it,
+		// we shouldn't mark it as parsed. It can be misleading for
+		// the rest of the components. See TT-5704.
+		r.isParsed = true
+	}
 	return report
 }
 


### PR DESCRIPTION
This PR fixes [TT-5704](https://tyktech.atlassian.net/jira/software/c/projects/TT/boards/26?modal=detail&selectedIssue=TT-5704).

Basically, my fix prevents marking a query as parsed unless it is parsed successfully. Now every caller of `parseQueryOnce` can be aware of parsing errors. 