### PR TITLE
add new subscription protocols from wg

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/pelletier/go-toml v1.6.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/qri-io/jsonschema v0.2.1
+	github.com/r3labs/sse/v2 v2.8.1
 	github.com/sebdah/goldie v0.0.0-20180424091453-8784dd1ab561
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/viper v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -252,6 +252,8 @@ github.com/qri-io/jsonpointer v0.1.1 h1:prVZBZLL6TW5vsSB9fFHFAMBLI4b0ri5vribQlTJ
 github.com/qri-io/jsonpointer v0.1.1/go.mod h1:DnJPaYgiKu56EuDp8TU5wFLdZIcAnb/uH9v37ZaMV64=
 github.com/qri-io/jsonschema v0.2.1 h1:NNFoKms+kut6ABPf6xiKNM5214jzxAhDBrPHCJ97Wg0=
 github.com/qri-io/jsonschema v0.2.1/go.mod h1:g7DPkiOsK1xv6T/Ao5scXRkd+yTFygcANPBaaqW+VrI=
+github.com/r3labs/sse/v2 v2.8.1 h1:lZH+W4XOLIq88U5MIHOsLec7+R62uhz3bIi2yn0Sg8o=
+github.com/r3labs/sse/v2 v2.8.1/go.mod h1:Igau6Whc+F17QUgML1fYe1VPZzTV6EMCnYktEmkNJ7I=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5XpJzTSTfLsJV/mx9Q9g7kxmchpfZyxgzM=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
@@ -348,6 +350,7 @@ golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20191116160921-f9c825593386/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20201224014010-6772e930b67b/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
@@ -422,6 +425,8 @@ google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQ
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=
 google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+gopkg.in/cenkalti/backoff.v1 v1.1.0 h1:Arh75ttbsvlpVA7WtVpH4u9h6Zl46xuptxqLxPiSo4Y=
