### PR TITLE
[TT-6110] Fix inconsistent behavior of the asterisk operator

### DIFF
--- a/pkg/graphql/request_fields_validator.go
+++ b/pkg/graphql/request_fields_validator.go
@@ -87,6 +87,7 @@ func (d DefaultFieldsValidator) checkForBlockedFields(restrictionList FieldRestr
 }
 
 func (d DefaultFieldsValidator) checkForAllowedFields(restrictionList FieldRestrictionList, requestTypes RequestTypes, report operationreport.Report) (RequestFieldsValidationResult, error) {
+	// Group allowed fields and types for easy access.
 	allowedFieldsLookupMap := make(map[string]map[string]bool)
 	for _, allowedType := range restrictionList.Types {
 		allowedFieldsLookupMap[allowedType.Name] = make(map[string]bool)
@@ -95,14 +96,17 @@ func (d DefaultFieldsValidator) checkForAllowedFields(restrictionList FieldRestr
 		}
 	}
 
+	// Try to find a disallowed field.
 	for requestType, requestFields := range requestTypes {
-		for requestField := range requestFields {
-			if _, ok := allowedFieldsLookupMap[requestType][asteriskCharacter]; ok {
-				return fieldsValidationResultForAsterisk(report, true, requestType)
-			}
+		if _, ok := allowedFieldsLookupMap[requestType][asteriskCharacter]; ok {
+			// Every field is allowed to access for this type.
+			continue
+		}
 
+		for requestField := range requestFields {
 			isAllowedField := allowedFieldsLookupMap[requestType][requestField]
 			if !isAllowedField {
+				// The requested field is not allowed to access.
 				return fieldsValidationResult(report, false, requestType, requestField)
 			}
 		}

--- a/pkg/graphql/request_fields_validator_test.go
+++ b/pkg/graphql/request_fields_validator_test.go
@@ -171,6 +171,24 @@ func TestFieldsValidator_ValidateByFieldList(t *testing.T) {
 			assert.True(t, result.Valid)
 			assert.Equal(t, 0, result.Errors.Count())
 		})
+
+		t.Run("should invalidate if only the fields of Query are only allowed to access", func(t *testing.T) {
+			allowList := FieldRestrictionList{
+				Kind: AllowList,
+				Types: []Type{
+					{
+						Name:   "Query",
+						Fields: []string{"*"},
+					},
+				},
+			}
+
+			validator := DefaultFieldsValidator{}
+			result, err := validator.ValidateByFieldList(&request, schema, allowList)
+			assert.NoError(t, err)
+			assert.False(t, result.Valid)
+			assert.Equal(t, 1, result.Errors.Count())
+		})
 	})
 
 }

--- a/pkg/graphql/request_fields_validator_test.go
+++ b/pkg/graphql/request_fields_validator_test.go
@@ -172,7 +172,7 @@ func TestFieldsValidator_ValidateByFieldList(t *testing.T) {
 			assert.Equal(t, 0, result.Errors.Count())
 		})
 
-		t.Run("should invalidate if only the fields of Query are only allowed to access", func(t *testing.T) {
+		t.Run("should invalidate if only the fields of Query are allowed to access", func(t *testing.T) {
 			allowList := FieldRestrictionList{
 				Kind: AllowList,
 				Types: []Type{


### PR DESCRIPTION
This PR fixes the bug described here: https://tyktech.atlassian.net/browse/TT-6110?focusedCommentId=28231

The bug is caused by the mislocation of the asterisk check and iterating over a map. Now it checks the asterisk character first for a requested type, then tries to find a disallowed field if there is any.

Also, I would like to clarify the usage of this allow-list feature. The following config snippet allows to access all current and future fields of the `Query` type.  But the other types and their fields are still disallowed to access. So the asterisk operator doesn't work recursively.

```json
"allowed_types": [
                {
                    "name": "Query",
                    "fields": ["*"]
                }
]
```

The following configuration snippet allows to access all current and future fields of the `Query` type. It also allows to access the `name` field on both `Country` and `Continent` types.

```json
"allowed_types": [{
			"name": "Query",
			"fields": ["*"]
		},
		{
			"name": "Country",
			"fields": ["name"]
		},
		{
			"name": "Continent",
			"fields": ["name"]
		}
	]
```

In short, the asterisk(*) operator only allows access to fields of a specific type. It doesn't work recursively. 