### PR TITLE
Add the service name explicitly to prevent the port collision.

### DIFF
--- a/examples/kafka_pubsub/README.md
+++ b/examples/kafka_pubsub/README.md
@@ -8,7 +8,7 @@ Open a terminal run the following:
 
 ```
 cd examples/kafka_pubsub
-docker-compose up
+docker-compose up kafka
 ```
 
 You need to wait some time while the cluster is being formed. 


### PR DESCRIPTION
We should give the service name explicitly to prevent port collision. Reported by @behcio.