### PR TITLE
[TT-6552] fixed bug in input coercion for list when extra invalid input passed

### DIFF
--- a/pkg/astnormalization/input_coercion_for_list.go
+++ b/pkg/astnormalization/input_coercion_for_list.go
@@ -192,8 +192,8 @@ func (i *inputCoercionForListVisitor) walkJsonObject(inputObjDefTypeRef int, dat
 		defer i.popQuery()
 
 		inputValueDefRef := i.definition.InputObjectTypeDefinitionInputValueDefinitionByName(inputObjDefTypeRef, key)
-		// if the inputValueDefRef is -1 then the input value of this variable key does not exist in the input object type so skip
-		if inputValueDefRef == -1 {
+		// if the inputValueDefRef is invalid then the input value of this variable key does not exist in the input object type so skip
+		if inputValueDefRef == ast.InvalidRef {
 			return nil
 		}
 		typeRef := i.definition.ResolveListOrNameType(i.definition.InputValueDefinitionType(inputValueDefRef))

--- a/pkg/astnormalization/input_coercion_for_list.go
+++ b/pkg/astnormalization/input_coercion_for_list.go
@@ -192,6 +192,10 @@ func (i *inputCoercionForListVisitor) walkJsonObject(inputObjDefTypeRef int, dat
 		defer i.popQuery()
 
 		inputValueDefRef := i.definition.InputObjectTypeDefinitionInputValueDefinitionByName(inputObjDefTypeRef, key)
+		// if the inputValueDefRef is -1 then the input value of this variable key does not exist in the input object type so skip
+		if inputValueDefRef == -1 {
+			return nil
+		}
 		typeRef := i.definition.ResolveListOrNameType(i.definition.InputValueDefinitionType(inputValueDefRef))
 
 		switch i.definition.Types[typeRef].TypeKind {

--- a/pkg/astnormalization/input_coercion_for_list_test.go
+++ b/pkg/astnormalization/input_coercion_for_list_test.go
@@ -83,6 +83,21 @@ input InputWithNestedScalarList {
 }`
 
 func TestInputCoercionForList(t *testing.T) {
+	t.Run("run with extra input field not defined", func(t *testing.T) {
+		runWithVariables(t, extractVariables, inputCoercionForListDefinition, `
+			query testQuery($in: InputWithList){
+			  inputWithList (input: $in){
+			     id
+			  }
+			}
+`, "testQuery", `
+			query testQuery($in: InputWithList){
+			  inputWithList (input: $in){
+			     id
+			  }
+			}
+`, `{"in":{"foo":"test","new":"new value"}}`, `{"in":{"foo":"test","new":"new value"}}`, inputCoercionForList)
+	})
 	t.Run("convert integer to list of integer", func(t *testing.T) {
 		runWithVariables(t, extractVariables, inputCoercionForListDefinition, `
 			query {


### PR DESCRIPTION
Fixed a bug where an extra value in the input (in variables) passed would cause the input_coercion_for_list visitor to panic
[TT-6552](https://tyktech.atlassian.net/browse/TT-6552)