### PR TITLE
[TT-6110] Allow list for field based permissions implement allow block full types with asterisk

### DIFF
--- a/pkg/graphql/request_fields_validator_test.go
+++ b/pkg/graphql/request_fields_validator_test.go
@@ -1,7 +1,6 @@
 package graphql
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -87,7 +86,7 @@ func TestFieldsValidator_ValidateByFieldList(t *testing.T) {
 			assert.Equal(t, 0, result.Errors.Count())
 		})
 
-		t.Run("should invalidate if blocked fields are used", func(t *testing.T) {
+		t.Run("should invalidate if all fields are blocked by an asterisk char", func(t *testing.T) {
 			blockList := FieldRestrictionList{
 				Kind: BlockList,
 				Types: []Type{
@@ -100,7 +99,6 @@ func TestFieldsValidator_ValidateByFieldList(t *testing.T) {
 
 			validator := DefaultFieldsValidator{}
 			result, err := validator.ValidateByFieldList(&request, schema, blockList)
-			fmt.Println(result, err)
 			assert.NoError(t, err)
 			assert.False(t, result.Valid)
 			assert.Equal(t, 1, result.Errors.Count())
@@ -152,7 +150,7 @@ func TestFieldsValidator_ValidateByFieldList(t *testing.T) {
 			assert.Equal(t, 0, result.Errors.Count())
 		})
 
-		t.Run("should validate if all fields of a type are allowed", func(t *testing.T) {
+		t.Run("should validate if all fields of a type are allowed with the asterisk char", func(t *testing.T) {
 			allowList := FieldRestrictionList{
 				Kind: AllowList,
 				Types: []Type{

--- a/pkg/graphql/request_fields_validator_test.go
+++ b/pkg/graphql/request_fields_validator_test.go
@@ -1,6 +1,7 @@
 package graphql
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -85,6 +86,25 @@ func TestFieldsValidator_ValidateByFieldList(t *testing.T) {
 			assert.True(t, result.Valid)
 			assert.Equal(t, 0, result.Errors.Count())
 		})
+
+		t.Run("should invalidate if blocked fields are used", func(t *testing.T) {
+			blockList := FieldRestrictionList{
+				Kind: BlockList,
+				Types: []Type{
+					{
+						Name:   "Character",
+						Fields: []string{"*"},
+					},
+				},
+			}
+
+			validator := DefaultFieldsValidator{}
+			result, err := validator.ValidateByFieldList(&request, schema, blockList)
+			fmt.Println(result, err)
+			assert.NoError(t, err)
+			assert.False(t, result.Valid)
+			assert.Equal(t, 1, result.Errors.Count())
+		})
 	})
 
 	t.Run("allow list", func(t *testing.T) {
@@ -121,6 +141,28 @@ func TestFieldsValidator_ValidateByFieldList(t *testing.T) {
 					{
 						Name:   "Character",
 						Fields: []string{"name"},
+					},
+				},
+			}
+
+			validator := DefaultFieldsValidator{}
+			result, err := validator.ValidateByFieldList(&request, schema, allowList)
+			assert.NoError(t, err)
+			assert.True(t, result.Valid)
+			assert.Equal(t, 0, result.Errors.Count())
+		})
+
+		t.Run("should validate if all fields of a type are allowed", func(t *testing.T) {
+			allowList := FieldRestrictionList{
+				Kind: AllowList,
+				Types: []Type{
+					{
+						Name:   "Query",
+						Fields: []string{"hero"},
+					},
+					{
+						Name:   "Character",
+						Fields: []string{"*"},
 					},
 				},
 			}


### PR DESCRIPTION
PR for [TT-6110](https://tyktech.atlassian.net/jira/software/c/projects/TT/boards/26?modal=detail&selectedIssue=TT-6110)

Initially, I thought it was good to use an empty fields list to implement that feature but the current implementation validates the input if the fields list is empty. So in order to avoid breaking the API and its behavior, I decided to use an asterisk(*) character to denote all fields of a type are allowed or blocked. 

See the following snippets:

```go
	FieldRestrictionList{
		Kind: AllowList,
		Types: []Type{
			{
				Name:   "Query",
				Fields: []string{"hero"},
			},
			{
				Name:   "Character",
				Fields: []string{"*"},
			},
		},
	}
```

The above sample allows all fields of the `Character` type.

```go
	FieldRestrictionList{
		Kind: BlockList,
		Types: []Type{
			{
				Name:   "Character",
				Fields: []string{"*"},
			},
		},
	}
```

The above sample restricts all fields of the `Character` type.

