### PR TITLE
add new subscription types to proxy-only and federation cfg generators

### DIFF
--- a/pkg/engine/datasource/graphql_datasource/graphql_subscription_client.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_subscription_client.go
@@ -65,6 +65,18 @@ type opts struct {
 	onWsConnectionInitCallback *OnWsConnectionInitCallback
 }
 
+// GraphQLSubscriptionClientFactory abstracts the way of creating a new GraphQLSubscriptionClient.
+// This can be very handy for testing purposes.
+type GraphQLSubscriptionClientFactory interface {
+	NewSubscriptionClient(httpClient, streamingClient *http.Client, engineCtx context.Context, options ...Options) GraphQLSubscriptionClient
+}
+
+type DefaultSubscriptionClientFactory struct{}
+
+func (d *DefaultSubscriptionClientFactory) NewSubscriptionClient(httpClient, streamingClient *http.Client, engineCtx context.Context, options ...Options) GraphQLSubscriptionClient {
+	return NewGraphQLSubscriptionClient(httpClient, streamingClient, engineCtx, options...)
+}
+
 func NewGraphQLSubscriptionClient(httpClient, streamingClient *http.Client, engineCtx context.Context, options ...Options) *SubscriptionClient {
 	op := &opts{
 		readTimeout: time.Second,

--- a/pkg/graphql/engine_config_v2.go
+++ b/pkg/graphql/engine_config_v2.go
@@ -96,8 +96,7 @@ func WithDataSourceV2GeneratorSubscriptionClientFactory(factory graphqlDataSourc
 }
 
 type graphqlDataSourceV2Generator struct {
-	document                  *ast.Document
-	subscriptionClientFactory graphqlDataSource.GraphQLSubscriptionClientFactory
+	document *ast.Document
 }
 
 func newGraphQLDataSourceV2Generator(document *ast.Document) *graphqlDataSourceV2Generator {

--- a/pkg/graphql/engine_config_v2.go
+++ b/pkg/graphql/engine_config_v2.go
@@ -1,6 +1,7 @@
 package graphql
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/TykTechnologies/graphql-go-tools/pkg/ast"
@@ -73,8 +74,30 @@ func (e *EngineV2Configuration) SetWebsocketBeforeStartHook(hook WebsocketBefore
 	e.websocketBeforeStartHook = hook
 }
 
+type dataSourceV2GeneratorOptions struct {
+	streamingClient           *http.Client
+	subscriptionType          SubscriptionType
+	subscriptionClientFactory graphqlDataSource.GraphQLSubscriptionClientFactory
+}
+
+type DataSourceV2GeneratorOption func(options *dataSourceV2GeneratorOptions)
+
+func WithDataSourceV2GeneratorSubscriptionConfiguration(streamingClient *http.Client, subscriptionType SubscriptionType) DataSourceV2GeneratorOption {
+	return func(options *dataSourceV2GeneratorOptions) {
+		options.streamingClient = streamingClient
+		options.subscriptionType = subscriptionType
+	}
+}
+
+func WithDataSourceV2GeneratorSubscriptionClientFactory(factory graphqlDataSource.GraphQLSubscriptionClientFactory) DataSourceV2GeneratorOption {
+	return func(options *dataSourceV2GeneratorOptions) {
+		options.subscriptionClientFactory = factory
+	}
+}
+
 type graphqlDataSourceV2Generator struct {
-	document *ast.Document
+	document                  *ast.Document
+	subscriptionClientFactory graphqlDataSource.GraphQLSubscriptionClientFactory
 }
 
 func newGraphQLDataSourceV2Generator(document *ast.Document) *graphqlDataSourceV2Generator {
@@ -83,20 +106,64 @@ func newGraphQLDataSourceV2Generator(document *ast.Document) *graphqlDataSourceV
 	}
 }
 
-func (d *graphqlDataSourceV2Generator) Generate(config graphqlDataSource.Configuration, batchFactory resolve.DataSourceBatchFactory, httpClient *http.Client) plan.DataSourceConfiguration {
+func (d *graphqlDataSourceV2Generator) Generate(config graphqlDataSource.Configuration, batchFactory resolve.DataSourceBatchFactory, httpClient *http.Client, options ...DataSourceV2GeneratorOption) (plan.DataSourceConfiguration, error) {
 	var planDataSource plan.DataSourceConfiguration
 	extractor := plan.NewLocalTypeFieldExtractor(d.document)
 	planDataSource.RootNodes, planDataSource.ChildNodes = extractor.GetAllNodes()
 
-	factory := &graphqlDataSource.Factory{
-		HTTPClient:   httpClient,
-		BatchFactory: batchFactory,
+	definedOptions := &dataSourceV2GeneratorOptions{
+		streamingClient:           &http.Client{Timeout: 0},
+		subscriptionType:          SubscriptionTypeUnknown,
+		subscriptionClientFactory: &graphqlDataSource.DefaultSubscriptionClientFactory{},
 	}
+
+	for _, option := range options {
+		option(definedOptions)
+	}
+
+	factory := &graphqlDataSource.Factory{
+		HTTPClient:      httpClient,
+		StreamingClient: definedOptions.streamingClient,
+		BatchFactory:    batchFactory,
+	}
+
+	subscriptionClient, err := d.generateSubscriptionClient(httpClient, definedOptions)
+	if err != nil {
+		return plan.DataSourceConfiguration{}, err
+	}
+	factory.SubscriptionClient = subscriptionClient
 
 	planDataSource.Factory = factory
 	planDataSource.Custom = graphqlDataSource.ConfigJson(config)
 
-	return planDataSource
+	return planDataSource, nil
+}
+
+func (d *graphqlDataSourceV2Generator) generateSubscriptionClient(httpClient *http.Client, definedOptions *dataSourceV2GeneratorOptions) (*graphqlDataSource.SubscriptionClient, error) {
+	var graphqlSubscriptionClient graphqlDataSource.GraphQLSubscriptionClient
+	switch definedOptions.subscriptionType {
+	case SubscriptionTypeGraphQLTransportWS:
+		graphqlSubscriptionClient = definedOptions.subscriptionClientFactory.NewSubscriptionClient(
+			httpClient,
+			definedOptions.streamingClient,
+			nil,
+			graphqlDataSource.WithWSSubProtocol(graphqlDataSource.ProtocolGraphQLTWS),
+		)
+	default:
+		// for compatibility reasons we fall back to graphql-ws protocol
+		graphqlSubscriptionClient = definedOptions.subscriptionClientFactory.NewSubscriptionClient(
+			httpClient,
+			definedOptions.streamingClient,
+			nil,
+			graphqlDataSource.WithWSSubProtocol(graphqlDataSource.ProtocolGraphQLWS),
+		)
+	}
+
+	subscriptionClient, ok := graphqlSubscriptionClient.(*graphqlDataSource.SubscriptionClient)
+	if !ok {
+		return nil, errors.New("invalid SubscriptionClient was instantiated")
+	}
+	return subscriptionClient, nil
 }
 
 type graphqlFieldConfigurationsV2Generator struct {

--- a/pkg/graphql/subscription.go
+++ b/pkg/graphql/subscription.go
@@ -1,0 +1,16 @@
+package graphql
+
+type SubscriptionType int
+
+const (
+	// SubscriptionTypeUnknown is for unknown or undefined subscriptions.
+	SubscriptionTypeUnknown = iota
+	// SubscriptionTypeSSE is for Server-Sent Events (SSE) subscriptions.
+	SubscriptionTypeSSE
+	// SubscriptionTypeGraphQLWS is for subscriptions using a WebSocket connection with
+	// 'graphql-ws' as protocol.
+	SubscriptionTypeGraphQLWS
+	// SubscriptionTypeGraphQLTransportWS is for subscriptions using a WebSocket connection with
+	// 'graphql-transport-ws' as protocol.
+	SubscriptionTypeGraphQLTransportWS
+)


### PR DESCRIPTION
This PR adds new subscription types to:
 - config generator for proxy-only
 - config generator for federation