+gopkg.in/cenkalti/backoff.v1 v1.1.0/go.mod h1:J6Vskwqd+OMVJl8C33mmtxTBs2gyzfv7UDAkHu8BrjI=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/pkg/engine/datasource/graphql_datasource/graphql_datasource.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_datasource.go
@@ -1146,12 +1146,13 @@ func (p *Planner) addField(ref int) {
 type Factory struct {
 	BatchFactory       resolve.DataSourceBatchFactory
 	HTTPClient         *http.Client
+	StreamingClient    *http.Client
 	subscriptionClient *SubscriptionClient
 }
 
 func (f *Factory) Planner(ctx context.Context) plan.DataSourcePlanner {
 	if f.subscriptionClient == nil {
-		f.subscriptionClient = NewGraphQLSubscriptionClient(f.HTTPClient, ctx)
+		f.subscriptionClient = NewGraphQLSubscriptionClient(f.HTTPClient, f.StreamingClient, ctx)
 	}
 	return &Planner{
 		batchFactory:       f.BatchFactory,

--- a/pkg/engine/datasource/graphql_datasource/graphql_datasource.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_datasource.go
@@ -211,7 +211,8 @@ type FederationConfiguration struct {
 }
 
 type SubscriptionConfiguration struct {
-	URL string
+	URL    string
+	UseSSE bool
 }
 
 type FetchConfiguration struct {
@@ -290,6 +291,9 @@ func (p *Planner) ConfigureSubscription() plan.SubscriptionConfiguration {
 	input := httpclient.SetInputBodyWithPath(nil, p.upstreamVariables, "variables")
 	input = httpclient.SetInputBodyWithPath(input, p.printOperation(), "query")
 	input = httpclient.SetInputURL(input, []byte(p.config.Subscription.URL))
+	if p.config.Subscription.UseSSE {
+		input = httpclient.SetInputFlag(input, httpclient.USESSE)
+	}
 
 	header, err := json.Marshal(p.config.Fetch.Header)
 	if err == nil && len(header) != 0 && !bytes.Equal(header, literal.NULL) {
@@ -994,22 +998,25 @@ Skips replace when:
 Example transformation:
 Original schema definition:
 
-type Query {
-	serviceOne(serviceOneArg: String): ServiceOneResponse
-	serviceTwo(serviceTwoArg: Boolean): ServiceTwoResponse
-}
-type ServiceOneResponse {
-	fieldOne: String!
-	countries: [Country!]! # nested datasource without explicit field path
-}
-type ServiceTwoResponse {
-	fieldTwo: String
-	serviceOneField: String
-	serviceOneResponse: ServiceOneResponse # nested datasource with implicit field path "serviceOne"
-}
-type Country {
-	name: String!
-}
+	type Query {
+		serviceOne(serviceOneArg: String): ServiceOneResponse
+		serviceTwo(serviceTwoArg: Boolean): ServiceTwoResponse
+	}
+
+	type ServiceOneResponse {
+		fieldOne: String!
+		countries: [Country!]! # nested datasource without explicit field path
+	}
+
+	type ServiceTwoResponse {
+		fieldTwo: String
+		serviceOneField: String
+		serviceOneResponse: ServiceOneResponse # nested datasource with implicit field path "serviceOne"
+	}
+
+	type Country {
+		name: String!
+	}
 
 `serviceOneResponse` field of a `ServiceTwoResponse` is nested but has a field path that exists on the Query type
 - In this case definition will not be modified
@@ -1019,24 +1026,25 @@ type Country {
 
 Modified schema definition:
 
-schema {
-   query: ServiceOneResponse
-}
+	schema {
+	   query: ServiceOneResponse
+	}
 
-type ServiceOneResponse {
-   fieldOne: String!
-   countries: [Country!]!
-}
+	type ServiceOneResponse {
+	   fieldOne: String!
+	   countries: [Country!]!
+	}
 
-type ServiceTwoResponse {
-   fieldTwo: String
-   serviceOneField: String
-   serviceOneResponse: ServiceOneResponse
-}
+	type ServiceTwoResponse {
+	   fieldTwo: String
+	   serviceOneField: String
+	   serviceOneResponse: ServiceOneResponse
+	}
 
-type Country {
-   name: String!
-}
+	type Country {
+	   name: String!
+	}
+
 Refer to pkg/engine/datasource/graphql_datasource/graphql_datasource_test.go:632
 Case name: TestGraphQLDataSource/nested_graphql_engines
 
@@ -1136,19 +1144,19 @@ func (p *Planner) addField(ref int) {
 }
 
 type Factory struct {
-	BatchFactory resolve.DataSourceBatchFactory
-	HTTPClient   *http.Client
-	wsClient     *WebSocketGraphQLSubscriptionClient
+	BatchFactory       resolve.DataSourceBatchFactory
+	HTTPClient         *http.Client
+	subscriptionClient *SubscriptionClient
 }
 
 func (f *Factory) Planner(ctx context.Context) plan.DataSourcePlanner {
-	if f.wsClient == nil {
-		f.wsClient = NewWebSocketGraphQLSubscriptionClient(f.HTTPClient, ctx)
+	if f.subscriptionClient == nil {
+		f.subscriptionClient = NewGraphQLSubscriptionClient(f.HTTPClient, ctx)
 	}
 	return &Planner{
 		batchFactory:       f.BatchFactory,
 		fetchClient:        f.HTTPClient,
-		subscriptionClient: f.wsClient,
+		subscriptionClient: f.subscriptionClient,
 	}
 }
 
@@ -1226,12 +1234,14 @@ type GraphQLSubscriptionOptions struct {
 	URL    string      `json:"url"`
 	Body   GraphQLBody `json:"body"`
 	Header http.Header `json:"header"`
+	UseSSE bool        `json:"use_sse"`
 }
 
 type GraphQLBody struct {
 	Query         string          `json:"query,omitempty"`
 	OperationName string          `json:"operationName,omitempty"`
 	Variables     json.RawMessage `json:"variables,omitempty"`
+	Extensions    json.RawMessage `json:"extensions,omitempty"`
 }
 
 type SubscriptionSource struct {

--- a/pkg/engine/datasource/graphql_datasource/graphql_datasource_test.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_datasource_test.go
@@ -3344,7 +3344,7 @@ func TestGraphQLDataSource(t *testing.T) {
 			Trigger: resolve.GraphQLSubscriptionTrigger{
 				Input: []byte(`{"url":"wss://swapi.com/graphql","body":{"query":"subscription{remainingJedis}"}}`),
 				Source: &SubscriptionSource{
-					NewGraphQLSubscriptionClient(http.DefaultClient, ctx),
+					NewGraphQLSubscriptionClient(http.DefaultClient, http.DefaultClient, ctx),
 				},
 			},
 			Response: &resolve.GraphQLResponse{
@@ -3382,7 +3382,7 @@ func TestGraphQLDataSource(t *testing.T) {
 					},
 				),
 				Source: &SubscriptionSource{
-					client: NewGraphQLSubscriptionClient(http.DefaultClient, ctx),
+					client: NewGraphQLSubscriptionClient(http.DefaultClient, http.DefaultClient, ctx),
 				},
 			},
 			Response: &resolve.GraphQLResponse{
@@ -5356,7 +5356,7 @@ func TestSubscriptionSource_Start(t *testing.T) {
 
 	newSubscriptionSource := func(ctx context.Context) SubscriptionSource {
 		httpClient := http.Client{}
-		subscriptionSource := SubscriptionSource{client: NewGraphQLSubscriptionClient(&httpClient, ctx)}
+		subscriptionSource := SubscriptionSource{client: NewGraphQLSubscriptionClient(&httpClient, http.DefaultClient, ctx)}
 		return subscriptionSource
 	}
 
@@ -5480,7 +5480,7 @@ func TestSubscription_GTWS_SubProtocol(t *testing.T) {
 	newSubscriptionSource := func(ctx context.Context) SubscriptionSource {
 		httpClient := http.Client{}
 		subscriptionSource := SubscriptionSource{
-			client: NewGraphQLSubscriptionClient(&httpClient, ctx, WithWSSubProtocol(protocolGraphQLTWS)),
+			client: NewGraphQLSubscriptionClient(&httpClient, http.DefaultClient, ctx, WithWSSubProtocol(protocolGraphQLTWS)),
 		}
 		return subscriptionSource
 	}

--- a/pkg/engine/datasource/graphql_datasource/graphql_datasource_test.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_datasource_test.go
@@ -3335,7 +3335,7 @@ func TestGraphQLDataSource(t *testing.T) {
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	t.Run("subscription", runTestOnTestDefinition(`
+	t.Run("Subscription", runTestOnTestDefinition(`
 		subscription RemainingJedis {
 			remainingJedis
 		}
@@ -3344,7 +3344,7 @@ func TestGraphQLDataSource(t *testing.T) {
 			Trigger: resolve.GraphQLSubscriptionTrigger{
 				Input: []byte(`{"url":"wss://swapi.com/graphql","body":{"query":"subscription{remainingJedis}"}}`),
 				Source: &SubscriptionSource{
-					NewWebSocketGraphQLSubscriptionClient(http.DefaultClient, ctx),
+					NewGraphQLSubscriptionClient(http.DefaultClient, ctx),
 				},
 			},
 			Response: &resolve.GraphQLResponse{
@@ -3363,7 +3363,7 @@ func TestGraphQLDataSource(t *testing.T) {
 		},
 	}, testWithFactory(factory)))
 
-	t.Run("subscription with variables", RunTest(`
+	t.Run("Subscription with variables", RunTest(`
 		type Subscription {
 			foo(bar: String): Int!
  		}
@@ -3382,7 +3382,7 @@ func TestGraphQLDataSource(t *testing.T) {
 					},
 				),
 				Source: &SubscriptionSource{
-					client: NewWebSocketGraphQLSubscriptionClient(http.DefaultClient, ctx),
+					client: NewGraphQLSubscriptionClient(http.DefaultClient, ctx),
 				},
 			},
 			Response: &resolve.GraphQLResponse{
@@ -5356,7 +5356,7 @@ func TestSubscriptionSource_Start(t *testing.T) {
 
 	newSubscriptionSource := func(ctx context.Context) SubscriptionSource {
 		httpClient := http.Client{}
-		subscriptionSource := SubscriptionSource{client: NewWebSocketGraphQLSubscriptionClient(&httpClient, ctx)}
+		subscriptionSource := SubscriptionSource{client: NewGraphQLSubscriptionClient(&httpClient, ctx)}
 		return subscriptionSource
 	}
 
@@ -5383,6 +5383,107 @@ func TestSubscriptionSource_Start(t *testing.T) {
 		err := source.Start(ctx, chatSubscriptionOptions, next)
 		require.ErrorIs(t, err, resolve.ErrUnableToResolve)
 	})
+
+	t.Run("invalid syntax (roomNam)", func(t *testing.T) {
+		next := make(chan []byte)
+		ctx := context.Background()
+		defer ctx.Done()
+
+		source := newSubscriptionSource(ctx)
+		chatSubscriptionOptions := chatServerSubscriptionOptions(t, `{"variables": {}, "extensions": {}, "operationName": "LiveMessages", "query": "subscription LiveMessages { messageAdded(roomNam: \"#test\") { text createdBy } }"}`)
+		err := source.Start(ctx, chatSubscriptionOptions, next)
+		require.NoError(t, err)
+
+		msg, ok := <-next
+		assert.True(t, ok)
+		assert.Equal(t, `{"errors":[{"message":"Unknown argument \"roomNam\" on field \"Subscription.messageAdded\". Did you mean \"roomName\"?","locations":[{"line":1,"column":29}],"extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}},{"message":"Field \"messageAdded\" argument \"roomName\" of type \"String!\" is required, but it was not provided.","locations":[{"line":1,"column":29}],"extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}]}`, string(msg))
+		_, ok = <-next
+		assert.False(t, ok)
+	})
+
+	t.Run("should close connection on stop message", func(t *testing.T) {
+		next := make(chan []byte)
+		subscriptionLifecycle, cancelSubscription := context.WithCancel(context.Background())
+		resolverLifecycle, cancelResolver := context.WithCancel(context.Background())
+		defer cancelResolver()
+
+		source := newSubscriptionSource(resolverLifecycle)
+		chatSubscriptionOptions := chatServerSubscriptionOptions(t, `{"variables": {}, "extensions": {}, "operationName": "LiveMessages", "query": "subscription LiveMessages { messageAdded(roomName: \"#test\") { text createdBy } }"}`)
+		err := source.Start(subscriptionLifecycle, chatSubscriptionOptions, next)
+		require.NoError(t, err)
+
+		username := "myuser"
+		message := "hello world!"
+		go sendChatMessage(t, username, message)
+
+		nextBytes := <-next
+		assert.Equal(t, `{"data":{"messageAdded":{"text":"hello world!","createdBy":"myuser"}}}`, string(nextBytes))
+		cancelSubscription()
+		_, ok := <-next
+		assert.False(t, ok)
+	})
+
+	t.Run("should successfully subscribe with chat example", func(t *testing.T) {
+		next := make(chan []byte)
+		ctx := context.Background()
+		defer ctx.Done()
+
+		source := newSubscriptionSource(ctx)
+		chatSubscriptionOptions := chatServerSubscriptionOptions(t, `{"variables": {}, "extensions": {}, "operationName": "LiveMessages", "query": "subscription LiveMessages { messageAdded(roomName: \"#test\") { text createdBy } }"}`)
+		err := source.Start(ctx, chatSubscriptionOptions, next)
+		require.NoError(t, err)
+
+		username := "myuser"
+		message := "hello world!"
+		go sendChatMessage(t, username, message)
+
+		nextBytes := <-next
+		assert.Equal(t, `{"data":{"messageAdded":{"text":"hello world!","createdBy":"myuser"}}}`, string(nextBytes))
+	})
+}
+
+func TestSubscription_GTWS_SubProtocol(t *testing.T) {
+	chatServer := httptest.NewServer(subscriptiontesting.ChatGraphQLEndpointHandler())
+	defer chatServer.Close()
+
+	sendChatMessage := func(t *testing.T, username, message string) {
+		time.Sleep(200 * time.Millisecond)
+		httpClient := http.Client{}
+		req, err := http.NewRequest(
+			http.MethodPost,
+			chatServer.URL,
+			bytes.NewBufferString(fmt.Sprintf(`{"variables": {}, "operationName": "SendMessage", "query": "mutation SendMessage { post(roomName: \"#test\", username: \"%s\", text: \"%s\") { id } }"}`, username, message)),
+		)
+		require.NoError(t, err)
+
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+	}
+
+	chatServerSubscriptionOptions := func(t *testing.T, body string) []byte {
+		var gqlBody GraphQLBody
+		_ = json.Unmarshal([]byte(body), &gqlBody)
+		options := GraphQLSubscriptionOptions{
+			URL:    chatServer.URL,
+			Body:   gqlBody,
+			Header: nil,
+		}
+
+		optionsBytes, err := json.Marshal(options)
+		require.NoError(t, err)
+
+		return optionsBytes
+	}
+
+	newSubscriptionSource := func(ctx context.Context) SubscriptionSource {
+		httpClient := http.Client{}
+		subscriptionSource := SubscriptionSource{
+			client: NewGraphQLSubscriptionClient(&httpClient, ctx, WithWSSubProtocol(protocolGraphQLTWS)),
+		}
+		return subscriptionSource
+	}
 
 	t.Run("invalid syntax (roomNam)", func(t *testing.T) {
 		next := make(chan []byte)

--- a/pkg/engine/datasource/graphql_datasource/graphql_sse_handler.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_sse_handler.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 
 	"github.com/buger/jsonparser"
@@ -74,7 +75,7 @@ func (h *gqlSSEConnectionHandler) subscribe(ctx context.Context, sub Subscriptio
 		_ = resp.Body.Close()
 	}()
 
-	reader := sse.NewEventStreamReader(resp.Body, 1<<32)
+	reader := sse.NewEventStreamReader(resp.Body, math.MaxInt)
 
 	for {
 		if ctx.Err() != nil {

--- a/pkg/engine/datasource/graphql_datasource/graphql_sse_handler.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_sse_handler.go
@@ -199,6 +199,23 @@ func (h *gqlSSEConnectionHandler) performSubscriptionRequest(ctx context.Context
 
 	query := req.URL.Query()
 	query.Add("query", h.options.Body.Query)
+
+	if h.options.Body.Variables != nil {
+		variables, _ := h.options.Body.Variables.MarshalJSON()
+
+		query.Add("variables", string(variables))
+	}
+
+	if h.options.Body.OperationName != "" {
+		query.Add("operationName", h.options.Body.OperationName)
+	}
+
+	if h.options.Body.Extensions != nil {
+		extensions, _ := h.options.Body.Extensions.MarshalJSON()
+
+		query.Add("extensions", string(extensions))
+	}
+
 	req.URL.RawQuery = query.Encode()
 
 	resp, err := h.conn.Do(req)

--- a/pkg/engine/datasource/graphql_datasource/graphql_sse_handler.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_sse_handler.go
@@ -75,7 +75,7 @@ func (h *gqlSSEConnectionHandler) subscribe(ctx context.Context, sub Subscriptio
 		_ = resp.Body.Close()
 	}()
 
-	reader := sse.NewEventStreamReader(resp.Body, math.MaxInt)
+	reader := sse.NewEventStreamReader(resp.Body, math.MaxInt32)
 
 	for {
 		if ctx.Err() != nil {

--- a/pkg/engine/datasource/graphql_datasource/graphql_sse_handler_test.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_sse_handler_test.go
@@ -41,7 +41,7 @@ func TestGraphQLSubscriptionClientSubscribe_SSE(t *testing.T) {
 
 	ctx, clientCancel := context.WithCancel(context.Background())
 
-	client := NewGraphQLSubscriptionClient(http.DefaultClient, serverCtx,
+	client := NewGraphQLSubscriptionClient(http.DefaultClient, http.DefaultClient, serverCtx,
 		WithReadTimeout(time.Millisecond),
 		WithLogger(logger()),
 	)
@@ -98,7 +98,7 @@ func TestGraphQLSubscriptionClientSubscribe_SSE_WithEvents(t *testing.T) {
 
 	ctx, clientCancel := context.WithCancel(context.Background())
 
-	client := NewGraphQLSubscriptionClient(http.DefaultClient, serverCtx,
+	client := NewGraphQLSubscriptionClient(http.DefaultClient, http.DefaultClient, serverCtx,
 		WithReadTimeout(time.Millisecond),
 		WithLogger(logger()),
 	)
@@ -150,7 +150,7 @@ func TestGraphQLSubscriptionClientSubscribe_SSE_Error(t *testing.T) {
 
 	ctx, clientCancel := context.WithCancel(context.Background())
 
-	client := NewGraphQLSubscriptionClient(http.DefaultClient, serverCtx,
+	client := NewGraphQLSubscriptionClient(http.DefaultClient, http.DefaultClient, serverCtx,
 		WithReadTimeout(time.Millisecond),
 		WithLogger(logger()),
 	)
@@ -200,7 +200,7 @@ func TestGraphQLSubscriptionClientSubscribe_SSE_Error_Without_Header(t *testing.
 
 	ctx, clientCancel := context.WithCancel(context.Background())
 
-	client := NewGraphQLSubscriptionClient(http.DefaultClient, serverCtx,
+	client := NewGraphQLSubscriptionClient(http.DefaultClient, http.DefaultClient, serverCtx,
 		WithReadTimeout(time.Millisecond),
 		WithLogger(logger()),
 	)
@@ -255,7 +255,7 @@ func TestGraphQLSubscriptionClientSubscribe_QueryParams(t *testing.T) {
 	serverCtx, serverCancel := context.WithCancel(context.Background())
 	ctx, clientCancel := context.WithCancel(context.Background())
 
-	client := NewGraphQLSubscriptionClient(http.DefaultClient, serverCtx,
+	client := NewGraphQLSubscriptionClient(http.DefaultClient, http.DefaultClient, serverCtx,
 		WithReadTimeout(time.Millisecond),
 		WithLogger(logger()),
 	)

--- a/pkg/engine/datasource/graphql_datasource/graphql_sse_handler_test.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_sse_handler_test.go
@@ -1,0 +1,225 @@
+package graphql_datasource
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGraphQLSubscriptionClientSubscribe_SSE(t *testing.T) {
+	serverDone := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Make sure that the writer supports flushing.
+		flusher, ok := w.(http.Flusher)
+		require.True(t, ok)
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+
+		_, _ = fmt.Fprintf(w, "data: %s\n\n", `{"data":{"messageAdded":{"text":"first"}}}`)
+		flusher.Flush()
+
+		_, _ = fmt.Fprintf(w, "data: %s\n\n", `{"data":{"messageAdded":{"text":"second"}}}`)
+		flusher.Flush()
+
+		close(serverDone)
+	}))
+	defer server.Close()
+
+	serverCtx, serverCancel := context.WithCancel(context.Background())
+
+	ctx, clientCancel := context.WithCancel(context.Background())
+
+	client := NewGraphQLSubscriptionClient(http.DefaultClient, serverCtx,
+		WithReadTimeout(time.Millisecond),
+		WithLogger(logger()),
+	)
+
+	next := make(chan []byte)
+	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
+		URL: server.URL,
+		Body: GraphQLBody{
+			Query: `subscription {messageAdded(roomName: "room"){text}}`,
+		},
+		UseSSE: true,
+	}, next)
+	assert.NoError(t, err)
+
+	first := <-next
+	second := <-next
+	assert.Equal(t, `{"data":{"messageAdded":{"text":"first"}}}`, string(first))
+	assert.Equal(t, `{"data":{"messageAdded":{"text":"second"}}}`, string(second))
+
+	clientCancel()
+	assert.Eventuallyf(t, func() bool {
+		<-serverDone
+		return true
+	}, time.Second, time.Millisecond*10, "server did not close")
+	serverCancel()
+}
+
+func TestGraphQLSubscriptionClientSubscribe_SSE_WithEvents(t *testing.T) {
+	serverDone := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Make sure that the writer supports flushing.
+		flusher, ok := w.(http.Flusher)
+		require.True(t, ok)
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+
+		_, _ = fmt.Fprintf(w, "event: next\ndata: %s\n\n", `{"data":{"messageAdded":{"text":"first"}}}`)
+		flusher.Flush()
+
+		_, _ = fmt.Fprintf(w, "event: next\ndata: %s\n\n", `{"data":{"messageAdded":{"text":"second"}}}`)
+		flusher.Flush()
+
+		_, _ = fmt.Fprintf(w, "event: complete\n\n")
+		flusher.Flush()
+
+		close(serverDone)
+	}))
+	defer server.Close()
+
+	serverCtx, serverCancel := context.WithCancel(context.Background())
+
+	ctx, clientCancel := context.WithCancel(context.Background())
+
+	client := NewGraphQLSubscriptionClient(http.DefaultClient, serverCtx,
+		WithReadTimeout(time.Millisecond),
+		WithLogger(logger()),
+	)
+
+	next := make(chan []byte)
+	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
+		URL: server.URL,
+		Body: GraphQLBody{
+			Query: `subscription {messageAdded(roomName: "room"){text}}`,
+		},
+		UseSSE: true,
+	}, next)
+	assert.NoError(t, err)
+
+	first := <-next
+	second := <-next
+
+	assert.Equal(t, `{"data":{"messageAdded":{"text":"first"}}}`, string(first))
+	assert.Equal(t, `{"data":{"messageAdded":{"text":"second"}}}`, string(second))
+
+	clientCancel()
+	assert.Eventuallyf(t, func() bool {
+		<-serverDone
+		return true
+	}, time.Second, time.Millisecond*10, "server did not close")
+	serverCancel()
+}
+
+func TestGraphQLSubscriptionClientSubscribe_SSE_Error(t *testing.T) {
+	serverDone := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Make sure that the writer supports flushing.
+		flusher, ok := w.(http.Flusher)
+		require.True(t, ok)
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+
+		_, _ = fmt.Fprintf(w, "data: %s\n\n", `{"errors":[{"message":"Unexpected error.","locations":[{"line":2,"column":3}],"path":["countdown"]}]}`)
+		flusher.Flush()
+
+		close(serverDone)
+	}))
+	defer server.Close()
+
+	serverCtx, serverCancel := context.WithCancel(context.Background())
+
+	ctx, clientCancel := context.WithCancel(context.Background())
+
+	client := NewGraphQLSubscriptionClient(http.DefaultClient, serverCtx,
+		WithReadTimeout(time.Millisecond),
+		WithLogger(logger()),
+	)
+
+	next := make(chan []byte)
+	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
+		URL: server.URL,
+		Body: GraphQLBody{
+			Query: `subscription {messageAdded(roomName: "room"){text}}`,
+		},
+		UseSSE: true,
+	}, next)
+	assert.NoError(t, err)
+
+	first := <-next
+
+	assert.Equal(t, `{"errors":[{"message":"Unexpected error.","locations":[{"line":2,"column":3}],"path":["countdown"]}]}`, string(first))
+
+	clientCancel()
+	assert.Eventuallyf(t, func() bool {
+		<-serverDone
+		return true
+	}, time.Second, time.Millisecond*10, "server did not close")
+	serverCancel()
+}
+
+func TestGraphQLSubscriptionClientSubscribe_SSE_Error_Without_Header(t *testing.T) {
+	serverDone := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Make sure that the writer supports flushing.
+		flusher, ok := w.(http.Flusher)
+		require.True(t, ok)
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+
+		_, _ = fmt.Fprintf(w, "%s\n\n", `{"errors":[{"message":"Unexpected error.","locations":[{"line":2,"column":3}],"path":["countdown"]}],"data":null}`)
+		flusher.Flush()
+
+		close(serverDone)
+	}))
+	defer server.Close()
+
+	serverCtx, serverCancel := context.WithCancel(context.Background())
+
+	ctx, clientCancel := context.WithCancel(context.Background())
+
+	client := NewGraphQLSubscriptionClient(http.DefaultClient, serverCtx,
+		WithReadTimeout(time.Millisecond),
+		WithLogger(logger()),
+	)
+
+	next := make(chan []byte)
+	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
+		URL: server.URL,
+		Body: GraphQLBody{
+			Query: `subscription {messageAdded(roomName: "room"){text}}`,
+		},
+		UseSSE: true,
+	}, next)
+	assert.NoError(t, err)
+
+	first := <-next
+
+	assert.Equal(t, `{"errors":[{"message":"Unexpected error.","locations":[{"line":2,"column":3}],"path":["countdown"]}]}`, string(first))
+
+	clientCancel()
+	assert.Eventuallyf(t, func() bool {
+		<-serverDone
+		return true
+	}, time.Second, time.Millisecond*10, "server did not close")
+	serverCancel()
+}

--- a/pkg/engine/datasource/graphql_datasource/graphql_sse_handler_test.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_sse_handler_test.go
@@ -15,6 +15,9 @@ import (
 func TestGraphQLSubscriptionClientSubscribe_SSE(t *testing.T) {
 	serverDone := make(chan struct{})
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		urlQuery := r.URL.Query()
+		assert.Equal(t, "subscription {messageAdded(roomName: \"room\"){text}}", urlQuery.Get("query"))
+
 		// Make sure that the writer supports flushing.
 		flusher, ok := w.(http.Flusher)
 		require.True(t, ok)
@@ -215,6 +218,63 @@ func TestGraphQLSubscriptionClientSubscribe_SSE_Error_Without_Header(t *testing.
 	first := <-next
 
 	assert.Equal(t, `{"errors":[{"message":"Unexpected error.","locations":[{"line":2,"column":3}],"path":["countdown"]}]}`, string(first))
+
+	clientCancel()
+	assert.Eventuallyf(t, func() bool {
+		<-serverDone
+		return true
+	}, time.Second, time.Millisecond*10, "server did not close")
+	serverCancel()
+}
+
+func TestGraphQLSubscriptionClientSubscribe_QueryParams(t *testing.T) {
+	serverDone := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		urlQuery := r.URL.Query()
+		assert.Equal(t, "subscription($a: Int!){countdown(from: $a)}", urlQuery.Get("query"))
+		assert.Equal(t, "CountDown", urlQuery.Get("operationName"))
+		assert.Equal(t, `{"a":5}`, urlQuery.Get("variables"))
+		assert.Equal(t, `{"persistedQuery":{"version":1,"sha256Hash":"d41d8cd98f00b204e9800998ecf8427e"}}`, urlQuery.Get("extensions"))
+
+		//Make sure that the writer supports flushing.
+		flusher, ok := w.(http.Flusher)
+		require.True(t, ok)
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+
+		_, _ = fmt.Fprintf(w, "data: %s\n\n", `{"data":{"countdown":5}}`)
+		flusher.Flush()
+
+		close(serverDone)
+	}))
+	defer server.Close()
+
+	serverCtx, serverCancel := context.WithCancel(context.Background())
+	ctx, clientCancel := context.WithCancel(context.Background())
+
+	client := NewGraphQLSubscriptionClient(http.DefaultClient, serverCtx,
+		WithReadTimeout(time.Millisecond),
+		WithLogger(logger()),
+	)
+
+	next := make(chan []byte)
+	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
+		URL: server.URL,
+		Body: GraphQLBody{
+			Query:         `subscription($a: Int!){countdown(from: $a)}`,
+			OperationName: "CountDown",
+			Variables:     []byte(`{"a":5}`),
+			Extensions:    []byte(`{"persistedQuery":{"version":1,"sha256Hash":"d41d8cd98f00b204e9800998ecf8427e"}}`),
+		},
+		UseSSE: true,
+	}, next)
+	assert.NoError(t, err)
+
+	first := <-next
+	assert.Equal(t, `{"data":{"countdown":5}}`, string(first))
 
 	clientCancel()
 	assert.Eventuallyf(t, func() bool {

--- a/pkg/engine/datasource/graphql_datasource/graphql_subscription_client.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_subscription_client.go
@@ -2,42 +2,31 @@ package graphql_datasource
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
-	"strconv"
 	"sync"
 	"time"
 
-	"github.com/buger/jsonparser"
 	"github.com/cespare/xxhash/v2"
+
+	"github.com/buger/jsonparser"
 	"github.com/jensneuse/abstractlogger"
 	"nhooyr.io/websocket"
 )
 
-var (
-	connectionInitMessage = []byte(`{"type":"connection_init"}`)
-)
+const ackWaitTimeout = 30 * time.Second
 
-const (
-	startMessage    = `{"type":"start","id":"%s","payload":%s}`
-	stopMessage     = `{"type":"stop","id":"%s"}`
-	internalError   = `{"errors":[{"message":"connection error"}]}`
-	connectionError = `{"errors":[{"message":"connection error"}]}`
-)
-
-const ackWaitTimeout = time.Second * 30
-
-// WebSocketGraphQLSubscriptionClient is a WebSocket client that allows running multiple subscriptions via the same WebSocket Connection
-// It takes care of de-duplicating WebSocket connections to the same origin under certain circumstances
-// If Hash(URL,Body,Headers) result in the same result, an existing WS connection is re-used
-type WebSocketGraphQLSubscriptionClient struct {
-	httpClient *http.Client
-	ctx        context.Context
-	log        abstractlogger.Logger
-	hashPool   sync.Pool
-	handlers   map[uint64]*connectionHandler
-	handlersMu sync.Mutex
+// SubscriptionClient allows running multiple subscriptions via the same WebSocket either SSE connection
+// It takes care of de-duplicating connections to the same origin under certain circumstances
+// If Hash(URL,Body,Headers) result in the same result, an existing connection is re-used
+type SubscriptionClient struct {
+	httpClient    *http.Client
+	engineCtx     context.Context
+	log           abstractlogger.Logger
+	hashPool      sync.Pool
+	handlers      map[uint64]ConnectionHandler
+	handlersMu    sync.Mutex
+	wsSubProtocol string
 
 	readTimeout time.Duration
 }
@@ -56,12 +45,19 @@ func WithReadTimeout(timeout time.Duration) Options {
 	}
 }
 
-type opts struct {
-	readTimeout time.Duration
-	log         abstractlogger.Logger
+func WithWSSubProtocol(protocol string) Options {
+	return func(options *opts) {
+		options.wsSubProtocol = protocol
+	}
 }
 
-func NewWebSocketGraphQLSubscriptionClient(httpClient *http.Client, ctx context.Context, options ...Options) *WebSocketGraphQLSubscriptionClient {
+type opts struct {
+	readTimeout   time.Duration
+	log           abstractlogger.Logger
+	wsSubProtocol string
+}
+
+func NewGraphQLSubscriptionClient(httpClient *http.Client, engineCtx context.Context, options ...Options) *SubscriptionClient {
 	op := &opts{
 		readTimeout: time.Second,
 		log:         abstractlogger.NoopLogger,
@@ -69,10 +65,10 @@ func NewWebSocketGraphQLSubscriptionClient(httpClient *http.Client, ctx context.
 	for _, option := range options {
 		option(op)
 	}
-	return &WebSocketGraphQLSubscriptionClient{
+	return &SubscriptionClient{
 		httpClient:  httpClient,
-		ctx:         ctx,
-		handlers:    map[uint64]*connectionHandler{},
+		engineCtx:   engineCtx,
+		handlers:    make(map[uint64]ConnectionHandler),
 		log:         op.log,
 		readTimeout: op.readTimeout,
 		hashPool: sync.Pool{
@@ -80,24 +76,49 @@ func NewWebSocketGraphQLSubscriptionClient(httpClient *http.Client, ctx context.
 				return xxhash.New()
 			},
 		},
+		wsSubProtocol: op.wsSubProtocol,
 	}
 }
 
 // Subscribe initiates a new GraphQL Subscription with the origin
-// Each WebSocket (WS) to an origin is uniquely identified by the Hash(URL,Headers,Body)
-// If an existing WS with the same ID (Hash) exists, it is being re-used
-// If no connection exists, the client initiates a new one and sends the "init" and "connection ack" messages
-func (c *WebSocketGraphQLSubscriptionClient) Subscribe(ctx context.Context, options GraphQLSubscriptionOptions, next chan<- []byte) error {
+// If an existing WS connection with the same ID (Hash) exists, it is being re-used
+// If connection protocol is SSE, a new connection is always created
+// If no connection exists, the client initiates a new one
+func (c *SubscriptionClient) Subscribe(reqCtx context.Context, options GraphQLSubscriptionOptions, next chan<- []byte) error {
+	if options.UseSSE {
+		return c.subscribeSSE(reqCtx, options, next)
+	}
 
+	return c.subscribeWS(reqCtx, options, next)
+}
+
+func (c *SubscriptionClient) subscribeSSE(reqCtx context.Context, options GraphQLSubscriptionOptions, next chan<- []byte) error {
+	sub := Subscription{
+		ctx:     reqCtx,
+		options: options,
+		next:    next,
+	}
+
+	handler := newSSEConnectionHandler(reqCtx, c.httpClient, options, c.log)
+
+	go func() {
+		handler.StartBlocking(sub)
+	}()
+
+	return nil
+}
+
+func (c *SubscriptionClient) subscribeWS(reqCtx context.Context, options GraphQLSubscriptionOptions, next chan<- []byte) error {
+	sub := Subscription{
+		ctx:     reqCtx,
+		options: options,
+		next:    next,
+	}
+
+	// each WS connection to an origin is uniquely identified by the Hash(URL,Headers,Body)
 	handlerID, err := c.generateHandlerIDHash(options)
 	if err != nil {
 		return err
-	}
-
-	sub := subscription{
-		ctx:     ctx,
-		options: options,
-		next:    next,
 	}
 
 	c.handlersMu.Lock()
@@ -105,51 +126,102 @@ func (c *WebSocketGraphQLSubscriptionClient) Subscribe(ctx context.Context, opti
 	handler, exists := c.handlers[handlerID]
 	if exists {
 		select {
-		case handler.subscribeCh <- sub:
-		case <-ctx.Done():
+		case handler.SubscribeCH() <- sub:
+		case <-reqCtx.Done():
 		}
 		return nil
 	}
 
-	if options.Header == nil {
-		options.Header = http.Header{}
-	}
-	options.Header.Set("Sec-WebSocket-Protocol", "graphql-ws")
-	options.Header.Set("Sec-WebSocket-Version", "13")
-
-	conn, upgradeResponse, err := websocket.Dial(ctx, options.URL, &websocket.DialOptions{
-		HTTPClient:      c.httpClient,
-		HTTPHeader:      options.Header,
-		CompressionMode: websocket.CompressionDisabled,
-		Subprotocols:    []string{"graphql-ws"},
-	})
-	if err != nil {
-		return err
-	}
-	if upgradeResponse.StatusCode != http.StatusSwitchingProtocols {
-		return fmt.Errorf("upgrade unsuccessful")
-	}
-	// init + ack
-	err = conn.Write(ctx, websocket.MessageText, connectionInitMessage)
+	handler, err = c.newWSConnectionHandler(reqCtx, options)
 	if err != nil {
 		return err
 	}
 
-	if err := waitForAck(ctx, conn); err != nil {
-		return err
-	}
-
-	handler = newConnectionHandler(c.ctx, conn, c.readTimeout, c.log)
 	c.handlers[handlerID] = handler
 
 	go func(handlerID uint64) {
-		handler.startBlocking(sub)
+		handler.StartBlocking(sub)
 		c.handlersMu.Lock()
 		delete(c.handlers, handlerID)
 		c.handlersMu.Unlock()
 	}(handlerID)
 
 	return nil
+}
+
+// generateHandlerIDHash generates a Hash based on: URL and Headers to uniquely identify Upgrade Requests
+func (c *SubscriptionClient) generateHandlerIDHash(options GraphQLSubscriptionOptions) (uint64, error) {
+	var (
+		err error
+	)
+	xxh := c.hashPool.Get().(*xxhash.Digest)
+	defer c.hashPool.Put(xxh)
+	xxh.Reset()
+
+	_, err = xxh.WriteString(options.URL)
+	if err != nil {
+		return 0, err
+	}
+	err = options.Header.Write(xxh)
+	if err != nil {
+		return 0, err
+	}
+
+	return xxh.Sum64(), nil
+}
+
+func (c *SubscriptionClient) newWSConnectionHandler(reqCtx context.Context, options GraphQLSubscriptionOptions) (ConnectionHandler, error) {
+	subProtocols := []string{protocolGraphQLWS, protocolGraphQLTWS}
+	if c.wsSubProtocol != "" {
+		subProtocols = []string{c.wsSubProtocol}
+	}
+
+	conn, upgradeResponse, err := websocket.Dial(reqCtx, options.URL, &websocket.DialOptions{
+		HTTPClient:      c.httpClient,
+		HTTPHeader:      options.Header,
+		CompressionMode: websocket.CompressionDisabled,
+		Subprotocols:    subProtocols,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if upgradeResponse.StatusCode != http.StatusSwitchingProtocols {
+		return nil, fmt.Errorf("upgrade unsuccessful")
+	}
+
+	// init + ack
+	err = conn.Write(reqCtx, websocket.MessageText, connectionInitMessage)
+	if err != nil {
+		return nil, err
+	}
+
+	if c.wsSubProtocol == "" {
+		c.wsSubProtocol = conn.Subprotocol()
+	}
+
+	if err := waitForAck(reqCtx, conn); err != nil {
+		return nil, err
+	}
+
+	switch c.wsSubProtocol {
+	case protocolGraphQLWS:
+		return newGQLWSConnectionHandler(c.engineCtx, conn, c.readTimeout, c.log), nil
+	case protocolGraphQLTWS:
+		return newGQLTWSConnectionHandler(c.engineCtx, conn, c.readTimeout, c.log), nil
+	default:
+		return nil, fmt.Errorf("unknown protocol %s", conn.Subprotocol())
+	}
+}
+
+type ConnectionHandler interface {
+	StartBlocking(sub Subscription)
+	SubscribeCH() chan<- Subscription
+}
+
+type Subscription struct {
+	ctx     context.Context
+	options GraphQLSubscriptionOptions
+	next    chan<- []byte
 }
 
 func waitForAck(ctx context.Context, conn *websocket.Conn) error {
@@ -174,268 +246,20 @@ func waitForAck(ctx context.Context, conn *websocket.Conn) error {
 			return err
 		}
 
-		if respType == "ka" {
+		switch respType {
+		case messageTypeConnectionKeepAlive:
 			continue
-		} else if respType == "connection_ack" {
-			break
-		} else {
+		case messageTypePing:
+			err := conn.Write(ctx, websocket.MessageText, []byte(pongMessage))
+			if err != nil {
+				return fmt.Errorf("failed to send pong message: %w", err)
+			}
+
+			continue
+		case messageTypeConnectionAck:
+			return nil
+		default:
 			return fmt.Errorf("expected connection_ack or ka, got %s", respType)
 		}
 	}
-	return nil
-}
-
-// generateHandlerIDHash generates a Hash based on: URL and Headers to uniquely identify Upgrade Requests
-func (c *WebSocketGraphQLSubscriptionClient) generateHandlerIDHash(options GraphQLSubscriptionOptions) (uint64, error) {
-	var (
-		err error
-	)
-	xxh := c.hashPool.Get().(*xxhash.Digest)
-	defer c.hashPool.Put(xxh)
-	xxh.Reset()
-
-	_, err = xxh.WriteString(options.URL)
-	if err != nil {
-		return 0, err
-	}
-	err = options.Header.Write(xxh)
-	if err != nil {
-		return 0, err
-	}
-
-	return xxh.Sum64(), nil
-}
-
-func newConnectionHandler(ctx context.Context, conn *websocket.Conn, readTimeout time.Duration, log abstractlogger.Logger) *connectionHandler {
-	return &connectionHandler{
-		conn:               conn,
-		ctx:                ctx,
-		log:                log,
-		subscribeCh:        make(chan subscription),
-		nextSubscriptionID: 0,
-		subscriptions:      map[string]subscription{},
-		readTimeout:        readTimeout,
-	}
-}
-
-// connectionHandler is responsible for handling a connection to an origin
-// it is responsible for managing all subscriptions using the underlying WebSocket connection
-// if all Subscriptions are complete or cancelled/unsubscribed the handler will terminate
-type connectionHandler struct {
-	conn               *websocket.Conn
-	ctx                context.Context
-	log                abstractlogger.Logger
-	subscribeCh        chan subscription
-	nextSubscriptionID int
-	subscriptions      map[string]subscription
-	readTimeout        time.Duration
-}
-
-type subscription struct {
-	ctx     context.Context
-	options GraphQLSubscriptionOptions
-	next    chan<- []byte
-}
-
-// startBlocking starts the single threaded event loop of the handler
-// if the global context returns or the websocket connection is terminated, it will stop
-func (h *connectionHandler) startBlocking(sub subscription) {
-	readCtx, cancel := context.WithCancel(h.ctx)
-	defer func() {
-		h.unsubscribeAllAndCloseConn()
-		cancel()
-	}()
-	h.subscribe(sub)
-	dataCh := make(chan []byte)
-	go h.readBlocking(readCtx, dataCh)
-	for {
-		if h.ctx.Err() != nil {
-			return
-		}
-		hasActiveSubscriptions := h.checkActiveSubscriptions()
-		if !hasActiveSubscriptions {
-			return
-		}
-		select {
-		case <-time.After(h.readTimeout):
-			continue
-		case sub = <-h.subscribeCh:
-			h.subscribe(sub)
-		case data := <-dataCh:
-			messageType, err := jsonparser.GetString(data, "type")
-			if err != nil {
-				continue
-			}
-			switch messageType {
-			case "data":
-				h.handleMessageTypeData(data)
-			case "complete":
-				h.handleMessageTypeComplete(data)
-			case "connection_error":
-				h.handleMessageTypeConnectionError()
-				return
-			case "error":
-				h.handleMessageTypeError(data)
-				continue
-			default:
-				continue
-			}
-		}
-	}
-}
-
-// readBlocking is a dedicated loop running in a separate goroutine
-// because the library "nhooyr.io/websocket" doesn't allow reading with a context with Timeout
-// we'll block forever on reading until the context of the connectionHandler stops
-func (h *connectionHandler) readBlocking(ctx context.Context, dataCh chan []byte) {
-	for {
-		msgType, data, err := h.conn.Read(ctx)
-		if ctx.Err() != nil {
-			return
-		}
-		if err != nil {
-			continue
-		}
-		if msgType != websocket.MessageText {
-			continue
-		}
-		select {
-		case dataCh <- data:
-		case <-ctx.Done():
-			return
-		}
-	}
-}
-
-func (h *connectionHandler) unsubscribeAllAndCloseConn() {
-	for id := range h.subscriptions {
-		h.unsubscribe(id)
-	}
-	_ = h.conn.Close(websocket.StatusNormalClosure, "")
-}
-
-// subscribe adds a new subscription to the connectionHandler and sends the startMessage to the origin
-func (h *connectionHandler) subscribe(sub subscription) {
-	graphQLBody, err := json.Marshal(sub.options.Body)
-	if err != nil {
-		return
-	}
-
-	h.nextSubscriptionID++
-
-	subscriptionID := strconv.Itoa(h.nextSubscriptionID)
-
-	startRequest := fmt.Sprintf(startMessage, subscriptionID, string(graphQLBody))
-	err = h.conn.Write(h.ctx, websocket.MessageText, []byte(startRequest))
-	if err != nil {
-		return
-	}
-
-	h.subscriptions[subscriptionID] = sub
-}
-
-func (h *connectionHandler) handleMessageTypeData(data []byte) {
-	id, err := jsonparser.GetString(data, "id")
-	if err != nil {
-		return
-	}
-	sub, ok := h.subscriptions[id]
-	if !ok {
-		return
-	}
-	payload, _, _, err := jsonparser.Get(data, "payload")
-	if err != nil {
-		return
-	}
-	ctx, cancel := context.WithTimeout(h.ctx, time.Second*5)
-	defer cancel()
-
-	select {
-	case <-ctx.Done():
-	case sub.next <- payload:
-	case <-sub.ctx.Done():
-	}
-}
-
-func (h *connectionHandler) handleMessageTypeConnectionError() {
-	for _, sub := range h.subscriptions {
-		ctx, cancel := context.WithTimeout(h.ctx, time.Second*5)
-		select {
-		case sub.next <- []byte(connectionError):
-			cancel()
-			continue
-		case <-ctx.Done():
-			cancel()
-			continue
-		}
-	}
-}
-
-func (h *connectionHandler) handleMessageTypeComplete(data []byte) {
-	id, err := jsonparser.GetString(data, "id")
-	if err != nil {
-		return
-	}
-	sub, ok := h.subscriptions[id]
-	if !ok {
-		return
-	}
-	close(sub.next)
-	delete(h.subscriptions, id)
-}
-
-func (h *connectionHandler) handleMessageTypeError(data []byte) {
-	id, err := jsonparser.GetString(data, "id")
-	if err != nil {
-		return
-	}
-	sub, ok := h.subscriptions[id]
-	if !ok {
-		return
-	}
-	value, valueType, _, err := jsonparser.Get(data, "payload")
-	if err != nil {
-		sub.next <- []byte(internalError)
-		return
-	}
-	switch valueType {
-	case jsonparser.Array:
-		response := []byte(`{}`)
-		response, err = jsonparser.Set(response, value, "errors")
-		if err != nil {
-			sub.next <- []byte(internalError)
-			return
-		}
-		sub.next <- response
-	case jsonparser.Object:
-		response := []byte(`{"errors":[]}`)
-		response, err = jsonparser.Set(response, value, "errors", "[0]")
-		if err != nil {
-			sub.next <- []byte(internalError)
-			return
-		}
-		sub.next <- response
-	default:
-		sub.next <- []byte(internalError)
-	}
-}
-
-func (h *connectionHandler) unsubscribe(subscriptionID string) {
-	sub, ok := h.subscriptions[subscriptionID]
-	if !ok {
-		return
-	}
-	close(sub.next)
-	delete(h.subscriptions, subscriptionID)
-	stopRequest := fmt.Sprintf(stopMessage, subscriptionID)
-	_ = h.conn.Write(h.ctx, websocket.MessageText, []byte(stopRequest))
-}
-
-func (h *connectionHandler) checkActiveSubscriptions() (hasActiveSubscriptions bool) {
-	for id, sub := range h.subscriptions {
-		if sub.ctx.Err() != nil {
-			h.unsubscribe(id)
-		}
-	}
-	return len(h.subscriptions) != 0
 }

--- a/pkg/engine/datasource/graphql_datasource/graphql_subscription_client_test.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_subscription_client_test.go
@@ -3,7 +3,6 @@ package graphql_datasource
 import (
 	"context"
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -27,342 +26,6 @@ func logger() ll.Logger {
 	}
 
 	return ll.NewZapLogger(logger, ll.DebugLevel)
-}
-
-func TestWebSocketSubscriptionClientInitIncludeKA(t *testing.T) {
-	serverDone := make(chan struct{})
-	assertion := require.New(t)
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		conn, err := websocket.Accept(w, r, nil)
-		assertion.NoError(err)
-
-		// write "ka" every second
-		go func() {
-			for {
-				err := conn.Write(r.Context(), websocket.MessageText, []byte(`{"type":"ka"}`))
-				if err != nil {
-					break
-				}
-				time.Sleep(time.Second)
-			}
-		}()
-		ctx := context.Background()
-		msgType, data, err := conn.Read(ctx)
-		assertion.NoError(err)
-		assertion.Equal(websocket.MessageText, msgType)
-		assertion.Equal(`{"type":"connection_init"}`, string(data))
-
-		err = conn.Write(r.Context(), websocket.MessageText, []byte(`{"type":"connection_ack"}`))
-		assertion.NoError(err)
-
-		msgType, data, err = conn.Read(ctx)
-		assertion.NoError(err)
-		assertion.Equal(websocket.MessageText, msgType)
-		assertion.Equal(`{"type":"start","id":"1","payload":{"query":"subscription {messageAdded(roomName: \"room\"){text}}"}}`, string(data))
-		err = conn.Write(r.Context(), websocket.MessageText, []byte(`{"type":"data","id":"1","payload":{"data":{"messageAdded":{"text":"first"}}}}`))
-		assertion.NoError(err)
-		err = conn.Write(r.Context(), websocket.MessageText, []byte(`{"type":"data","id":"1","payload":{"data":{"messageAdded":{"text":"second"}}}}`))
-		assertion.NoError(err)
-		assertion.NoError(err)
-
-		msgType, data, err = conn.Read(ctx)
-		assertion.NoError(err)
-		assertion.Equal(websocket.MessageText, msgType)
-		assertion.Equal(`{"type":"stop","id":"1"}`, string(data))
-		close(serverDone)
-	}))
-
-	defer server.Close()
-	ctx, clientCancel := context.WithCancel(context.Background())
-	defer clientCancel()
-	serverCtx, serverCancel := context.WithCancel(context.Background())
-	defer serverCancel()
-
-	client := NewWebSocketGraphQLSubscriptionClient(http.DefaultClient, serverCtx,
-		WithReadTimeout(time.Millisecond),
-		WithLogger(logger()),
-	)
-	next := make(chan []byte)
-	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
-		URL: strings.Replace(server.URL, "http", "ws", -1),
-		Body: GraphQLBody{
-			Query: `subscription {messageAdded(roomName: "room"){text}}`,
-		},
-	}, next)
-	assertion.NoError(err)
-	first := <-next
-	second := <-next
-	assertion.Equal(`{"data":{"messageAdded":{"text":"first"}}}`, string(first))
-	assertion.Equal(`{"data":{"messageAdded":{"text":"second"}}}`, string(second))
-	clientCancel()
-	assertion.Eventuallyf(func() bool {
-		<-serverDone
-		return true
-	}, time.Second, time.Millisecond*10, "server did not close")
-	serverCancel()
-	assertion.Eventuallyf(func() bool {
-		return len(client.handlers) == 0
-	}, time.Second, time.Millisecond, "client handlers not 0")
-}
-
-func TestWebsocketSubscriptionClient(t *testing.T) {
-	serverDone := make(chan struct{})
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		conn, err := websocket.Accept(w, r, nil)
-		assert.NoError(t, err)
-		ctx := context.Background()
-		msgType, data, err := conn.Read(ctx)
-		assert.NoError(t, err)
-		assert.Equal(t, websocket.MessageText, msgType)
-		assert.Equal(t, `{"type":"connection_init"}`, string(data))
-		err = conn.Write(r.Context(), websocket.MessageText, []byte(`{"type":"connection_ack"}`))
-		assert.NoError(t, err)
-		msgType, data, err = conn.Read(ctx)
-		assert.NoError(t, err)
-		assert.Equal(t, websocket.MessageText, msgType)
-		assert.Equal(t, `{"type":"start","id":"1","payload":{"query":"subscription {messageAdded(roomName: \"room\"){text}}"}}`, string(data))
-		err = conn.Write(r.Context(), websocket.MessageText, []byte(`{"type":"data","id":"1","payload":{"data":{"messageAdded":{"text":"first"}}}}`))
-		assert.NoError(t, err)
-		err = conn.Write(r.Context(), websocket.MessageText, []byte(`{"type":"data","id":"1","payload":{"data":{"messageAdded":{"text":"second"}}}}`))
-		assert.NoError(t, err)
-		err = conn.Write(r.Context(), websocket.MessageText, []byte(`{"type":"data","id":"1","payload":{"data":{"messageAdded":{"text":"third"}}}}`))
-		assert.NoError(t, err)
-
-		msgType, data, err = conn.Read(ctx)
-		assert.NoError(t, err)
-		assert.Equal(t, websocket.MessageText, msgType)
-		assert.Equal(t, `{"type":"stop","id":"1"}`, string(data))
-		close(serverDone)
-	}))
-	defer server.Close()
-	ctx, clientCancel := context.WithCancel(context.Background())
-
-	serverCtx, serverCancel := context.WithCancel(context.Background())
-	defer serverCancel()
-
-	client := NewWebSocketGraphQLSubscriptionClient(http.DefaultClient, serverCtx,
-		WithReadTimeout(time.Millisecond),
-		WithLogger(logger()),
-	)
-	next := make(chan []byte)
-	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
-		URL: strings.Replace(server.URL, "http", "ws", -1),
-		Body: GraphQLBody{
-			Query: `subscription {messageAdded(roomName: "room"){text}}`,
-		},
-	}, next)
-	assert.NoError(t, err)
-	first := <-next
-	second := <-next
-	third := <-next
-	assert.Equal(t, `{"data":{"messageAdded":{"text":"first"}}}`, string(first))
-	assert.Equal(t, `{"data":{"messageAdded":{"text":"second"}}}`, string(second))
-	assert.Equal(t, `{"data":{"messageAdded":{"text":"third"}}}`, string(third))
-	clientCancel()
-	assert.Eventuallyf(t, func() bool {
-		<-serverDone
-		return true
-	}, time.Second, time.Millisecond*10, "server did not close")
-	serverCancel()
-	assert.Eventuallyf(t, func() bool {
-		return len(client.handlers) == 0
-	}, time.Second, time.Millisecond, "client handlers not 0")
-}
-
-func TestWebsocketSubscriptionClientImmediateClientCancel(t *testing.T) {
-	serverInvocations := atomic.NewInt64(0)
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		serverInvocations.Inc()
-	}))
-	defer server.Close()
-	ctx, clientCancel := context.WithCancel(context.Background())
-	clientCancel()
-	serverCtx, serverCancel := context.WithCancel(context.Background())
-	defer serverCancel()
-	client := NewWebSocketGraphQLSubscriptionClient(http.DefaultClient, serverCtx,
-		WithReadTimeout(time.Millisecond),
-		WithLogger(logger()),
-	)
-	next := make(chan []byte)
-	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
-		URL: strings.Replace(server.URL, "http", "ws", -1),
-		Body: GraphQLBody{
-			Query: `subscription {messageAdded(roomName: "room"){text}}`,
-		},
-	}, next)
-	assert.Error(t, err)
-	assert.Eventuallyf(t, func() bool {
-		return serverInvocations.Load() == 0
-	}, time.Second, time.Millisecond*10, "server did not close")
-	serverCancel()
-	assert.Eventuallyf(t, func() bool {
-		return len(client.handlers) == 0
-	}, time.Second, time.Millisecond, "client handlers not 0")
-}
-
-func TestWebsocketSubscriptionClientWithServerDisconnect(t *testing.T) {
-	serverDone := make(chan struct{})
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		conn, err := websocket.Accept(w, r, nil)
-		assert.NoError(t, err)
-		ctx := context.Background()
-		msgType, data, err := conn.Read(ctx)
-		assert.NoError(t, err)
-		assert.Equal(t, websocket.MessageText, msgType)
-		assert.Equal(t, `{"type":"connection_init"}`, string(data))
-		err = conn.Write(r.Context(), websocket.MessageText, []byte(`{"type":"connection_ack"}`))
-		assert.NoError(t, err)
-		msgType, data, err = conn.Read(ctx)
-		assert.NoError(t, err)
-		assert.Equal(t, websocket.MessageText, msgType)
-		assert.Equal(t, `{"type":"start","id":"1","payload":{"query":"subscription {messageAdded(roomName: \"room\"){text}}"}}`, string(data))
-		err = conn.Write(r.Context(), websocket.MessageText, []byte(`{"type":"data","id":"1","payload":{"data":{"messageAdded":{"text":"first"}}}}`))
-		assert.NoError(t, err)
-		err = conn.Write(r.Context(), websocket.MessageText, []byte(`{"type":"data","id":"1","payload":{"data":{"messageAdded":{"text":"second"}}}}`))
-		assert.NoError(t, err)
-		err = conn.Write(r.Context(), websocket.MessageText, []byte(`{"type":"data","id":"1","payload":{"data":{"messageAdded":{"text":"third"}}}}`))
-		assert.NoError(t, err)
-
-		_, _, err = conn.Read(ctx)
-		assert.Error(t, err)
-		close(serverDone)
-	}))
-	defer server.Close()
-	ctx, clientCancel := context.WithCancel(context.Background())
-	defer clientCancel()
-	serverCtx, serverCancel := context.WithCancel(context.Background())
-	defer serverCancel()
-
-	client := NewWebSocketGraphQLSubscriptionClient(http.DefaultClient, serverCtx,
-		WithReadTimeout(time.Millisecond),
-		WithLogger(logger()),
-	)
-	next := make(chan []byte)
-	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
-		URL: strings.Replace(server.URL, "http", "ws", -1),
-		Body: GraphQLBody{
-			Query: `subscription {messageAdded(roomName: "room"){text}}`,
-		},
-	}, next)
-	assert.NoError(t, err)
-	first := <-next
-	second := <-next
-	third := <-next
-	assert.Equal(t, `{"data":{"messageAdded":{"text":"first"}}}`, string(first))
-	assert.Equal(t, `{"data":{"messageAdded":{"text":"second"}}}`, string(second))
-	assert.Equal(t, `{"data":{"messageAdded":{"text":"third"}}}`, string(third))
-	serverCancel()
-	assert.Eventuallyf(t, func() bool {
-		<-serverDone
-		return true
-	}, time.Second, time.Millisecond*10, "server did not close")
-	assert.Eventuallyf(t, func() bool {
-		return len(client.handlers) == 0
-	}, time.Second, time.Millisecond, "client handlers not 0")
-}
-
-func TestWebsocketSubscriptionClientErrorArray(t *testing.T) {
-	serverDone := make(chan struct{})
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		conn, err := websocket.Accept(w, r, nil)
-		assert.NoError(t, err)
-		msgType, data, err := conn.Read(r.Context())
-		assert.NoError(t, err)
-		assert.Equal(t, websocket.MessageText, msgType)
-		assert.Equal(t, `{"type":"connection_init"}`, string(data))
-		err = conn.Write(r.Context(), websocket.MessageText, []byte(`{"type":"connection_ack"}`))
-		assert.NoError(t, err)
-		msgType, data, err = conn.Read(r.Context())
-		assert.NoError(t, err)
-		assert.Equal(t, websocket.MessageText, msgType)
-		assert.Equal(t, `{"type":"start","id":"1","payload":{"query":"subscription {messageAdded(roomNam: \"room\"){text}}"}}`, string(data))
-		err = conn.Write(r.Context(), websocket.MessageText, []byte(`{"type":"error","id":"1","payload":[{"message":"error"},{"message":"error"}]}`))
-		assert.NoError(t, err)
-		msgType, data, err = conn.Read(r.Context())
-		assert.NoError(t, err)
-		assert.Equal(t, websocket.MessageText, msgType)
-		assert.Equal(t, `{"type":"stop","id":"1"}`, string(data))
-		_, _, err = conn.Read(r.Context())
-		assert.NotNil(t, err)
-		close(serverDone)
-	}))
-	defer server.Close()
-	serverCtx, serverCancel := context.WithCancel(context.Background())
-	defer serverCancel()
-	clientCtx, clientCancel := context.WithCancel(context.Background())
-	client := NewWebSocketGraphQLSubscriptionClient(http.DefaultClient, serverCtx,
-		WithReadTimeout(time.Millisecond),
-		WithLogger(logger()),
-	)
-	next := make(chan []byte)
-	err := client.Subscribe(clientCtx, GraphQLSubscriptionOptions{
-		URL: strings.Replace(server.URL, "http", "ws", -1),
-		Body: GraphQLBody{
-			Query: `subscription {messageAdded(roomNam: "room"){text}}`,
-		},
-	}, next)
-	assert.NoError(t, err)
-	message := <-next
-	assert.Equal(t, `{"errors":[{"message":"error"},{"message":"error"}]}`, string(message))
-	clientCancel()
-	_, ok := <-next
-	assert.False(t, ok)
-	assert.Eventuallyf(t, func() bool {
-		<-serverDone
-		return true
-	}, time.Second, time.Millisecond*10, "server did not close")
-}
-
-func TestWebsocketSubscriptionClientErrorObject(t *testing.T) {
-	serverDone := make(chan struct{})
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		conn, err := websocket.Accept(w, r, nil)
-		assert.NoError(t, err)
-		msgType, data, err := conn.Read(r.Context())
-		assert.NoError(t, err)
-		assert.Equal(t, websocket.MessageText, msgType)
-		assert.Equal(t, `{"type":"connection_init"}`, string(data))
-		err = conn.Write(r.Context(), websocket.MessageText, []byte(`{"type":"connection_ack"}`))
-		assert.NoError(t, err)
-		msgType, data, err = conn.Read(r.Context())
-		assert.NoError(t, err)
-		assert.Equal(t, websocket.MessageText, msgType)
-		assert.Equal(t, `{"type":"start","id":"1","payload":{"query":"subscription {messageAdded(roomNam: \"room\"){text}}"}}`, string(data))
-		err = conn.Write(r.Context(), websocket.MessageText, []byte(`{"type":"error","id":"1","payload":{"message":"error"}}`))
-		assert.NoError(t, err)
-		msgType, data, err = conn.Read(r.Context())
-		assert.NoError(t, err)
-		assert.Equal(t, websocket.MessageText, msgType)
-		assert.Equal(t, `{"type":"stop","id":"1"}`, string(data))
-		_, _, err = conn.Read(r.Context())
-		assert.NotNil(t, err)
-		close(serverDone)
-	}))
-	defer server.Close()
-	serverCtx, serverCancel := context.WithCancel(context.Background())
-	defer serverCancel()
-	clientCtx, clientCancel := context.WithCancel(context.Background())
-	client := NewWebSocketGraphQLSubscriptionClient(http.DefaultClient, serverCtx,
-		WithReadTimeout(time.Millisecond),
-		WithLogger(logger()),
-	)
-	next := make(chan []byte)
-	err := client.Subscribe(clientCtx, GraphQLSubscriptionOptions{
-		URL: strings.Replace(server.URL, "http", "ws", -1),
-		Body: GraphQLBody{
-			Query: `subscription {messageAdded(roomNam: "room"){text}}`,
-		},
-	}, next)
-	assert.NoError(t, err)
-	message := <-next
-	assert.Equal(t, `{"errors":[{"message":"error"}]}`, string(message))
-	clientCancel()
-	_, ok := <-next
-	assert.False(t, ok)
-	assert.Eventuallyf(t, func() bool {
-		<-serverDone
-		return true
-	}, time.Second, time.Millisecond*10, "server did not close")
 }
 
 func TestWebsocketSubscriptionClientDeDuplication(t *testing.T) {
@@ -452,9 +115,10 @@ func TestWebsocketSubscriptionClientDeDuplication(t *testing.T) {
 	defer server.Close()
 	serverCtx, serverCancel := context.WithCancel(context.Background())
 	defer serverCancel()
-	client := NewWebSocketGraphQLSubscriptionClient(http.DefaultClient, serverCtx,
+	client := NewGraphQLSubscriptionClient(http.DefaultClient, serverCtx,
 		WithReadTimeout(time.Millisecond),
 		WithLogger(logger()),
+		WithWSSubProtocol(protocolGraphQLWS),
 	)
 	clientsDone := &sync.WaitGroup{}
 
@@ -496,4 +160,98 @@ func TestWebsocketSubscriptionClientDeDuplication(t *testing.T) {
 	assert.Eventuallyf(t, func() bool {
 		return connectedClients.Load() == 0
 	}, time.Second, time.Millisecond, "clients not 0")
+}
+
+func TestWebsocketSubscriptionClientImmediateClientCancel(t *testing.T) {
+	serverInvocations := atomic.NewInt64(0)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		serverInvocations.Inc()
+	}))
+	defer server.Close()
+	ctx, clientCancel := context.WithCancel(context.Background())
+	clientCancel()
+	serverCtx, serverCancel := context.WithCancel(context.Background())
+	defer serverCancel()
+	client := NewGraphQLSubscriptionClient(http.DefaultClient, serverCtx,
+		WithReadTimeout(time.Millisecond),
+		WithLogger(logger()),
+		WithWSSubProtocol(protocolGraphQLWS),
+	)
+	next := make(chan []byte)
+	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
+		URL: strings.Replace(server.URL, "http", "ws", -1),
+		Body: GraphQLBody{
+			Query: `subscription {messageAdded(roomName: "room"){text}}`,
+		},
+	}, next)
+	assert.Error(t, err)
+	assert.Eventuallyf(t, func() bool {
+		return serverInvocations.Load() == 0
+	}, time.Second, time.Millisecond*10, "server did not close")
+	serverCancel()
+	assert.Eventuallyf(t, func() bool {
+		return len(client.handlers) == 0
+	}, time.Second, time.Millisecond, "client handlers not 0")
+}
+
+func TestWebsocketSubscriptionClientWithServerDisconnect(t *testing.T) {
+	serverDone := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		assert.NoError(t, err)
+		ctx := context.Background()
+		msgType, data, err := conn.Read(ctx)
+		assert.NoError(t, err)
+		assert.Equal(t, websocket.MessageText, msgType)
+		assert.Equal(t, `{"type":"connection_init"}`, string(data))
+		err = conn.Write(r.Context(), websocket.MessageText, []byte(`{"type":"connection_ack"}`))
+		assert.NoError(t, err)
+		msgType, data, err = conn.Read(ctx)
+		assert.NoError(t, err)
+		assert.Equal(t, websocket.MessageText, msgType)
+		assert.Equal(t, `{"type":"start","id":"1","payload":{"query":"subscription {messageAdded(roomName: \"room\"){text}}"}}`, string(data))
+		err = conn.Write(r.Context(), websocket.MessageText, []byte(`{"type":"data","id":"1","payload":{"data":{"messageAdded":{"text":"first"}}}}`))
+		assert.NoError(t, err)
+		err = conn.Write(r.Context(), websocket.MessageText, []byte(`{"type":"data","id":"1","payload":{"data":{"messageAdded":{"text":"second"}}}}`))
+		assert.NoError(t, err)
+		err = conn.Write(r.Context(), websocket.MessageText, []byte(`{"type":"data","id":"1","payload":{"data":{"messageAdded":{"text":"third"}}}}`))
+		assert.NoError(t, err)
+
+		_, _, err = conn.Read(ctx)
+		assert.Error(t, err)
+		close(serverDone)
+	}))
+	defer server.Close()
+	ctx, clientCancel := context.WithCancel(context.Background())
+	defer clientCancel()
+	serverCtx, serverCancel := context.WithCancel(context.Background())
+	defer serverCancel()
+
+	client := NewGraphQLSubscriptionClient(http.DefaultClient, serverCtx,
+		WithReadTimeout(time.Millisecond),
+		WithLogger(logger()),
+		WithWSSubProtocol(protocolGraphQLWS),
+	)
+	next := make(chan []byte)
+	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
+		URL: strings.Replace(server.URL, "http", "ws", -1),
+		Body: GraphQLBody{
+			Query: `subscription {messageAdded(roomName: "room"){text}}`,
+		},
+	}, next)
+	assert.NoError(t, err)
+	first := <-next
+	second := <-next
+	third := <-next
+	assert.Equal(t, `{"data":{"messageAdded":{"text":"first"}}}`, string(first))
+	assert.Equal(t, `{"data":{"messageAdded":{"text":"second"}}}`, string(second))
+	assert.Equal(t, `{"data":{"messageAdded":{"text":"third"}}}`, string(third))
+	serverCancel()
+	assert.Eventuallyf(t, func() bool {
+		<-serverDone
+		return true
+	}, time.Second, time.Millisecond*10, "server did not close")
+	assert.Eventuallyf(t, func() bool {
+		return len(client.handlers) == 0
+	}, time.Second, time.Millisecond, "client handlers not 0")
 }

