### PR TITLE
[TT-6798] Reconnection feature is broken in subscription

### DIFF
--- a/pkg/engine/datasource/graphql_datasource/graphql_sse_handler_test.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_sse_handler_test.go
@@ -283,3 +283,66 @@ func TestGraphQLSubscriptionClientSubscribe_QueryParams(t *testing.T) {
 	}, time.Second, time.Millisecond*10, "server did not close")
 	serverCancel()
 }
+
+func TestGraphQLSubscriptionClientSubscribe_SSE_Upstream_Dies(t *testing.T) {
+	serverDone := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		urlQuery := r.URL.Query()
+		assert.Equal(t, "subscription {messageAdded(roomName: \"room\"){text}}", urlQuery.Get("query"))
+
+		// Make sure that the writer supports flushing.
+		flusher, ok := w.(http.Flusher)
+		require.True(t, ok)
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+
+		_, _ = fmt.Fprintf(w, "data: %s\n\n", `{"data":{"messageAdded":{"text":"first"}}}`)
+		flusher.Flush()
+
+		// Kill the upstream server. We should catch this event as an "unexpected EOF"
+		// error and return an error message to the subscriber.
+		h, ok := w.(http.Hijacker)
+		require.True(t, ok)
+		rawConn, _, err := h.Hijack()
+		require.NoError(t, err)
+		_ = rawConn.Close()
+
+		close(serverDone)
+	}))
+	defer server.Close()
+
+	serverCtx, serverCancel := context.WithCancel(context.Background())
+
+	ctx, clientCancel := context.WithCancel(context.Background())
+
+	client := NewGraphQLSubscriptionClient(http.DefaultClient, http.DefaultClient, serverCtx,
+		WithReadTimeout(time.Millisecond),
+		WithLogger(logger()),
+	)
+
+	next := make(chan []byte)
+	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
+		URL: server.URL,
+		Body: GraphQLBody{
+			Query: `subscription {messageAdded(roomName: "room"){text}}`,
+		},
+		UseSSE: true,
+	}, next)
+	assert.NoError(t, err)
+
+	first := <-next
+	second := <-next
+	assert.Equal(t, `{"data":{"messageAdded":{"text":"first"}}}`, string(first))
+	// Upstream died
+	assert.Equal(t, `{"errors":[{"message":"internal error"}]}`, string(second))
+
+	clientCancel()
+	assert.Eventuallyf(t, func() bool {
+		<-serverDone
+		return true
+	}, time.Second, time.Millisecond*10, "server did not close")
+	serverCancel()
+}

--- a/pkg/engine/datasource/graphql_datasource/graphql_ws_handler_test.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_ws_handler_test.go
@@ -2,6 +2,7 @@ package graphql_datasource
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -260,3 +261,91 @@ func TestWebsocketSubscriptionClientErrorObject(t *testing.T) {
 		return true
 	}, time.Second, time.Millisecond*10, "server did not close")
 }
+
+func TestWebsocketSubscriptionClient_GQLWS_Upstream_Dies(t *testing.T) {
+	serverCtx, serverCancel := context.WithCancel(context.Background())
+	defer serverCancel()
+
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		assert.NoError(t, err)
+		ctx := context.Background()
+		msgType, data, err := conn.Read(ctx)
+		assert.NoError(t, err)
+		assert.Equal(t, websocket.MessageText, msgType)
+		assert.Equal(t, `{"type":"connection_init"}`, string(data))
+		err = conn.Write(r.Context(), websocket.MessageText, []byte(`{"type":"connection_ack"}`))
+		assert.NoError(t, err)
+		msgType, data, err = conn.Read(ctx)
+		assert.NoError(t, err)
+		assert.Equal(t, websocket.MessageText, msgType)
+		assert.Equal(t, `{"type":"start","id":"1","payload":{"query":"subscription {messageAdded(roomName: \"room\"){text}}"}}`, string(data))
+		err = conn.Write(r.Context(), websocket.MessageText, []byte(`{"type":"data","id":"1","payload":{"data":{"messageAdded":{"text":"first"}}}}`))
+
+		<-serverCtx.Done()
+	}))
+
+	// Wrap the listener to hijack the underlying TCP connection.
+	// Hijacking via http.ResponseWriter doesn't work because the WebSocket
+	// client already hijacks the connection before us.
+	wrappedListener := &listenerWrapper{
+		listener: server.Listener,
+	}
+	server.Listener = wrappedListener
+	server.Start()
+
+	defer server.Close()
+	ctx, clientCancel := context.WithCancel(context.Background())
+
+	// Start a new GQL subscription and exchange some messages.
+	client := NewGraphQLSubscriptionClient(http.DefaultClient, http.DefaultClient, serverCtx,
+		WithReadTimeout(time.Second),
+		WithLogger(logger()),
+		WithWSSubProtocol(ProtocolGraphQLWS),
+	)
+	next := make(chan []byte)
+	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
+		URL: server.URL,
+		Body: GraphQLBody{
+			Query: `subscription {messageAdded(roomName: "room"){text}}`,
+		},
+	}, next)
+	assert.NoError(t, err)
+	first := <-next
+	assert.Equal(t, `{"data":{"messageAdded":{"text":"first"}}}`, string(first))
+
+	// Kill the upstream here. We should get an End-of-File error.
+	assert.NoError(t, wrappedListener.underlyingConnection.Close())
+	errorMessage := <-next
+	assert.Equal(t, `{"errors":[{"message":"failed to get reader: failed to read frame header: EOF"}]}`, string(errorMessage))
+
+	serverCancel()
+	clientCancel()
+	assert.Eventuallyf(t, func() bool {
+		return len(client.handlers) == 0
+	}, time.Second, time.Millisecond, "client handlers not 0")
+}
+
+type listenerWrapper struct {
+	listener             net.Listener
+	underlyingConnection net.Conn
+}
+
+func (l *listenerWrapper) Accept() (net.Conn, error) {
+	conn, err := l.listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+	l.underlyingConnection = conn
+	return l.underlyingConnection, nil
+}
+
+func (l *listenerWrapper) Close() error {
+	return l.listener.Close()
+}
+
+func (l *listenerWrapper) Addr() net.Addr {
+	return l.listener.Addr()
+}
+
+var _ net.Listener = (*listenerWrapper)(nil)

