### PR TITLE
engine: added support for injected header

### DIFF
--- a/pkg/graphql/execution_engine_v2.go
+++ b/pkg/graphql/execution_engine_v2.go
@@ -11,9 +11,9 @@ import (
 	"strconv"
 	"sync"
 
+	"github.com/TykTechnologies/graphql-go-tools/pkg/engine/datasource/introspection_datasource"
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/jensneuse/abstractlogger"
-	"github.com/TykTechnologies/graphql-go-tools/pkg/engine/datasource/introspection_datasource"
 
 	"github.com/TykTechnologies/graphql-go-tools/pkg/ast"
 	"github.com/TykTechnologies/graphql-go-tools/pkg/astprinter"
@@ -157,6 +157,12 @@ type ExecutionOptionsV2 func(ctx *internalExecutionContext)
 func WithBeforeFetchHook(hook resolve.BeforeFetchHook) ExecutionOptionsV2 {
 	return func(ctx *internalExecutionContext) {
 		ctx.resolveContext.SetBeforeFetchHook(hook)
+	}
+}
+
+func WithUpstreamHeaders(header http.Header) ExecutionOptionsV2 {
+	return func(ctx *internalExecutionContext) {
+		ctx.postProcessor.AddPostProcessor(postprocess.NewProcessInjectHeader(header))
 	}
 }
 

--- a/pkg/postprocess/injectheader.go
+++ b/pkg/postprocess/injectheader.go
@@ -1,0 +1,103 @@
+package postprocess
+
+import (
+	"encoding/json"
+	"github.com/TykTechnologies/graphql-go-tools/pkg/engine/plan"
+	"github.com/TykTechnologies/graphql-go-tools/pkg/engine/resolve"
+	"github.com/buger/jsonparser"
+	"net/http"
+)
+
+type ProcessInjectHeader struct {
+	header http.Header
+}
+
+func NewProcessInjectHeader(header http.Header) *ProcessInjectHeader {
+	return &ProcessInjectHeader{header: header}
+}
+
+func (p *ProcessInjectHeader) Process(pre plan.Plan) plan.Plan {
+	switch t := pre.(type) {
+	case *plan.SynchronousResponsePlan:
+		p.traverseNode(t.Response.Data)
+	case *plan.StreamingResponsePlan:
+		p.traverseNode(t.Response.InitialResponse.Data)
+		for i := range t.Response.Patches {
+			p.traverseFetch(t.Response.Patches[i].Fetch)
+			p.traverseNode(t.Response.Patches[i].Value)
+		}
+	case *plan.SubscriptionResponsePlan:
+		p.traverseTrigger(&t.Response.Trigger)
+		p.traverseNode(t.Response.Response.Data)
+	}
+	return pre
+}
+
+func (p *ProcessInjectHeader) traverseNode(node resolve.Node) {
+	switch n := node.(type) {
+	case *resolve.Object:
+		p.traverseFetch(n.Fetch)
+		for i := range n.Fields {
+			p.traverseNode(n.Fields[i].Value)
+		}
+	case *resolve.Array:
+		p.traverseNode(n.Item)
+	}
+}
+
+func (p *ProcessInjectHeader) traverseFetch(fetch resolve.Fetch) {
+	if fetch == nil {
+		return
+	}
+	switch f := fetch.(type) {
+	case *resolve.SingleFetch:
+		p.traverseSingleFetch(f)
+	case *resolve.BatchFetch:
+		p.traverseSingleFetch(f.Fetch)
+	case *resolve.ParallelFetch:
+		for i := range f.Fetches {
+			p.traverseFetch(f.Fetches[i])
+		}
+	}
+}
+
+func (p *ProcessInjectHeader) traverseTrigger(trigger *resolve.GraphQLSubscriptionTrigger) {
+	trigger.Input = []byte(p.injectHeader(trigger.Input))
+}
+
+func (p *ProcessInjectHeader) traverseSingleFetch(fetch *resolve.SingleFetch) {
+	fetch.Input = p.injectHeader([]byte(fetch.Input))
+}
+
+func (p *ProcessInjectHeader) injectHeader(input []byte) string {
+	var header http.Header
+	val, valType, _, err := jsonparser.Get(input, "header")
+	if err != nil && valType != jsonparser.NotExist {
+		return string(input)
+	}
+
+	switch valType {
+	case jsonparser.NotExist:
+		header = p.header
+	case jsonparser.Object:
+		err := json.Unmarshal(val, &header)
+		if err != nil {
+			return string(input)
+		}
+		for key, val := range p.header {
+			header[key] = val
+		}
+	default:
+		return string(input)
+	}
+
+	m, err := json.Marshal(header)
+	if err != nil {
+		return string(input)
+	}
+	updated, err := jsonparser.Set(input, m, "header")
+	if err != nil {
+		return string(input)
+	}
+	return string(updated)
+}

--- a/pkg/postprocess/injectheader_test.go
+++ b/pkg/postprocess/injectheader_test.go
@@ -1,0 +1,168 @@
+package postprocess
+
+import (
+	"github.com/TykTechnologies/graphql-go-tools/pkg/engine/plan"
+	"github.com/TykTechnologies/graphql-go-tools/pkg/engine/resolve"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestProcessInjectHeader_Process(t *testing.T) {
+
+	pre := &plan.SynchronousResponsePlan{
+		Response: &resolve.GraphQLResponse{
+			Data: &resolve.Object{
+				Fetch: &resolve.SingleFetch{
+					BufferId:   0,
+					Input:      `{"method":"POST","url":"http://localhost:4001/$$0$$","body":{"query":"{me {id username}}"}}`,
+					DataSource: nil,
+					Variables: []resolve.Variable{
+						&resolve.HeaderVariable{
+							Path: []string{"Authorization"},
+						},
+					},
+				},
+				Fields: []*resolve.Field{
+					{
+						HasBuffer: true,
+						BufferID:  0,
+						Name:      []byte("me"),
+						Value: &resolve.Object{
+							Fetch: &resolve.SingleFetch{
+								BufferId: 1,
+								Input:    `{"method":"POST","url":"http://localhost:4002","body":{"query":"query($representations: [_Any!]!){_entities(representations: $representations){... on User {reviews {body product {upc __typename}}}}}","variables":{"representations":[{"id":"$$0$$","__typename":"User"}]}}}`,
+								Variables: resolve.NewVariables(
+									&resolve.ObjectVariable{
+										Path: []string{"id"},
+									},
+								),
+								DataSource: nil,
+								ProcessResponseConfig: resolve.ProcessResponseConfig{
+									ExtractGraphqlResponse:    true,
+									ExtractFederationEntities: true,
+								},
+							},
+							Path:     []string{"me"},
+							Nullable: true,
+							Fields: []*resolve.Field{
+								{
+									Name: []byte("id"),
+									Value: &resolve.String{
+										Path: []string{"id"},
+									},
+								},
+								{
+									Name: []byte("username"),
+									Value: &resolve.String{
+										Path: []string{"username"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	expected := &plan.SynchronousResponsePlan{
+		Response: &resolve.GraphQLResponse{
+			Data: &resolve.Object{
+				Fetch: &resolve.SingleFetch{
+					BufferId: 0,
+					Variables: []resolve.Variable{
+						&resolve.HeaderVariable{
+							Path: []string{"Authorization"},
+						},
+					},
+					Input:         `{"method":"POST","url":"http://localhost:4001/$$0$$","body":{"query":"{me {id username}}"},"header":{"X-Tyk-Custom":["hello"]}}`,
+					InputTemplate: resolve.InputTemplate{},
+					DataSource:    nil,
+				},
+				Fields: []*resolve.Field{
+					{
+						HasBuffer: true,
+						BufferID:  0,
+						Name:      []byte("me"),
+						Value: &resolve.Object{
+							Fetch: &resolve.SingleFetch{
+								BufferId: 1,
+								Variables: resolve.NewVariables(
+									&resolve.ObjectVariable{
+										Path: []string{"id"},
+									},
+								),
+								Input:         `{"method":"POST","url":"http://localhost:4002","body":{"query":"query($representations: [_Any!]!){_entities(representations: $representations){... on User {reviews {body product {upc __typename}}}}}","variables":{"representations":[{"id":"$$0$$","__typename":"User"}]}},"header":{"X-Tyk-Custom":["hello"]}}`,
+								InputTemplate: resolve.InputTemplate{},
+								DataSource:    nil,
+								ProcessResponseConfig: resolve.ProcessResponseConfig{
+									ExtractGraphqlResponse:    true,
+									ExtractFederationEntities: true,
+								},
+							},
+							Path:     []string{"me"},
+							Nullable: true,
+							Fields: []*resolve.Field{
+								{
+									Name: []byte("id"),
+									Value: &resolve.String{
+										Path: []string{"id"},
+									},
+								},
+								{
+									Name: []byte("username"),
+									Value: &resolve.String{
+										Path: []string{"username"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	processor := &ProcessInjectHeader{
+		header: map[string][]string{
+			"X-Tyk-Custom": {"hello"},
+		},
+	}
+	actual := processor.Process(pre)
+
+	assert.Equal(t, expected, actual)
+}
+
+func TestProcessInjectHeader_injectHeader(t *testing.T) {
+	testCases := []struct {
+		name     string
+		in       []byte
+		expected string
+	}{
+		{
+			name:     "no existing header",
+			in:       []byte(`{"method":"POST","url":"http://localhost:4001/$$0$$","body":{"query":"{me {id username}}"}}`),
+			expected: `{"method":"POST","url":"http://localhost:4001/$$0$$","body":{"query":"{me {id username}}"},"header":{"custom":["hello"]}}`,
+		},
+		{
+			name:     "existing header",
+			in:       []byte(`{"method":"POST","header":{"test":["holla"]},"url":"http://localhost:4001/$$0$$","body":{"query":"{me {id username}}"}}`),
+			expected: `{"method":"POST","header":{"custom":["hello"],"test":["holla"]},"url":"http://localhost:4001/$$0$$","body":{"query":"{me {id username}}"}}`,
+		},
+		{
+			name:     "invalid header",
+			in:       []byte(`{"method":"POST","header":1,"url":"http://localhost:4001/$$0$$","body":{"query":"{me {id username}}"}}`),
+			expected: `{"method":"POST","header":1,"url":"http://localhost:4001/$$0$$","body":{"query":"{me {id username}}"}}`,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			processor := &ProcessInjectHeader{header: map[string][]string{
+				"custom": {"hello"},
+			}}
+			gotten := processor.injectHeader(test.in)
+			assert.Equal(t, test.expected, gotten)
+		})
+	}
+}

--- a/pkg/postprocess/postprocess.go
+++ b/pkg/postprocess/postprocess.go
@@ -12,6 +12,10 @@ type Processor struct {
 	postProcessors []PostProcessor
 }
 
+func (p *Processor) AddPostProcessor(pr PostProcessor) {
+	p.postProcessors = append([]PostProcessor{pr}, p.postProcessors...)
+}
+
 func DefaultProcessor() *Processor {
 	return &Processor{
 		[]PostProcessor{


### PR DESCRIPTION
This Pr adds a new post processor that allows manipulation of the headers for requests being sent to upstream.

[TT-5852](https://tyktech.atlassian.net/browse/TT-5852)