--- a/pkg/engine/datasource/graphql_datasource/graphql_subscription_client_test.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_subscription_client_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -115,7 +114,7 @@ func TestWebsocketSubscriptionClientDeDuplication(t *testing.T) {
 	defer server.Close()
 	serverCtx, serverCancel := context.WithCancel(context.Background())
 	defer serverCancel()
-	client := NewGraphQLSubscriptionClient(http.DefaultClient, serverCtx,
+	client := NewGraphQLSubscriptionClient(http.DefaultClient, http.DefaultClient, serverCtx,
 		WithReadTimeout(time.Millisecond),
 		WithLogger(logger()),
 		WithWSSubProtocol(protocolGraphQLWS),
@@ -125,7 +124,7 @@ func TestWebsocketSubscriptionClientDeDuplication(t *testing.T) {
 	next := make(chan []byte)
 	ctx, clientCancel := context.WithCancel(context.Background())
 	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
-		URL: strings.Replace(server.URL, "http", "ws", -1),
+		URL: server.URL,
 		Body: GraphQLBody{
 			Query: `subscription {messageAdded(roomName: "room"){text}}`,
 		},
@@ -140,7 +139,7 @@ func TestWebsocketSubscriptionClientDeDuplication(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 
 		err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
-			URL: strings.Replace(server.URL, "http", "ws", -1),
+			URL: server.URL,
 			Body: GraphQLBody{
 				Query: `subscription {messageAdded(roomName: "room"){text}}`,
 			},
@@ -172,14 +171,14 @@ func TestWebsocketSubscriptionClientImmediateClientCancel(t *testing.T) {
 	clientCancel()
 	serverCtx, serverCancel := context.WithCancel(context.Background())
 	defer serverCancel()
-	client := NewGraphQLSubscriptionClient(http.DefaultClient, serverCtx,
+	client := NewGraphQLSubscriptionClient(http.DefaultClient, http.DefaultClient, serverCtx,
 		WithReadTimeout(time.Millisecond),
 		WithLogger(logger()),
 		WithWSSubProtocol(protocolGraphQLWS),
 	)
 	next := make(chan []byte)
 	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
-		URL: strings.Replace(server.URL, "http", "ws", -1),
+		URL: server.URL,
 		Body: GraphQLBody{
 			Query: `subscription {messageAdded(roomName: "room"){text}}`,
 		},
@@ -227,14 +226,14 @@ func TestWebsocketSubscriptionClientWithServerDisconnect(t *testing.T) {
 	serverCtx, serverCancel := context.WithCancel(context.Background())
 	defer serverCancel()
 
-	client := NewGraphQLSubscriptionClient(http.DefaultClient, serverCtx,
+	client := NewGraphQLSubscriptionClient(http.DefaultClient, http.DefaultClient, serverCtx,
 		WithReadTimeout(time.Millisecond),
 		WithLogger(logger()),
 		WithWSSubProtocol(protocolGraphQLWS),
 	)
 	next := make(chan []byte)
 	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
-		URL: strings.Replace(server.URL, "http", "ws", -1),
+		URL: server.URL,
 		Body: GraphQLBody{
 			Query: `subscription {messageAdded(roomName: "room"){text}}`,
 		},

--- a/pkg/engine/datasource/graphql_datasource/graphql_tws_handler.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_tws_handler.go
@@ -1,0 +1,253 @@
+package graphql_datasource
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/buger/jsonparser"
+	log "github.com/jensneuse/abstractlogger"
+	"nhooyr.io/websocket"
+)
+
+// gqlTWSConnectionHandler is responsible for handling a connection to an origin
+// it is responsible for managing all subscriptions using the underlying WebSocket connection
+// if all Subscriptions are complete or cancelled/unsubscribed the handler will terminate
+type gqlTWSConnectionHandler struct {
+	conn               *websocket.Conn
+	ctx                context.Context
+	log                log.Logger
+	subscribeCh        chan Subscription
+	nextSubscriptionID int
+	subscriptions      map[string]Subscription
+	readTimeout        time.Duration
+}
+
+func newGQLTWSConnectionHandler(ctx context.Context, conn *websocket.Conn, rt time.Duration, l log.Logger) *gqlTWSConnectionHandler {
+	return &gqlTWSConnectionHandler{
+		conn:               conn,
+		ctx:                ctx,
+		log:                l,
+		subscribeCh:        make(chan Subscription),
+		nextSubscriptionID: 0,
+		subscriptions:      map[string]Subscription{},
+		readTimeout:        rt,
+	}
+}
+
+func (h *gqlTWSConnectionHandler) SubscribeCH() chan<- Subscription {
+	return h.subscribeCh
+}
+
+func (h *gqlTWSConnectionHandler) StartBlocking(sub Subscription) {
+	readCtx, cancel := context.WithCancel(h.ctx)
+	defer func() {
+		h.unsubscribeAllAndCloseConn()
+		cancel()
+	}()
+
+	h.subscribe(sub)
+	dataCh := make(chan []byte)
+	go h.readBlocking(readCtx, dataCh)
+
+	for {
+		if h.ctx.Err() != nil || !h.hasActiveSubscriptions() {
+			return
+		}
+
+		select {
+		case <-time.After(h.readTimeout):
+			continue
+		case sub = <-h.subscribeCh:
+			h.subscribe(sub)
+		case data := <-dataCh:
+			messageType, err := jsonparser.GetString(data, "type")
+			if err != nil {
+				continue
+			}
+
+			switch messageType {
+			case messageTypePing:
+				h.handleMessageTypePing()
+			case messageTypeNext:
+				h.handleMessageTypeNext(data)
+			case messageTypeComplete:
+				h.handleMessageTypeComplete(data)
+			case messageTypeError:
+				h.handleMessageTypeError(data)
+				continue
+			default:
+				h.log.Error("unknown message type", log.String("type", messageType))
+				continue
+			}
+		}
+	}
+}
+
+func (h *gqlTWSConnectionHandler) unsubscribeAllAndCloseConn() {
+	for id := range h.subscriptions {
+		h.unsubscribe(id)
+	}
+	_ = h.conn.Close(websocket.StatusNormalClosure, "")
+}
+
+func (h *gqlTWSConnectionHandler) unsubscribe(subscriptionID string) {
+	sub, ok := h.subscriptions[subscriptionID]
+	if !ok {
+		return
+	}
+	close(sub.next)
+	delete(h.subscriptions, subscriptionID)
+
+	req := fmt.Sprintf(completeMessage, subscriptionID)
+	err := h.conn.Write(h.ctx, websocket.MessageText, []byte(req))
+	if err != nil {
+		h.log.Error("failed to write complete message", log.Error(err))
+	}
+}
+
+// subscribe adds a new Subscription to the gqlTWSConnectionHandler and sends the subscribeMessage to the origin
+func (h *gqlTWSConnectionHandler) subscribe(sub Subscription) {
+	graphQLBody, err := json.Marshal(sub.options.Body)
+	if err != nil {
+		h.log.Error("failed to marshal GraphQL body", log.Error(err))
+		return
+	}
+
+	h.nextSubscriptionID++
+
+	subscriptionID := strconv.Itoa(h.nextSubscriptionID)
+
+	subscribeRequest := fmt.Sprintf(subscribeMessage, subscriptionID, string(graphQLBody))
+	err = h.conn.Write(h.ctx, websocket.MessageText, []byte(subscribeRequest))
+	if err != nil {
+		h.log.Error("failed to write subscribe message", log.Error(err))
+		return
+	}
+
+	h.subscriptions[subscriptionID] = sub
+}
+
+func (h *gqlTWSConnectionHandler) handleMessageTypeComplete(data []byte) {
+	id, err := jsonparser.GetString(data, "id")
+	if err != nil {
+		return
+	}
+	sub, ok := h.subscriptions[id]
+	if !ok {
+		return
+	}
+	close(sub.next)
+	delete(h.subscriptions, id)
+}
+
+func (h *gqlTWSConnectionHandler) handleMessageTypeError(data []byte) {
+	id, err := jsonparser.GetString(data, "id")
+	if err != nil {
+		return
+	}
+	sub, ok := h.subscriptions[id]
+	if !ok {
+		return
+	}
+
+	value, valueType, _, err := jsonparser.Get(data, "payload")
+	if err != nil {
+		h.log.Error(
+			"failed to get payload from error message",
+			log.Error(err),
+			log.ByteString("raw message", data),
+		)
+		sub.next <- []byte(internalError)
+		return
+	}
+
+	switch valueType {
+	case jsonparser.Array:
+		response := []byte(`{}`)
+		response, err = jsonparser.Set(response, value, "errors")
+		if err != nil {
+			h.log.Error(
+				"failed to set errors response",
+				log.Error(err),
+				log.ByteString("raw message", value),
+			)
+			sub.next <- []byte(internalError)
+			return
+		}
+		sub.next <- response
+	default:
+		sub.next <- []byte(internalError)
+	}
+}
+
+func (h *gqlTWSConnectionHandler) handleMessageTypePing() {
+	err := h.conn.Write(h.ctx, websocket.MessageText, []byte(pongMessage))
+	if err != nil {
+		h.log.Error("failed to write pong message", log.Error(err))
+	}
+}
+
+func (h *gqlTWSConnectionHandler) handleMessageTypeNext(data []byte) {
+	id, err := jsonparser.GetString(data, "id")
+	if err != nil {
+		return
+	}
+	sub, ok := h.subscriptions[id]
+	if !ok {
+		return
+	}
+
+	value, _, _, err := jsonparser.Get(data, "payload")
+	if err != nil {
+		h.log.Error(
+			"failed to get payload from next message",
+			log.Error(err),
+		)
+		sub.next <- []byte(internalError)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(h.ctx, time.Second*5)
+	defer cancel()
+
+	select {
+	case <-ctx.Done():
+	case sub.next <- value:
+	case <-sub.ctx.Done():
+	}
+}
+
+// readBlocking is a dedicated loop running in a separate goroutine
+// because the library "nhooyr.io/websocket" doesn't allow reading with a context with Timeout
+// we'll block forever on reading until the context of the gqlTWSConnectionHandler stops
+func (h *gqlTWSConnectionHandler) readBlocking(ctx context.Context, dataCh chan []byte) {
+	for {
+		msgType, data, err := h.conn.Read(ctx)
+		if ctx.Err() != nil {
+			return
+		}
+		if err != nil {
+			continue
+		}
+		if msgType != websocket.MessageText {
+			continue
+		}
+		select {
+		case dataCh <- data:
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (h *gqlTWSConnectionHandler) hasActiveSubscriptions() (hasActiveSubscriptions bool) {
+	for id, sub := range h.subscriptions {
+		if sub.ctx.Err() != nil {
+			h.unsubscribe(id)
+		}
+	}
+	return len(h.subscriptions) != 0
+}

--- a/pkg/engine/datasource/graphql_datasource/graphql_tws_handler_test.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_tws_handler_test.go
@@ -1,0 +1,303 @@
+package graphql_datasource
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+	"nhooyr.io/websocket"
+)
+
+func TestWebsocketSubscriptionClient_GQLTWS(t *testing.T) {
+	serverDone := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		assert.NoError(t, err)
+
+		ctx := context.Background()
+		msgType, data, err := conn.Read(ctx)
+		assert.NoError(t, err)
+		assert.Equal(t, websocket.MessageText, msgType)
+		assert.Equal(t, `{"type":"connection_init"}`, string(data))
+
+		err = conn.Write(r.Context(), websocket.MessageText, []byte(`{"type":"connection_ack"}`))
+		assert.NoError(t, err)
+
+		msgType, data, err = conn.Read(ctx)
+		assert.NoError(t, err)
+		assert.Equal(t, websocket.MessageText, msgType)
+		assert.Equal(t, `{"id":"1","type":"subscribe","payload":{"query":"subscription {messageAdded(roomName: \"room\"){text}}"}}`, string(data))
+
+		err = conn.Write(r.Context(), websocket.MessageText, []byte(`{"id":"1","type":"next","payload":{"data":{"messageAdded":{"text":"first"}}}}`))
+		assert.NoError(t, err)
+		err = conn.Write(r.Context(), websocket.MessageText, []byte(`{"id":"1","type":"next","payload":{"data":{"messageAdded":{"text":"second"}}}}`))
+		assert.NoError(t, err)
+		err = conn.Write(r.Context(), websocket.MessageText, []byte(`{"id":"1","type":"next","payload":{"data":{"messageAdded":{"text":"third"}}}}`))
+		assert.NoError(t, err)
+
+		msgType, data, err = conn.Read(ctx)
+		assert.NoError(t, err)
+		assert.Equal(t, websocket.MessageText, msgType)
+		assert.Equal(t, `{"id":"1","type":"complete"}`, string(data))
+		close(serverDone)
+	}))
+	defer server.Close()
+	ctx, clientCancel := context.WithCancel(context.Background())
+
+	serverCtx, serverCancel := context.WithCancel(context.Background())
+
+	client := NewGraphQLSubscriptionClient(http.DefaultClient, serverCtx,
+		WithReadTimeout(time.Millisecond),
+		WithLogger(logger()),
+		WithWSSubProtocol(protocolGraphQLTWS),
+	)
+
+	next := make(chan []byte)
+	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
+		URL: strings.Replace(server.URL, "http", "ws", -1),
+		Body: GraphQLBody{
+			Query: `subscription {messageAdded(roomName: "room"){text}}`,
+		},
+	}, next)
+	assert.NoError(t, err)
+
+	first := <-next
+	second := <-next
+	third := <-next
+	assert.Equal(t, `{"data":{"messageAdded":{"text":"first"}}}`, string(first))
+	assert.Equal(t, `{"data":{"messageAdded":{"text":"second"}}}`, string(second))
+	assert.Equal(t, `{"data":{"messageAdded":{"text":"third"}}}`, string(third))
+
+	clientCancel()
+	assert.Eventuallyf(t, func() bool {
+		<-serverDone
+		return true
+	}, time.Second, time.Millisecond*10, "server did not close")
+	serverCancel()
+	assert.Eventuallyf(t, func() bool {
+		return len(client.handlers) == 0
+	}, time.Second, time.Millisecond, "client handlers not 0")
+}
+
+func TestWebsocketSubscriptionClientPing_GQLTWS(t *testing.T) {
+	serverDone := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		assert.NoError(t, err)
+
+		ctx := context.Background()
+		msgType, data, err := conn.Read(ctx)
+		assert.NoError(t, err)
+		assert.Equal(t, websocket.MessageText, msgType)
+		assert.Equal(t, `{"type":"connection_init"}`, string(data))
+
+		err = conn.Write(r.Context(), websocket.MessageText, []byte(`{"type":"connection_ack"}`))
+		assert.NoError(t, err)
+
+		msgType, data, err = conn.Read(ctx)
+		assert.NoError(t, err)
+		assert.Equal(t, websocket.MessageText, msgType)
+		assert.Equal(t, `{"id":"1","type":"subscribe","payload":{"query":"subscription {messageAdded(roomName: \"room\"){text}}"}}`, string(data))
+
+		err = conn.Write(r.Context(), websocket.MessageText, []byte(`{"id":"1","type":"next","payload":{"data":{"messageAdded":{"text":"first"}}}}`))
+		assert.NoError(t, err)
+
+		err = conn.Write(r.Context(), websocket.MessageText, []byte(`{"type":"ping"}`))
+		assert.NoError(t, err)
+
+		msgType, data, err = conn.Read(ctx)
+		assert.NoError(t, err)
+		assert.Equal(t, websocket.MessageText, msgType)
+		assert.Equal(t, `{"type":"pong"}`, string(data))
+
+		msgType, data, err = conn.Read(ctx)
+		assert.NoError(t, err)
+		assert.Equal(t, websocket.MessageText, msgType)
+		assert.Equal(t, `{"id":"1","type":"complete"}`, string(data))
+		close(serverDone)
+	}))
+	defer server.Close()
+	ctx, clientCancel := context.WithCancel(context.Background())
+
+	serverCtx, serverCancel := context.WithCancel(context.Background())
+
+	client := NewGraphQLSubscriptionClient(http.DefaultClient, serverCtx,
+		WithReadTimeout(time.Millisecond),
+		WithLogger(logger()),
+		WithWSSubProtocol(protocolGraphQLTWS),
+	)
+
+	next := make(chan []byte)
+	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
+		URL: strings.Replace(server.URL, "http", "ws", -1),
+		Body: GraphQLBody{
+			Query: `subscription {messageAdded(roomName: "room"){text}}`,
+		},
+	}, next)
+	assert.NoError(t, err)
+
+	first := <-next
+	assert.Equal(t, `{"data":{"messageAdded":{"text":"first"}}}`, string(first))
+
+	clientCancel()
+	assert.Eventuallyf(t, func() bool {
+		<-serverDone
+		return true
+	}, time.Second, time.Millisecond*10, "server did not close")
+	serverCancel()
+	assert.Eventuallyf(t, func() bool {
+		return len(client.handlers) == 0
+	}, time.Second, time.Millisecond, "client handlers not 0")
+}
+
+func TestWebsocketSubscriptionClientError_GQLTWS(t *testing.T) {
+	serverDone := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		assert.NoError(t, err)
+
+		msgType, data, err := conn.Read(r.Context())
+		assert.NoError(t, err)
+		assert.Equal(t, websocket.MessageText, msgType)
+		assert.Equal(t, `{"type":"connection_init"}`, string(data))
+
+		err = conn.Write(r.Context(), websocket.MessageText, []byte(`{"type":"connection_ack"}`))
+		assert.NoError(t, err)
+
+		msgType, data, err = conn.Read(r.Context())
+		assert.NoError(t, err)
+		assert.Equal(t, websocket.MessageText, msgType)
+		assert.Equal(t, `{"id":"1","type":"subscribe","payload":{"query":"wrongQuery {messageAdded(roomName: \"room\"){text}}"}}`, string(data))
+
+		err = conn.Write(r.Context(), websocket.MessageText, []byte(`{"payload":[{"message":"Unexpected Name \"wrongQuery\"","locations":[{"line":1,"column":1}],"extensions":{"code":"GRAPHQL_PARSE_FAILED"}}],"id":"1","type":"error"}`))
+		assert.NoError(t, err)
+
+		err = conn.Write(r.Context(), websocket.MessageText, []byte(`{"id":"1",type":"complete"}`))
+		assert.NoError(t, err)
+
+		close(serverDone)
+	}))
+	defer server.Close()
+
+	serverCtx, serverCancel := context.WithCancel(context.Background())
+
+	clientCtx, clientCancel := context.WithCancel(context.Background())
+	client := NewGraphQLSubscriptionClient(http.DefaultClient, serverCtx,
+		WithReadTimeout(time.Millisecond),
+		WithLogger(logger()),
+		WithWSSubProtocol(protocolGraphQLTWS),
+	)
+
+	next := make(chan []byte)
+	err := client.Subscribe(clientCtx, GraphQLSubscriptionOptions{
+		URL: strings.Replace(server.URL, "http", "ws", -1),
+		Body: GraphQLBody{
+			Query: `wrongQuery {messageAdded(roomName: "room"){text}}`,
+		},
+	}, next)
+	assert.NoError(t, err)
+
+	message := <-next
+	assert.Equal(t, `{"errors":[{"message":"Unexpected Name \"wrongQuery\"","locations":[{"line":1,"column":1}],"extensions":{"code":"GRAPHQL_PARSE_FAILED"}}]}`, string(message))
+
+	clientCancel()
+	_, ok := <-next
+	assert.False(t, ok)
+
+	serverCancel()
+	assert.Eventuallyf(t, func() bool {
+		<-serverDone
+		return true
+	}, time.Second, time.Millisecond*10, "server did not close")
+}
+
+func TestWebSocketSubscriptionClientInitIncludePing_GQLTWS(t *testing.T) {
+	serverDone := make(chan struct{})
+	assertion := require.New(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		assertion.NoError(err)
+
+		// write "ping" every second
+		go func() {
+			for {
+				err := conn.Write(r.Context(), websocket.MessageText, []byte(`{"type":"ping"}`))
+				if err != nil {
+					break
+				}
+				time.Sleep(time.Second)
+			}
+		}()
+
+		ctx := context.Background()
+		msgType, data, err := conn.Read(ctx)
+		assertion.NoError(err)
+
+		assertion.Equal(websocket.MessageText, msgType)
+		assertion.Equal(`{"type":"connection_init"}`, string(data))
+
+		err = conn.Write(r.Context(), websocket.MessageText, []byte(`{"type":"connection_ack"}`))
+		assertion.NoError(err)
+
+		msgType, data, err = conn.Read(ctx)
+		assertion.NoError(err)
+		assertion.Equal(websocket.MessageText, msgType)
+		assertion.Equal(`{"type":"pong"}`, string(data))
+
+		msgType, data, err = conn.Read(ctx)
+		assertion.NoError(err)
+		assertion.Equal(websocket.MessageText, msgType)
+		assertion.Equal(`{"id":"1","type":"subscribe","payload":{"query":"subscription {messageAdded(roomName: \"room\"){text}}"}}`, string(data))
+
+		err = conn.Write(r.Context(), websocket.MessageText, []byte(`{"id":"1","type":"next","payload":{"data":{"messageAdded":{"text":"first"}}}}`))
+		assertion.NoError(err)
+
+		err = conn.Write(r.Context(), websocket.MessageText, []byte(`{"id":"1","type":"next","payload":{"data":{"messageAdded":{"text":"second"}}}}`))
+		assertion.NoError(err)
+
+		msgType, data, err = conn.Read(ctx)
+		assertion.NoError(err)
+		assertion.Equal(websocket.MessageText, msgType)
+		assertion.Equal(`{"id":"1","type":"complete"}`, string(data))
+		close(serverDone)
+	}))
+
+	defer server.Close()
+	ctx, clientCancel := context.WithCancel(context.Background())
+	serverCtx, serverCancel := context.WithCancel(context.Background())
+
+	client := NewGraphQLSubscriptionClient(http.DefaultClient, serverCtx,
+		WithReadTimeout(time.Millisecond),
+		WithLogger(logger()),
+		WithWSSubProtocol(protocolGraphQLTWS),
+	)
+	next := make(chan []byte)
+	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
+		URL: strings.Replace(server.URL, "http", "ws", -1),
+		Body: GraphQLBody{
+			Query: `subscription {messageAdded(roomName: "room"){text}}`,
+		},
+	}, next)
+	assertion.NoError(err)
+
+	first := <-next
+	second := <-next
+	assertion.Equal(`{"data":{"messageAdded":{"text":"first"}}}`, string(first))
+	assertion.Equal(`{"data":{"messageAdded":{"text":"second"}}}`, string(second))
+
+	clientCancel()
+	assertion.Eventuallyf(func() bool {
+		<-serverDone
+		return true
+	}, time.Second, time.Millisecond*10, "server did not close")
+	serverCancel()
+	assertion.Eventuallyf(func() bool {
+		return len(client.handlers) == 0
+	}, time.Second, time.Millisecond, "client handlers not 0")
+}

