### PR TITLE
[TT-6022] Kafka data source should subscribe to multiple topics

### DIFF
--- a/examples/kafka_pubsub/README.md
+++ b/examples/kafka_pubsub/README.md
@@ -85,7 +85,7 @@ Here is a sample data source configuration. It is a part of `examples/kafka_pubs
   }],
   "config": {
     "broker_addresses": ["localhost:9092"],
-    "topic": "test.topic.{{.arguments.name}}",
+    "topics": ["test.topic.{{.arguments.name}}"],
     "group_id": "test.group",
     "client_id": "tyk-kafka-integration-{{.arguments.name}}"
   }
@@ -153,7 +153,7 @@ On the API definition side,
 ```json
 {
   "broker_addresses": ["localhost:9092"],
-  "topic": "test.topic.product2",
+  "topics": ["test.topic.product2"],
   "group_id": "test.group",
   "client_id": "tyk-kafka-integration-{{.arguments.name}}",
   "sasl": {

--- a/examples/kafka_pubsub/tyk-api-definition.json
+++ b/examples/kafka_pubsub/tyk-api-definition.json
@@ -482,7 +482,7 @@
           ],
           "config": {
             "broker_addresses": ["localhost:9092"],
-            "topic": "test.topic.{{.arguments.name}}",
+            "topics": ["test.topic.{{.arguments.name}}"],
             "group_id": "test.group",
             "client_id": "tyk-kafka-integration-{{.arguments.name}}"
           }

--- a/pkg/engine/datasource/kafka_datasource/config.go
+++ b/pkg/engine/datasource/kafka_datasource/config.go
@@ -58,7 +58,7 @@ type SASL struct {
 
 type GraphQLSubscriptionOptions struct {
 	BrokerAddresses      []string `json:"broker_addresses"`
-	Topic                string   `json:"topic"`
+	Topics               []string `json:"topics"`
 	GroupID              string   `json:"group_id"`
 	ClientID             string   `json:"client_id"`
 	KafkaVersion         string   `json:"kafka_version"`
@@ -88,8 +88,8 @@ func (g *GraphQLSubscriptionOptions) Validate() error {
 	switch {
 	case len(g.BrokerAddresses) == 0:
 		return fmt.Errorf("broker_addresses cannot be empty")
-	case g.Topic == "":
-		return fmt.Errorf("topic cannot be empty")
+	case len(g.Topics) == 0:
+		return fmt.Errorf("topics cannot be empty")
 	case g.GroupID == "":
 		return fmt.Errorf("group_id cannot be empty")
 	case g.ClientID == "":

--- a/pkg/engine/datasource/kafka_datasource/config_test.go
+++ b/pkg/engine/datasource/kafka_datasource/config_test.go
@@ -1,8 +1,9 @@
 package kafka_datasource
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestConfig_GraphQLSubscriptionOptions(t *testing.T) {
@@ -26,7 +27,7 @@ func TestConfig_GraphQLSubscriptionOptions(t *testing.T) {
 
 	t.Run("Empty broker_addresses not allowed", func(t *testing.T) {
 		g := &GraphQLSubscriptionOptions{
-			Topic:    "foobar",
+			Topics:   []string{"foobar"},
 			GroupID:  "groupid",
 			ClientID: "clientid",
 		}
@@ -43,13 +44,13 @@ func TestConfig_GraphQLSubscriptionOptions(t *testing.T) {
 		}
 		g.Sanitize()
 		err := g.Validate()
-		require.Equal(t, err.Error(), "topic cannot be empty")
+		require.Equal(t, err.Error(), "topics cannot be empty")
 	})
 
 	t.Run("Empty client_id not allowed", func(t *testing.T) {
 		g := &GraphQLSubscriptionOptions{
 			BrokerAddresses: []string{"localhost:9092"},
-			Topic:           "foobar",
+			Topics:          []string{"foobar"},
 			GroupID:         "groupid",
 		}
 		g.Sanitize()
@@ -60,7 +61,7 @@ func TestConfig_GraphQLSubscriptionOptions(t *testing.T) {
 	t.Run("Invalid Kafka version", func(t *testing.T) {
 		g := &GraphQLSubscriptionOptions{
 			BrokerAddresses: []string{"localhost:9092"},
-			Topic:           "foobar",
+			Topics:          []string{"foobar"},
 			GroupID:         "groupid",
 			ClientID:        "clientid",
 			KafkaVersion:    "1.3.5",
@@ -73,7 +74,7 @@ func TestConfig_GraphQLSubscriptionOptions(t *testing.T) {
 	t.Run("Invalid SASL configuration - SASL nil", func(t *testing.T) {
 		g := &GraphQLSubscriptionOptions{
 			BrokerAddresses: []string{"localhost:9092"},
-			Topic:           "foobar",
+			Topics:          []string{"foobar"},
 			GroupID:         "groupid",
 			ClientID:        "clientid",
 			SASL:            SASL{},
@@ -86,7 +87,7 @@ func TestConfig_GraphQLSubscriptionOptions(t *testing.T) {
 	t.Run("Invalid SASL configuration - auth disabled", func(t *testing.T) {
 		g := &GraphQLSubscriptionOptions{
 			BrokerAddresses: []string{"localhost:9092"},
-			Topic:           "foobar",
+			Topics:          []string{"foobar"},
 			GroupID:         "groupid",
 			ClientID:        "clientid",
 			SASL: SASL{
@@ -101,7 +102,7 @@ func TestConfig_GraphQLSubscriptionOptions(t *testing.T) {
 	t.Run("Invalid SASL configuration - user cannot be empty", func(t *testing.T) {
 		g := &GraphQLSubscriptionOptions{
 			BrokerAddresses: []string{"localhost:9092"},
-			Topic:           "foobar",
+			Topics:          []string{"foobar"},
 			GroupID:         "groupid",
 			ClientID:        "clientid",
 			SASL: SASL{
@@ -116,7 +117,7 @@ func TestConfig_GraphQLSubscriptionOptions(t *testing.T) {
 	t.Run("Invalid SASL configuration - password cannot be empty", func(t *testing.T) {
 		g := &GraphQLSubscriptionOptions{
 			BrokerAddresses: []string{"localhost:9092"},
-			Topic:           "foobar",
+			Topics:          []string{"foobar"},
 			GroupID:         "groupid",
 			ClientID:        "clientid",
 			SASL: SASL{
@@ -132,7 +133,7 @@ func TestConfig_GraphQLSubscriptionOptions(t *testing.T) {
 	t.Run("Valid SASL configuration", func(t *testing.T) {
 		g := &GraphQLSubscriptionOptions{
 			BrokerAddresses: []string{"localhost:9092"},
-			Topic:           "foobar",
+			Topics:          []string{"foobar"},
 			GroupID:         "groupid",
 			ClientID:        "clientid",
 			SASL: SASL{

--- a/pkg/engine/datasource/kafka_datasource/kafka_consumer_group.go
+++ b/pkg/engine/datasource/kafka_datasource/kafka_consumer_group.go
@@ -38,7 +38,7 @@ type kafkaConsumerGroupHandler struct {
 // Setup is run at the beginning of a new session, before ConsumeClaim.
 func (k *kafkaConsumerGroupHandler) Setup(_ sarama.ConsumerGroupSession) error {
 	k.log.Debug("kafkaConsumerGroupHandler.Setup",
-		log.String("topic", k.options.Topic),
+		log.Strings("topics", k.options.Topics),
 		log.String("groupID", k.options.GroupID),
 		log.String("clientID", k.options.ClientID),
 	)
@@ -49,7 +49,7 @@ func (k *kafkaConsumerGroupHandler) Setup(_ sarama.ConsumerGroupSession) error {
 // but before the offsets are committed for the very last time.
 func (k *kafkaConsumerGroupHandler) Cleanup(_ sarama.ConsumerGroupSession) error {
 	k.log.Debug("kafkaConsumerGroupHandler.Cleanup",
-		log.String("topic", k.options.Topic),
+		log.Strings("topics", k.options.Topics),
 		log.String("groupID", k.options.GroupID),
 		log.String("clientID", k.options.ClientID),
 	)
@@ -86,7 +86,7 @@ func (k *kafkaConsumerGroupHandler) ConsumeClaim(session sarama.ConsumerGroupSes
 		}
 	}
 	k.log.Debug("kafkaConsumerGroupHandler.ConsumeClaim is gone",
-		log.String("topic", k.options.Topic),
+		log.Strings("topics", k.options.Topics),
 		log.String("groupID", k.options.GroupID),
 		log.String("clientID", k.options.ClientID))
 	return nil
@@ -117,7 +117,7 @@ func (k *KafkaConsumerGroup) startConsuming(handler sarama.ConsumerGroupHandler)
 	defer func() {
 		if err := k.consumerGroup.Close(); err != nil {
 			k.log.Error("KafkaConsumerGroup.Close returned an error",
-				log.String("topic", k.options.Topic),
+				log.Strings("topics", k.options.Topics),
 				log.String("groupID", k.options.GroupID),
 				log.String("clientID", k.options.ClientID),
 				log.Error(err))
@@ -134,7 +134,7 @@ func (k *KafkaConsumerGroup) startConsuming(handler sarama.ConsumerGroupHandler)
 		// Consumer.Return.Errors setting to true, and read from this channel.
 		for err := range k.consumerGroup.Errors() {
 			k.log.Error("KafkaConsumerGroup.Consumer",
-				log.String("topic", k.options.Topic),
+				log.Strings("topics", k.options.Topics),
 				log.String("groupID", k.options.GroupID),
 				log.String("clientID", k.options.ClientID),
 				log.Error(err))
@@ -154,15 +154,15 @@ func (k *KafkaConsumerGroup) startConsuming(handler sarama.ConsumerGroupHandler)
 		}
 
 		k.log.Info("KafkaConsumerGroup.consumerGroup.Consume has been called",
-			log.String("topic", k.options.Topic),
+			log.Strings("topics", k.options.Topics),
 			log.String("groupID", k.options.GroupID),
 			log.String("clientID", k.options.ClientID))
 
 		// Blocking call
-		err := k.consumerGroup.Consume(k.ctx, []string{k.options.Topic}, handler)
+		err := k.consumerGroup.Consume(k.ctx, k.options.Topics, handler)
 		if err != nil {
 			k.log.Error("KafkaConsumerGroup.startConsuming",
-				log.String("topic", k.options.Topic),
+				log.Strings("topics", k.options.Topics),
 				log.String("groupID", k.options.GroupID),
 				log.String("clientID", k.options.ClientID),
 				log.Error(err))
@@ -286,7 +286,7 @@ func (c *KafkaConsumerGroupBridge) Subscribe(ctx context.Context, options GraphQ
 		defer func() {
 			if err := cg.Close(); err != nil {
 				c.log.Error("KafkaConsumerGroup.Close returned an error",
-					log.String("topic", options.Topic),
+					log.Strings("topics", options.Topics),
 					log.String("groupID", options.GroupID),
 					log.String("clientID", options.ClientID),
 					log.Error(err),

--- a/pkg/engine/datasource/kafka_datasource/kafka_consumer_group_test.go
+++ b/pkg/engine/datasource/kafka_datasource/kafka_consumer_group_test.go
@@ -212,7 +212,7 @@ func TestKafkaConsumerGroup_StartConsuming_And_Stop(t *testing.T) {
 
 	options := GraphQLSubscriptionOptions{
 		BrokerAddresses: []string{mockBroker.Addr()},
-		Topic:           topic,
+		Topics:          []string{topic},
 		GroupID:         consumerGroup,
 		ClientID:        "graphql-go-tools-test",
 		KafkaVersion:    testMockKafkaVersion,
@@ -270,7 +270,7 @@ func TestKafkaConsumerGroup_Config_StartConsumingLatest(t *testing.T) {
 		log:      logger(),
 		options: &GraphQLSubscriptionOptions{
 			StartConsumingLatest: true,
-			Topic:                mockTopicName,
+			Topics:               []string{mockTopicName},
 			GroupID:              "test.consumer.group",
 			ClientID:             "test.client.id",
 		},

--- a/pkg/engine/datasource/kafka_datasource/kafka_datasource.go
+++ b/pkg/engine/datasource/kafka_datasource/kafka_datasource.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/jensneuse/abstractlogger"
 	"github.com/TykTechnologies/graphql-go-tools/pkg/engine/plan"
+	"github.com/jensneuse/abstractlogger"
 )
 
 type Planner struct {

--- a/pkg/engine/datasource/kafka_datasource/kafka_datasource_test.go
+++ b/pkg/engine/datasource/kafka_datasource/kafka_datasource_test.go
@@ -247,7 +247,7 @@ func TestKafkaDataSource_Subscription_Start(t *testing.T) {
 
 		options := GraphQLSubscriptionOptions{
 			BrokerAddresses: []string{mockBroker.Addr()},
-			Topic:           topic,
+			Topics:          []string{topic},
 			GroupID:         groupID,
 			ClientID:        "graphql-go-tools.test.groupid",
 			KafkaVersion:    testMockKafkaVersion,
@@ -294,7 +294,7 @@ func TestKafkaConsumerGroupBridge_Subscribe(t *testing.T) {
 
 	options := GraphQLSubscriptionOptions{
 		BrokerAddresses: []string{mockBroker.Addr()},
-		Topic:           topic,
+		Topics:          []string{topic},
 		GroupID:         consumerGroup,
 		ClientID:        "graphql-go-tools-test",
 		KafkaVersion:    testMockKafkaVersion,


### PR DESCRIPTION
With this PR, the Kafka data source can subscribe to multiple topics on a Kafka cluster. See `TestSarama_Subscribe_To_Multiple_Topics` for details.

I also improved the test suite for the sake of maintainability.