### PR TITLE
[TT-6669] Strict version of IsIntrospectionQuery

### DIFF
--- a/pkg/graphql/request.go
+++ b/pkg/graphql/request.go
@@ -243,9 +243,9 @@ func (r *Request) IsIntrospectionQueryStrict() (result bool, err error) {
 		selectionSets = append(selectionSets, selectionSet)
 	}
 
-	for _, selectionSet := range selectionSets {
-		for i := 0; i < len(selectionSet.SelectionRefs); i++ {
-			selection := r.document.Selections[selectionSet.SelectionRefs[i]]
+	for _, selectionSetItem := range selectionSets {
+		for i := 0; i < len(selectionSetItem.SelectionRefs); i++ {
+			selection := r.document.Selections[selectionSetItem.SelectionRefs[i]]
 			if selection.Kind != ast.SelectionKindField {
 				continue
 			}

--- a/pkg/graphql/request.go
+++ b/pkg/graphql/request.go
@@ -179,16 +179,24 @@ func (r *Request) scanFragmentDefinitionsFindSelectionSets() ([]*ast.SelectionSe
 	var selectionSets []*ast.SelectionSet
 	for i := 0; i < len(r.document.FragmentDefinitions); i++ {
 		fragment := r.document.FragmentDefinitions[i]
-		selectionSet := r.document.SelectionSets[fragment.SelectionSet]
-		if len(selectionSet.SelectionRefs) == 0 {
-			continue
+		if fragment.HasSelections {
+			if fragment.SelectionSet == ast.InvalidRef {
+				continue
+			}
+			selectionSet := r.document.SelectionSets[fragment.SelectionSet]
+			selectionSets = append(selectionSets, &selectionSet)
 		}
-		selectionSets = append(selectionSets, &selectionSet)
 	}
 
 	for i := 0; i < len(r.document.InlineFragments); i++ {
-		selectionSet := r.document.SelectionSets[r.document.InlineFragments[i].SelectionSet]
-		selectionSets = append(selectionSets, &selectionSet)
+		inlineFragment := r.document.InlineFragments[i]
+		if inlineFragment.HasSelections {
+			if inlineFragment.SelectionSet == ast.InvalidRef {
+				continue
+			}
+			selectionSet := r.document.SelectionSets[inlineFragment.SelectionSet]
+			selectionSets = append(selectionSets, &selectionSet)
+		}
 	}
 
 	return selectionSets, nil

--- a/pkg/graphql/request_test.go
+++ b/pkg/graphql/request_test.go
@@ -181,6 +181,8 @@ func TestRequest_IsIntrospectionQueryStrict(t *testing.T) {
 		t.Run("with inline fragment", run(inlineFragmentedIntrospectionQueryType, true))
 		t.Run("with inline fragment on type query", run(inlineFragmentedIntrospectionQueryWithFragmentOnQuery, true))
 		t.Run("with fragment", run(fragmentedIntrospectionQuery, true))
+		t.Run("schema introspection query with additional non-introspection fields", run(nonSchemaIntrospectionQueryWithAdditionalFields, true))
+		t.Run("type introspection query with additional non-introspection fields", run(nonTypeIntrospectionQueryWithAdditionalFields, true))
 	})
 
 	t.Run("type introspection query", func(t *testing.T) {
@@ -194,8 +196,6 @@ func TestRequest_IsIntrospectionQueryStrict(t *testing.T) {
 		t.Run("Foo mutation", run(mutationQuery, false))
 		t.Run("fake schema introspection with alias", run(nonSchemaIntrospectionQueryWithAliases, false))
 		t.Run("fake type introspection with alias", run(nonTypeIntrospectionQueryWithAliases, false))
-		t.Run("schema introspection query with additional non-introspection fields", run(nonSchemaIntrospectionQueryWithAdditionalFields, true))
-		t.Run("type introspection query with additional non-introspection fields", run(nonTypeIntrospectionQueryWithAdditionalFields, true))
 		t.Run("schema introspection with multiple queries in payload", run(nonSchemaIntrospectionQueryWithMultipleQueries, false))
 		t.Run("type introspection with multiple queries in payload", run(nonTypeIntrospectionQueryWithMultipleQueries, false))
 	})

--- a/pkg/graphql/request_test.go
+++ b/pkg/graphql/request_test.go
@@ -157,6 +157,50 @@ func TestRequest_IsIntrospectionQuery(t *testing.T) {
 	})
 }
 
+func TestRequest_IsIntrospectionQueryStrict(t *testing.T) {
+	run := func(queryPayload string, expectedIsIntrospection bool) func(t *testing.T) {
+		return func(t *testing.T) {
+			t.Helper()
+
+			var request Request
+			err := UnmarshalRequest(strings.NewReader(queryPayload), &request)
+			assert.NoError(t, err)
+
+			actualIsIntrospection, err := request.IsIntrospectionQueryStrict()
+			assert.NoError(t, err)
+			assert.Equal(t, expectedIsIntrospection, actualIsIntrospection)
+		}
+	}
+
+	t.Run("schema introspection query", func(t *testing.T) {
+		t.Run("with operation name IntrospectionQuery", run(namedIntrospectionQuery, true))
+		t.Run("without operation name IntrospectionQuery but as single query", run(singleNamedIntrospectionQueryWithoutOperationName, true))
+		t.Run("with empty operation name", run(silentIntrospectionQuery, true))
+		t.Run("with operation name but as silent query", run(silentIntrospectionQueryWithOperationName, true))
+		t.Run("with multiple queries in payload", run(schemaIntrospectionQueryWithMultipleQueries, true))
+		t.Run("with inline fragment", run(inlineFragmentedIntrospectionQueryType, true))
+		t.Run("with inline fragment on type query", run(inlineFragmentedIntrospectionQueryWithFragmentOnQuery, true))
+		t.Run("with fragment", run(fragmentedIntrospectionQuery, true))
+	})
+
+	t.Run("type introspection query", func(t *testing.T) {
+		t.Run("as single introspection", run(typeIntrospectionQuery, true))
+		t.Run("with multiple queries in payload", run(typeIntrospectionQueryWithMultipleQueries, true))
+	})
+
+	t.Run("not introspection query", func(t *testing.T) {
+		t.Run("query with operation name IntrospectionQuery", run(nonIntrospectionQueryWithIntrospectionQueryName, false))
+		t.Run("Foo query", run(nonIntrospectionQuery, false))
+		t.Run("Foo mutation", run(mutationQuery, false))
+		t.Run("fake schema introspection with alias", run(nonSchemaIntrospectionQueryWithAliases, false))
+		t.Run("fake type introspection with alias", run(nonTypeIntrospectionQueryWithAliases, false))
+		t.Run("schema introspection query with additional non-introspection fields", run(nonSchemaIntrospectionQueryWithAdditionalFields, true))
+		t.Run("type introspection query with additional non-introspection fields", run(nonTypeIntrospectionQueryWithAdditionalFields, true))
+		t.Run("schema introspection with multiple queries in payload", run(nonSchemaIntrospectionQueryWithMultipleQueries, false))
+		t.Run("type introspection with multiple queries in payload", run(nonTypeIntrospectionQueryWithMultipleQueries, false))
+	})
+}
+
 func TestRequest_OperationType(t *testing.T) {
 	request := Request{
 		OperationName: "",


### PR DESCRIPTION
This PR proposes a solution for the problem described here: [TT-6669](https://tyktech.atlassian.net/jira/software/c/projects/TT/boards/26?modal=detail&selectedIssue=TT-6669)

After an initial investigation, I found that the original author deliberately implemented the feature I described in the ticket. 

In brief, the following query is an introspection query:

```graphql
{
  __schema {
    types {
      name
    }
  }
}
```

`IsIntrospectionQuery` returns true for this and this is the expected behavior. But if we add an additional field to the above query, `IsIntrospectionQuery` returns false and this behavior breaks the granular access policy of Tyk Gateway. See the related ticket on Jira: [TT-6568](https://tyktech.atlassian.net/browse/TT-6568)

```graphql
{
  __schema {
    types {
      name
    }
  }
  countries { name }
}
```

So the above query returns the introspection response and the name of all countries worldwide even if a user deliberately disabled GQL introspection on this API.

It looks like this is the expected behavior for `IsIntrospectionQuery` because I found the following tests in `TestRequest_IsIntrospectionQuery`:

```go
t.Run("schema introspection query with additional non-introspection fields", run(nonSchemaIntrospectionQueryWithAdditionalFields, false))
t.Run("type introspection query with additional non-introspection fields", run(nonTypeIntrospectionQueryWithAdditionalFields, false))
```

In order to protect the current behavior and prevent breaking the other users' code, I decided to add a stricter version of `IsIntrospectionQuery`. It is called `IsIntrospectionQueryStrict`. Basically, it tries to find the `__schema` and `__type` fields in a given query by scanning the operation and fragment/inline fragment definitions. 

I used the same test cases to verify its function. I also never touched the business logic of `IsIntrospectionQuery`. I just split it into smaller chunks to reuse some code.  