--- a/pkg/engine/datasource/graphql_datasource/graphql_tws_handler_test.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_tws_handler_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 	"time"
 
@@ -52,7 +51,7 @@ func TestWebsocketSubscriptionClient_GQLTWS(t *testing.T) {
 
 	serverCtx, serverCancel := context.WithCancel(context.Background())
 
-	client := NewGraphQLSubscriptionClient(http.DefaultClient, serverCtx,
+	client := NewGraphQLSubscriptionClient(http.DefaultClient, http.DefaultClient, serverCtx,
 		WithReadTimeout(time.Millisecond),
 		WithLogger(logger()),
 		WithWSSubProtocol(protocolGraphQLTWS),
@@ -60,7 +59,7 @@ func TestWebsocketSubscriptionClient_GQLTWS(t *testing.T) {
 
 	next := make(chan []byte)
 	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
-		URL: strings.Replace(server.URL, "http", "ws", -1),
+		URL: server.URL,
 		Body: GraphQLBody{
 			Query: `subscription {messageAdded(roomName: "room"){text}}`,
 		},
@@ -127,7 +126,7 @@ func TestWebsocketSubscriptionClientPing_GQLTWS(t *testing.T) {
 
 	serverCtx, serverCancel := context.WithCancel(context.Background())
 
-	client := NewGraphQLSubscriptionClient(http.DefaultClient, serverCtx,
+	client := NewGraphQLSubscriptionClient(http.DefaultClient, http.DefaultClient, serverCtx,
 		WithReadTimeout(time.Millisecond),
 		WithLogger(logger()),
 		WithWSSubProtocol(protocolGraphQLTWS),
@@ -135,7 +134,7 @@ func TestWebsocketSubscriptionClientPing_GQLTWS(t *testing.T) {
 
 	next := make(chan []byte)
 	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
-		URL: strings.Replace(server.URL, "http", "ws", -1),
+		URL: server.URL,
 		Body: GraphQLBody{
 			Query: `subscription {messageAdded(roomName: "room"){text}}`,
 		},
@@ -188,7 +187,7 @@ func TestWebsocketSubscriptionClientError_GQLTWS(t *testing.T) {
 	serverCtx, serverCancel := context.WithCancel(context.Background())
 
 	clientCtx, clientCancel := context.WithCancel(context.Background())
-	client := NewGraphQLSubscriptionClient(http.DefaultClient, serverCtx,
+	client := NewGraphQLSubscriptionClient(http.DefaultClient, http.DefaultClient, serverCtx,
 		WithReadTimeout(time.Millisecond),
 		WithLogger(logger()),
 		WithWSSubProtocol(protocolGraphQLTWS),
@@ -196,7 +195,7 @@ func TestWebsocketSubscriptionClientError_GQLTWS(t *testing.T) {
 
 	next := make(chan []byte)
 	err := client.Subscribe(clientCtx, GraphQLSubscriptionOptions{
-		URL: strings.Replace(server.URL, "http", "ws", -1),
+		URL: server.URL,
 		Body: GraphQLBody{
 			Query: `wrongQuery {messageAdded(roomName: "room"){text}}`,
 		},
@@ -272,14 +271,14 @@ func TestWebSocketSubscriptionClientInitIncludePing_GQLTWS(t *testing.T) {
 	ctx, clientCancel := context.WithCancel(context.Background())
 	serverCtx, serverCancel := context.WithCancel(context.Background())
 
-	client := NewGraphQLSubscriptionClient(http.DefaultClient, serverCtx,
+	client := NewGraphQLSubscriptionClient(http.DefaultClient, http.DefaultClient, serverCtx,
 		WithReadTimeout(time.Millisecond),
 		WithLogger(logger()),
 		WithWSSubProtocol(protocolGraphQLTWS),
 	)
 	next := make(chan []byte)
 	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
-		URL: strings.Replace(server.URL, "http", "ws", -1),
+		URL: server.URL,
 		Body: GraphQLBody{
 			Query: `subscription {messageAdded(roomName: "room"){text}}`,
 		},

--- a/pkg/engine/datasource/graphql_datasource/graphql_ws_handler.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_ws_handler.go
@@ -1,0 +1,245 @@
+package graphql_datasource
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/buger/jsonparser"
+	"github.com/jensneuse/abstractlogger"
+	"nhooyr.io/websocket"
+)
+
+// gqlWSConnectionHandler is responsible for handling a connection to an origin
+// it is responsible for managing all subscriptions using the underlying WebSocket connection
+// if all Subscriptions are complete or cancelled/unsubscribed the handler will terminate
+type gqlWSConnectionHandler struct {
+	conn               *websocket.Conn
+	ctx                context.Context
+	log                abstractlogger.Logger
+	subscribeCh        chan Subscription
+	nextSubscriptionID int
+	subscriptions      map[string]Subscription
+	readTimeout        time.Duration
+}
+
+func newGQLWSConnectionHandler(ctx context.Context, conn *websocket.Conn, readTimeout time.Duration, log abstractlogger.Logger) *gqlWSConnectionHandler {
+	return &gqlWSConnectionHandler{
+		conn:               conn,
+		ctx:                ctx,
+		log:                log,
+		subscribeCh:        make(chan Subscription),
+		nextSubscriptionID: 0,
+		subscriptions:      map[string]Subscription{},
+		readTimeout:        readTimeout,
+	}
+}
+
+func (h *gqlWSConnectionHandler) SubscribeCH() chan<- Subscription {
+	return h.subscribeCh
+}
+
+// StartBlocking starts the single threaded event loop of the handler
+// if the global context returns or the websocket connection is terminated, it will stop
+func (h *gqlWSConnectionHandler) StartBlocking(sub Subscription) {
+	readCtx, cancel := context.WithCancel(h.ctx)
+	defer func() {
+		h.unsubscribeAllAndCloseConn()
+		cancel()
+	}()
+	h.subscribe(sub)
+	dataCh := make(chan []byte)
+	go h.readBlocking(readCtx, dataCh)
+	for {
+		if h.ctx.Err() != nil {
+			return
+		}
+		hasActiveSubscriptions := h.checkActiveSubscriptions()
+		if !hasActiveSubscriptions {
+			return
+		}
+		select {
+		case <-time.After(h.readTimeout):
+			continue
+		case sub = <-h.subscribeCh:
+			h.subscribe(sub)
+		case data := <-dataCh:
+			messageType, err := jsonparser.GetString(data, "type")
+			if err != nil {
+				continue
+			}
+			switch messageType {
+			case messageTypeData:
+				h.handleMessageTypeData(data)
+			case messageTypeComplete:
+				h.handleMessageTypeComplete(data)
+			case messageTypeConnectionError:
+				h.handleMessageTypeConnectionError()
+				return
+			case messageTypeError:
+				h.handleMessageTypeError(data)
+				continue
+			default:
+				continue
+			}
+		}
+	}
+}
+
+// readBlocking is a dedicated loop running in a separate goroutine
+// because the library "nhooyr.io/websocket" doesn't allow reading with a context with Timeout
+// we'll block forever on reading until the context of the gqlWSConnectionHandler stops
+func (h *gqlWSConnectionHandler) readBlocking(ctx context.Context, dataCh chan []byte) {
+	for {
+		msgType, data, err := h.conn.Read(ctx)
+		if ctx.Err() != nil {
+			return
+		}
+		if err != nil {
+			continue
+		}
+		if msgType != websocket.MessageText {
+			continue
+		}
+		select {
+		case dataCh <- data:
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (h *gqlWSConnectionHandler) unsubscribeAllAndCloseConn() {
+	for id := range h.subscriptions {
+		h.unsubscribe(id)
+	}
+	_ = h.conn.Close(websocket.StatusNormalClosure, "")
+}
+
+// subscribe adds a new Subscription to the gqlWSConnectionHandler and sends the startMessage to the origin
+func (h *gqlWSConnectionHandler) subscribe(sub Subscription) {
+	graphQLBody, err := json.Marshal(sub.options.Body)
+	if err != nil {
+		return
+	}
+
+	h.nextSubscriptionID++
+
+	subscriptionID := strconv.Itoa(h.nextSubscriptionID)
+
+	startRequest := fmt.Sprintf(startMessage, subscriptionID, string(graphQLBody))
+	err = h.conn.Write(h.ctx, websocket.MessageText, []byte(startRequest))
+	if err != nil {
+		return
+	}
+
+	h.subscriptions[subscriptionID] = sub
+}
+
+func (h *gqlWSConnectionHandler) handleMessageTypeData(data []byte) {
+	id, err := jsonparser.GetString(data, "id")
+	if err != nil {
+		return
+	}
+	sub, ok := h.subscriptions[id]
+	if !ok {
+		return
+	}
+	payload, _, _, err := jsonparser.Get(data, "payload")
+	if err != nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(h.ctx, time.Second*5)
+	defer cancel()
+
+	select {
+	case <-ctx.Done():
+	case sub.next <- payload:
+	case <-sub.ctx.Done():
+	}
+}
+
+func (h *gqlWSConnectionHandler) handleMessageTypeConnectionError() {
+	for _, sub := range h.subscriptions {
+		ctx, cancel := context.WithTimeout(h.ctx, time.Second*5)
+		select {
+		case sub.next <- []byte(connectionError):
+			cancel()
+			continue
+		case <-ctx.Done():
+			cancel()
+			continue
+		}
+	}
+}
+
+func (h *gqlWSConnectionHandler) handleMessageTypeComplete(data []byte) {
+	id, err := jsonparser.GetString(data, "id")
+	if err != nil {
+		return
+	}
+	sub, ok := h.subscriptions[id]
+	if !ok {
+		return
+	}
+	close(sub.next)
+	delete(h.subscriptions, id)
+}
+
+func (h *gqlWSConnectionHandler) handleMessageTypeError(data []byte) {
+	id, err := jsonparser.GetString(data, "id")
+	if err != nil {
+		return
+	}
+	sub, ok := h.subscriptions[id]
+	if !ok {
+		return
+	}
+	value, valueType, _, err := jsonparser.Get(data, "payload")
+	if err != nil {
+		sub.next <- []byte(internalError)
+		return
+	}
+	switch valueType {
+	case jsonparser.Array:
+		response := []byte(`{}`)
+		response, err = jsonparser.Set(response, value, "errors")
+		if err != nil {
+			sub.next <- []byte(internalError)
+			return
+		}
+		sub.next <- response
+	case jsonparser.Object:
+		response := []byte(`{"errors":[]}`)
+		response, err = jsonparser.Set(response, value, "errors", "[0]")
+		if err != nil {
+			sub.next <- []byte(internalError)
+			return
+		}
+		sub.next <- response
+	default:
+		sub.next <- []byte(internalError)
+	}
+}
+
+func (h *gqlWSConnectionHandler) unsubscribe(subscriptionID string) {
+	sub, ok := h.subscriptions[subscriptionID]
+	if !ok {
+		return
+	}
+	close(sub.next)
+	delete(h.subscriptions, subscriptionID)
+	stopRequest := fmt.Sprintf(stopMessage, subscriptionID)
+	_ = h.conn.Write(h.ctx, websocket.MessageText, []byte(stopRequest))
+}
+
+func (h *gqlWSConnectionHandler) checkActiveSubscriptions() (hasActiveSubscriptions bool) {
+	for id, sub := range h.subscriptions {
+		if sub.ctx.Err() != nil {
+			h.unsubscribe(id)
+		}
+	}
+	return len(h.subscriptions) != 0
+}

--- a/pkg/engine/datasource/graphql_datasource/graphql_ws_handler_test.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_ws_handler_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 	"time"
 
@@ -63,14 +62,14 @@ func TestWebSocketSubscriptionClientInitIncludeKA_GQLWS(t *testing.T) {
 	serverCtx, serverCancel := context.WithCancel(context.Background())
 	defer serverCancel()
 
-	client := NewGraphQLSubscriptionClient(http.DefaultClient, serverCtx,
+	client := NewGraphQLSubscriptionClient(http.DefaultClient, http.DefaultClient, serverCtx,
 		WithReadTimeout(time.Millisecond),
 		WithLogger(logger()),
 		WithWSSubProtocol(protocolGraphQLWS),
 	)
 	next := make(chan []byte)
 	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
-		URL: strings.Replace(server.URL, "http", "ws", -1),
+		URL: server.URL,
 		Body: GraphQLBody{
 			Query: `subscription {messageAdded(roomName: "room"){text}}`,
 		},
@@ -126,14 +125,14 @@ func TestWebsocketSubscriptionClient_GQLWS(t *testing.T) {
 	serverCtx, serverCancel := context.WithCancel(context.Background())
 	defer serverCancel()
 
-	client := NewGraphQLSubscriptionClient(http.DefaultClient, serverCtx,
+	client := NewGraphQLSubscriptionClient(http.DefaultClient, http.DefaultClient, serverCtx,
 		WithReadTimeout(time.Millisecond),
 		WithLogger(logger()),
 		WithWSSubProtocol(protocolGraphQLWS),
 	)
 	next := make(chan []byte)
 	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
-		URL: strings.Replace(server.URL, "http", "ws", -1),
+		URL: server.URL,
 		Body: GraphQLBody{
 			Query: `subscription {messageAdded(roomName: "room"){text}}`,
 		},
@@ -185,14 +184,14 @@ func TestWebsocketSubscriptionClientErrorArray(t *testing.T) {
 	serverCtx, serverCancel := context.WithCancel(context.Background())
 	defer serverCancel()
 	clientCtx, clientCancel := context.WithCancel(context.Background())
-	client := NewGraphQLSubscriptionClient(http.DefaultClient, serverCtx,
+	client := NewGraphQLSubscriptionClient(http.DefaultClient, http.DefaultClient, serverCtx,
 		WithReadTimeout(time.Millisecond),
 		WithLogger(logger()),
 		WithWSSubProtocol(protocolGraphQLWS),
 	)
 	next := make(chan []byte)
 	err := client.Subscribe(clientCtx, GraphQLSubscriptionOptions{
-		URL: strings.Replace(server.URL, "http", "ws", -1),
+		URL: server.URL,
 		Body: GraphQLBody{
 			Query: `subscription {messageAdded(roomNam: "room"){text}}`,
 		},
@@ -238,14 +237,14 @@ func TestWebsocketSubscriptionClientErrorObject(t *testing.T) {
 	serverCtx, serverCancel := context.WithCancel(context.Background())
 	defer serverCancel()
 	clientCtx, clientCancel := context.WithCancel(context.Background())
-	client := NewGraphQLSubscriptionClient(http.DefaultClient, serverCtx,
+	client := NewGraphQLSubscriptionClient(http.DefaultClient, http.DefaultClient, serverCtx,
 		WithReadTimeout(time.Millisecond),
 		WithLogger(logger()),
 		WithWSSubProtocol(protocolGraphQLWS),
 	)
 	next := make(chan []byte)
 	err := client.Subscribe(clientCtx, GraphQLSubscriptionOptions{
-		URL: strings.Replace(server.URL, "http", "ws", -1),
+		URL: server.URL,
 		Body: GraphQLBody{
 			Query: `subscription {messageAdded(roomNam: "room"){text}}`,
 		},

--- a/pkg/engine/datasource/graphql_datasource/graphql_ws_handler_test.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_ws_handler_test.go
@@ -1,0 +1,263 @@
+package graphql_datasource
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+	"nhooyr.io/websocket"
+)
+
+func TestWebSocketSubscriptionClientInitIncludeKA_GQLWS(t *testing.T) {
+	serverDone := make(chan struct{})
+	assertion := require.New(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		assertion.NoError(err)
+
+		// write "ka" every second
+		go func() {
+			for {
+				err := conn.Write(r.Context(), websocket.MessageText, []byte(`{"type":"ka"}`))
+				if err != nil {
+					break
+				}
+				time.Sleep(time.Second)
+			}
+		}()
+		ctx := context.Background()
+		msgType, data, err := conn.Read(ctx)
+		assertion.NoError(err)
+		assertion.Equal(websocket.MessageText, msgType)
+		assertion.Equal(`{"type":"connection_init"}`, string(data))
+
+		err = conn.Write(r.Context(), websocket.MessageText, []byte(`{"type":"connection_ack"}`))
+		assertion.NoError(err)
+
+		msgType, data, err = conn.Read(ctx)
+		assertion.NoError(err)
+		assertion.Equal(websocket.MessageText, msgType)
+		assertion.Equal(`{"type":"start","id":"1","payload":{"query":"subscription {messageAdded(roomName: \"room\"){text}}"}}`, string(data))
+		err = conn.Write(r.Context(), websocket.MessageText, []byte(`{"type":"data","id":"1","payload":{"data":{"messageAdded":{"text":"first"}}}}`))
+		assertion.NoError(err)
+		err = conn.Write(r.Context(), websocket.MessageText, []byte(`{"type":"data","id":"1","payload":{"data":{"messageAdded":{"text":"second"}}}}`))
+		assertion.NoError(err)
+		assertion.NoError(err)
+
+		msgType, data, err = conn.Read(ctx)
+		assertion.NoError(err)
+		assertion.Equal(websocket.MessageText, msgType)
+		assertion.Equal(`{"type":"stop","id":"1"}`, string(data))
+		close(serverDone)
+	}))
+
+	defer server.Close()
+	ctx, clientCancel := context.WithCancel(context.Background())
+	defer clientCancel()
+	serverCtx, serverCancel := context.WithCancel(context.Background())
+	defer serverCancel()
+
+	client := NewGraphQLSubscriptionClient(http.DefaultClient, serverCtx,
+		WithReadTimeout(time.Millisecond),
+		WithLogger(logger()),
+		WithWSSubProtocol(protocolGraphQLWS),
+	)
+	next := make(chan []byte)
+	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
+		URL: strings.Replace(server.URL, "http", "ws", -1),
+		Body: GraphQLBody{
+			Query: `subscription {messageAdded(roomName: "room"){text}}`,
+		},
+	}, next)
+	assertion.NoError(err)
+	first := <-next
+	second := <-next
+	assertion.Equal(`{"data":{"messageAdded":{"text":"first"}}}`, string(first))
+	assertion.Equal(`{"data":{"messageAdded":{"text":"second"}}}`, string(second))
+	clientCancel()
+	assertion.Eventuallyf(func() bool {
+		<-serverDone
+		return true
+	}, time.Second, time.Millisecond*10, "server did not close")
+	serverCancel()
+	assertion.Eventuallyf(func() bool {
+		return len(client.handlers) == 0
+	}, time.Second, time.Millisecond, "client handlers not 0")
+}
+
+func TestWebsocketSubscriptionClient_GQLWS(t *testing.T) {
+	serverDone := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		assert.NoError(t, err)
+		ctx := context.Background()
+		msgType, data, err := conn.Read(ctx)
+		assert.NoError(t, err)
+		assert.Equal(t, websocket.MessageText, msgType)
+		assert.Equal(t, `{"type":"connection_init"}`, string(data))
+		err = conn.Write(r.Context(), websocket.MessageText, []byte(`{"type":"connection_ack"}`))
+		assert.NoError(t, err)
+		msgType, data, err = conn.Read(ctx)
+		assert.NoError(t, err)
+		assert.Equal(t, websocket.MessageText, msgType)
+		assert.Equal(t, `{"type":"start","id":"1","payload":{"query":"subscription {messageAdded(roomName: \"room\"){text}}"}}`, string(data))
+		err = conn.Write(r.Context(), websocket.MessageText, []byte(`{"type":"data","id":"1","payload":{"data":{"messageAdded":{"text":"first"}}}}`))
+		assert.NoError(t, err)
+		err = conn.Write(r.Context(), websocket.MessageText, []byte(`{"type":"data","id":"1","payload":{"data":{"messageAdded":{"text":"second"}}}}`))
+		assert.NoError(t, err)
+		err = conn.Write(r.Context(), websocket.MessageText, []byte(`{"type":"data","id":"1","payload":{"data":{"messageAdded":{"text":"third"}}}}`))
+		assert.NoError(t, err)
+
+		msgType, data, err = conn.Read(ctx)
+		assert.NoError(t, err)
+		assert.Equal(t, websocket.MessageText, msgType)
+		assert.Equal(t, `{"type":"stop","id":"1"}`, string(data))
+		close(serverDone)
+	}))
+	defer server.Close()
+	ctx, clientCancel := context.WithCancel(context.Background())
+
+	serverCtx, serverCancel := context.WithCancel(context.Background())
+	defer serverCancel()
+
+	client := NewGraphQLSubscriptionClient(http.DefaultClient, serverCtx,
+		WithReadTimeout(time.Millisecond),
+		WithLogger(logger()),
+		WithWSSubProtocol(protocolGraphQLWS),
+	)
+	next := make(chan []byte)
+	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
+		URL: strings.Replace(server.URL, "http", "ws", -1),
+		Body: GraphQLBody{
+			Query: `subscription {messageAdded(roomName: "room"){text}}`,
+		},
+	}, next)
+	assert.NoError(t, err)
+	first := <-next
+	second := <-next
+	third := <-next
+	assert.Equal(t, `{"data":{"messageAdded":{"text":"first"}}}`, string(first))
+	assert.Equal(t, `{"data":{"messageAdded":{"text":"second"}}}`, string(second))
+	assert.Equal(t, `{"data":{"messageAdded":{"text":"third"}}}`, string(third))
+	clientCancel()
+	assert.Eventuallyf(t, func() bool {
+		<-serverDone
+		return true
+	}, time.Second, time.Millisecond*10, "server did not close")
+	serverCancel()
+	assert.Eventuallyf(t, func() bool {
+		return len(client.handlers) == 0
+	}, time.Second, time.Millisecond, "client handlers not 0")
+}
+
+func TestWebsocketSubscriptionClientErrorArray(t *testing.T) {
+	serverDone := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		assert.NoError(t, err)
+		msgType, data, err := conn.Read(r.Context())
+		assert.NoError(t, err)
+		assert.Equal(t, websocket.MessageText, msgType)
+		assert.Equal(t, `{"type":"connection_init"}`, string(data))
+		err = conn.Write(r.Context(), websocket.MessageText, []byte(`{"type":"connection_ack"}`))
+		assert.NoError(t, err)
+		msgType, data, err = conn.Read(r.Context())
+		assert.NoError(t, err)
+		assert.Equal(t, websocket.MessageText, msgType)
+		assert.Equal(t, `{"type":"start","id":"1","payload":{"query":"subscription {messageAdded(roomNam: \"room\"){text}}"}}`, string(data))
+		err = conn.Write(r.Context(), websocket.MessageText, []byte(`{"type":"error","id":"1","payload":[{"message":"error"},{"message":"error"}]}`))
+		assert.NoError(t, err)
+		msgType, data, err = conn.Read(r.Context())
+		assert.NoError(t, err)
+		assert.Equal(t, websocket.MessageText, msgType)
+		assert.Equal(t, `{"type":"stop","id":"1"}`, string(data))
+		_, _, err = conn.Read(r.Context())
+		assert.NotNil(t, err)
+		close(serverDone)
+	}))
+	defer server.Close()
+	serverCtx, serverCancel := context.WithCancel(context.Background())
+	defer serverCancel()
+	clientCtx, clientCancel := context.WithCancel(context.Background())
+	client := NewGraphQLSubscriptionClient(http.DefaultClient, serverCtx,
+		WithReadTimeout(time.Millisecond),
+		WithLogger(logger()),
+		WithWSSubProtocol(protocolGraphQLWS),
+	)
+	next := make(chan []byte)
+	err := client.Subscribe(clientCtx, GraphQLSubscriptionOptions{
+		URL: strings.Replace(server.URL, "http", "ws", -1),
+		Body: GraphQLBody{
+			Query: `subscription {messageAdded(roomNam: "room"){text}}`,
+		},
+	}, next)
+	assert.NoError(t, err)
+	message := <-next
+	assert.Equal(t, `{"errors":[{"message":"error"},{"message":"error"}]}`, string(message))
+	clientCancel()
+	_, ok := <-next
+	assert.False(t, ok)
+	assert.Eventuallyf(t, func() bool {
+		<-serverDone
+		return true
+	}, time.Second, time.Millisecond*10, "server did not close")
+}
+
+func TestWebsocketSubscriptionClientErrorObject(t *testing.T) {
+	serverDone := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		assert.NoError(t, err)
+		msgType, data, err := conn.Read(r.Context())
+		assert.NoError(t, err)
+		assert.Equal(t, websocket.MessageText, msgType)
+		assert.Equal(t, `{"type":"connection_init"}`, string(data))
+		err = conn.Write(r.Context(), websocket.MessageText, []byte(`{"type":"connection_ack"}`))
+		assert.NoError(t, err)
+		msgType, data, err = conn.Read(r.Context())
+		assert.NoError(t, err)
+		assert.Equal(t, websocket.MessageText, msgType)
+		assert.Equal(t, `{"type":"start","id":"1","payload":{"query":"subscription {messageAdded(roomNam: \"room\"){text}}"}}`, string(data))
+		err = conn.Write(r.Context(), websocket.MessageText, []byte(`{"type":"error","id":"1","payload":{"message":"error"}}`))
+		assert.NoError(t, err)
+		msgType, data, err = conn.Read(r.Context())
+		assert.NoError(t, err)
+		assert.Equal(t, websocket.MessageText, msgType)
+		assert.Equal(t, `{"type":"stop","id":"1"}`, string(data))
+		_, _, err = conn.Read(r.Context())
+		assert.NotNil(t, err)
+		close(serverDone)
+	}))
+	defer server.Close()
+	serverCtx, serverCancel := context.WithCancel(context.Background())
+	defer serverCancel()
+	clientCtx, clientCancel := context.WithCancel(context.Background())
+	client := NewGraphQLSubscriptionClient(http.DefaultClient, serverCtx,
+		WithReadTimeout(time.Millisecond),
+		WithLogger(logger()),
+		WithWSSubProtocol(protocolGraphQLWS),
+	)
+	next := make(chan []byte)
+	err := client.Subscribe(clientCtx, GraphQLSubscriptionOptions{
+		URL: strings.Replace(server.URL, "http", "ws", -1),
+		Body: GraphQLBody{
+			Query: `subscription {messageAdded(roomNam: "room"){text}}`,
+		},
+	}, next)
+	assert.NoError(t, err)
+	message := <-next
+	assert.Equal(t, `{"errors":[{"message":"error"}]}`, string(message))
+	clientCancel()
+	_, ok := <-next
+	assert.False(t, ok)
+	assert.Eventuallyf(t, func() bool {
+		<-serverDone
+		return true
+	}, time.Second, time.Millisecond*10, "server did not close")
+}

--- a/pkg/engine/datasource/graphql_datasource/graphql_ws_proto_types.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_ws_proto_types.go
@@ -1,0 +1,44 @@
+package graphql_datasource
+
+// common
+var (
+	connectionInitMessage = []byte(`{"type":"connection_init"}`)
+)
+
+const (
+	messageTypeConnectionAck = "connection_ack"
+	messageTypeComplete      = "complete"
+	messageTypeError         = "error"
+)
+
+// websocket sub-protocol:
+// https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md
+const (
+	protocolGraphQLWS = "graphql-ws"
+
+	startMessage = `{"type":"start","id":"%s","payload":%s}`
+	stopMessage  = `{"type":"stop","id":"%s"}`
+
+	messageTypeConnectionKeepAlive = "ka"
+	messageTypeData                = "data"
+	messageTypeConnectionError     = "connection_error"
+)
+
+// websocket sub-protocol:
+// https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md
+const (
+	protocolGraphQLTWS = "graphql-transport-ws"
+
+	subscribeMessage = `{"id":"%s","type":"subscribe","payload":%s}`
+	pongMessage      = `{"type":"pong"}`
+	completeMessage  = `{"id":"%s","type":"complete"}`
+
+	messageTypePing = "ping"
+	messageTypeNext = "next"
+)
+
+// internal
+const (
+	internalError   = `{"errors":[{"message":"internal error"}]}`
+	connectionError = `{"errors":[{"message":"connection error"}]}`
+)

--- a/pkg/engine/datasource/httpclient/httpclient.go
+++ b/pkg/engine/datasource/httpclient/httpclient.go
@@ -23,6 +23,7 @@ const (
 	BODY          = "body"
 	HEADER        = "header"
 	QUERYPARAMS   = "query_params"
+	USESSE        = "use_sse"
 
 	SCHEME = "scheme"
 	HOST   = "host"
@@ -102,6 +103,11 @@ func SetInputURLEncodeBody(input []byte, urlEncodeBody bool) []byte {
 		return input
 	}
 	out, _ := sjson.SetRawBytes(input, URLENCODEBODY, []byte("true"))
+	return out
+}
+
+func SetInputFlag(input []byte, flagName string) []byte {
+	out, _ := sjson.SetRawBytes(input, flagName, []byte("true"))
 	return out
 }
 


### PR DESCRIPTION
This PR ports the new subscription protocol implementations (SSE, graphql-transport-ws) from Wundergraph to Tyk.