### PR TITLE
add method to enable single flight in engine v2 config

### DIFF
--- a/pkg/graphql/engine_config_v2.go
+++ b/pkg/graphql/engine_config_v2.go
@@ -69,6 +69,10 @@ func (e *EngineV2Configuration) EnableDataLoader(enable bool) {
 	e.dataLoaderConfig.EnableDataLoader = enable
 }
 
+func (e *EngineV2Configuration) EnableSingleFlight(enable bool) {
+	e.dataLoaderConfig.EnableSingleFlightLoader = enable
+}
+
 // SetWebsocketBeforeStartHook - sets before start hook which will be called before processing any operation sent over websockets
 func (e *EngineV2Configuration) SetWebsocketBeforeStartHook(hook WebsocketBeforeStartHook) {
 	e.websocketBeforeStartHook = hook

--- a/pkg/graphql/engine_config_v2_test.go
+++ b/pkg/graphql/engine_config_v2_test.go
@@ -277,6 +277,20 @@ func TestGraphqlFieldConfigurationsV2Generator_Generate(t *testing.T) {
 
 }
 
+func TestEngineV2Configuration_EnableSingleFlight(t *testing.T) {
+	schema, err := NewSchemaFromString(graphqlGeneratorSchema)
+	require.NoError(t, err)
+
+	conf := NewEngineV2Configuration(schema)
+	require.Falsef(t, conf.dataLoaderConfig.EnableSingleFlightLoader, "single flight is not disabled by default")
+
+	conf.EnableSingleFlight(true)
+	assert.True(t, conf.dataLoaderConfig.EnableSingleFlightLoader)
+
+	conf.EnableSingleFlight(false)
+	assert.False(t, conf.dataLoaderConfig.EnableSingleFlightLoader)
+}
+
 var mockSubscriptionClient = &graphqlDataSource.SubscriptionClient{}
 
 type MockSubscriptionClientFactory struct{}


### PR DESCRIPTION
This PR (finally) adds a method to `EngineV2Configuration` to enable single flight.