--- a/pkg/engine/datasource/graphql_datasource/graphql_ws_handler_test.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_ws_handler_test.go
@@ -281,6 +281,7 @@ func TestWebsocketSubscriptionClient_GQLWS_Upstream_Dies(t *testing.T) {
 		assert.Equal(t, websocket.MessageText, msgType)
 		assert.Equal(t, `{"type":"start","id":"1","payload":{"query":"subscription {messageAdded(roomName: \"room\"){text}}"}}`, string(data))
 		err = conn.Write(r.Context(), websocket.MessageText, []byte(`{"type":"data","id":"1","payload":{"data":{"messageAdded":{"text":"first"}}}}`))
+		assert.NoError(t, err)
 
 		<-serverCtx.Done()
 	}))

--- a/pkg/engine/datasource/graphql_datasource/graphql_ws_proto_types.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_ws_proto_types.go
@@ -39,6 +39,7 @@ const (
 
 // internal
 const (
-	internalError   = `{"errors":[{"message":"internal error"}]}`
-	connectionError = `{"errors":[{"message":"connection error"}]}`
+	internalError        = `{"errors":[{"message":"internal error"}]}`
+	connectionError      = `{"errors":[{"message":"connection error"}]}`
+	errorMessageTemplate = `{"errors":[{"message":"%s"}]}`
 )


### PR DESCRIPTION
This PR fixes the wrong handling of connection errors in the GQL subscription. Previously, it was hiding the connection errors due to this faulty behavior, it was failing to trigger the reconnection mechanism. It was waiting forever in an uninterruptible and unobservable state. 

I added integration tests to simulate an upstream failure. Basically, the tests kill the underlying TCP socket and trigger the reconnection mechanism, and return the error messages.

For example, if I kill the upstream service at some point it returns the following error messages:

```json
{"id":"1","type":"data","payload":{"errors":[{"message":"unable to resolve","locations":[{"line":2,"column":3}],"path":["getUserNotifications"]},{"message":"failed to get reader: failed to read frame header: EOF"}],"data":null}}
{"id":"1","type":"error","payload":[{"message":"failed to WebSocket dial: failed to send handshake request: Get \"http://localhost:4204/query\": dial tcp [::1]:4204: connect: connection refused"}]}
{"id":"1","type":"error","payload":[{"message":"failed to WebSocket dial: failed to send handshake request: Get \"http://localhost:4204/query\": dial tcp [::1]:4204: connect: connection refused"}]}
{"id":"1","type":"error","payload":[{"message":"failed to WebSocket dial: failed to send handshake request: Get \"http://localhost:4204/query\": dial tcp [::1]:4204: connect: connection refused"}]}
```

This client may choose a STOP message to halt the subscription instead of waiting to reconnect to the upstream.

By the way, the GQL resolver tries to resolve the first error message. I think the `type` should be `error` instead of `data`. Is this a bug or a feature? cc: @pvormste

```json
{"id":"1","type":"data","payload":{"errors":[{"message":"unable to resolve","locations":[{"line":2,"column":3}],"path":["getUserNotifications"]},{"message":"failed to get reader: failed to read frame header: EOF"}],"data":null}}
```