### PR TITLE
[TT-6737] Starting a subscription without attached data source crashes GW

### DIFF
--- a/pkg/engine/resolve/resolve_test.go
+++ b/pkg/engine/resolve/resolve_test.go
@@ -3149,7 +3149,7 @@ func (f *_fakeStream) Start(ctx context.Context, input []byte, next chan<- []byt
 
 func TestResolver_ResolveGraphQLSubscription(t *testing.T) {
 
-	setup := func(ctx context.Context, stream *_fakeStream) (*Resolver, *GraphQLSubscription, *TestFlushWriter) {
+	setup := func(ctx context.Context, stream SubscriptionDataSource) (*Resolver, *GraphQLSubscription, *TestFlushWriter) {
 		plan := &GraphQLSubscription{
 			Trigger: GraphQLSubscriptionTrigger{
 				Source: stream,
@@ -3193,6 +3193,22 @@ func TestResolver_ResolveGraphQLSubscription(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(out.flushed))
 		assert.Equal(t, `{"errors":[{"message":"unable to resolve","locations":[{"line":0,"column":0}]},{"message":"Validation error occurred","locations":[{"line":1,"column":1}],"extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}],"data":null}`, out.flushed[0])
+	})
+
+	t.Run("should return an error if the data source has not been defined", func(t *testing.T) {
+		c, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		resolver, plan, out := setup(c, nil)
+
+		ctx := Context{
+			Context: c,
+		}
+
+		err := resolver.ResolveGraphQLSubscription(&ctx, plan, out)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(out.flushed))
+		assert.Equal(t, `{"errors":[{"message":"no data source found"}]}`, out.flushed[0])
 	})
 
 	t.Run("should successfully get result from upstream", func(t *testing.T) {


### PR DESCRIPTION
PR for [TT-6737](https://tyktech.atlassian.net/jira/software/c/projects/TT/boards/26?modal=detail&selectedIssue=TT-6737)

Now the library returns the following error if the data source has not been defined: 

```json
{"errors":[{"message":"no data source found"}]}
```

I investigated the possibility of controlling this before calling `ResolveGraphQLSubscription` but it seems that there is no way to do it. See the following: 

```go
func (v *Visitor) LeaveDocument(operation, definition *ast.Document) {
	for _, config := range v.fetchConfigurations {
		if config.isSubscription {
			v.configureSubscription(config)
		} else {
			v.configureObjectFetch(config)
		}
	}
}
```

`v.fetchConfigurations` was empty our case. Possibly, we need to spend more time implementing a more general solution. The solution proposed here just works. 