### PR TITLE
[TT-6419] Querying for __typename in any graph causes a 502 error

### DIFF
--- a/pkg/engine/datasource/graphql_datasource/graphql_datasource_test.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_datasource_test.go
@@ -409,7 +409,8 @@ func TestGraphQLDataSource(t *testing.T) {
 									},
 								},
 								{
-									Name: []byte("__typename"),
+									Name:     []byte("__typename"),
+									TypeName: "User",
 									Value: &resolve.String{
 										Path:       []string{"__typename"},
 										IsTypeName: true,
@@ -418,7 +419,8 @@ func TestGraphQLDataSource(t *testing.T) {
 									SkipVariableName:     "skip",
 								},
 								{
-									Name: []byte("tn2"),
+									Name:     []byte("tn2"),
+									TypeName: "User",
 									Value: &resolve.String{
 										Path:       []string{"__typename"},
 										IsTypeName: true,
@@ -3213,7 +3215,8 @@ func TestGraphQLDataSource(t *testing.T) {
 					},
 					Fields: []*resolve.Field{
 						{
-							Name: []byte("__typename"),
+							Name:     []byte("__typename"),
+							TypeName: "Mutation",
 							Value: &resolve.String{
 								Path:       []string{"__typename"},
 								Nullable:   false,
@@ -3228,7 +3231,8 @@ func TestGraphQLDataSource(t *testing.T) {
 								Path: []string{"namespaceCreate"},
 								Fields: []*resolve.Field{
 									{
-										Name: []byte("__typename"),
+										Name:     []byte("__typename"),
+										TypeName: "CreateNamespaceResponse",
 										Value: &resolve.String{
 											Path:       []string{"__typename"},
 											Nullable:   false,
@@ -3371,7 +3375,8 @@ func TestGraphQLDataSource(t *testing.T) {
 								Path: []string{"namespaceCreate"},
 								Fields: []*resolve.Field{
 									{
-										Name: []byte("__typename"),
+										Name:     []byte("__typename"),
+										TypeName: "CreateNamespaceResponse",
 										Value: &resolve.String{
 											Path:       []string{"__typename"},
 											Nullable:   false,
@@ -4056,7 +4061,8 @@ func TestGraphQLDataSource(t *testing.T) {
 													},
 												},
 												{
-													Name: []byte("__typename"),
+													Name:     []byte("__typename"),
+													TypeName: "Vehicle",
 													Value: &resolve.String{
 														Path:       []string{"__typename"},
 														IsTypeName: true,
@@ -4429,7 +4435,8 @@ func TestGraphQLDataSource(t *testing.T) {
 													},
 												},
 												{
-													Name: []byte("__typename"),
+													Name:     []byte("__typename"),
+													TypeName: "Vehicle",
 													Value: &resolve.String{
 														Path:       []string{"__typename"},
 														IsTypeName: true,

--- a/pkg/engine/plan/plan.go
+++ b/pkg/engine/plan/plan.go
@@ -525,6 +525,7 @@ func (v *Visitor) EnterField(ref int) {
 				IsTypeName: true,
 			},
 			OnTypeName:              v.resolveOnTypeName(),
+			TypeName:                v.Walker.EnclosingTypeDefinition.NameString(v.Definition),
 			Position:                v.resolveFieldPosition(ref),
 			SkipDirectiveDefined:    skip,
 			SkipVariableName:        skipVariableName,

--- a/pkg/engine/resolve/resolve.go
+++ b/pkg/engine/resolve/resolve.go
@@ -5,6 +5,7 @@ package resolve
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -1103,6 +1104,12 @@ func (r *Resolver) resolveObject(ctx *Context, object *Object, data []byte, obje
 				ctx.resetResponsePathElements()
 				ctx.lastFetchID = object.Fields[i].BufferID
 			}
+		} else if bytes.Equal(object.Fields[i].Name, literal.TYPENAME) {
+			typeNameValue, _ := json.Marshal(object.Fields[i].TypeName)
+			fieldData, err = jsonparser.Set([]byte("{}"), typeNameValue, string(literal.TYPENAME))
+			if err != nil {
+				return
+			}
 		} else {
 			fieldData = data
 		}
@@ -1348,6 +1355,7 @@ type Field struct {
 	HasBuffer               bool
 	BufferID                int
 	OnTypeName              []byte
+	TypeName                string
 	SkipDirectiveDefined    bool
 	SkipVariableName        string
 	IncludeDirectiveDefined bool


### PR DESCRIPTION
Currently, when you send the following query for both proxy-only and UDG APIs, the GW panics and the user gets 502 for the query.

```graphql
query {
    __typename
}
```

The actual error message is the following:

```json
{
    "errors": [
        {
            "message": "unable to resolve",
            "locations": [
                {
                    "line": 2,
                    "column": 5
                }
            ]
        }
    ],
    "data": null
}
```

The `data` is null because no data source is attached to the `__typename`. It's evaluated by this block: https://github.com/TykTechnologies/graphql-go-tools/blob/c2dd74b524578d0653cf7652efba56a19304ebae/pkg/engine/plan/plan.go#L519

Initially, I thought that it would be enough to proxy the request to the upstream. It works for the proxy-only mode but it doesn't work for UDG. 

Consider the following example. I have a dummy REST service that returns `{"temp": random-number}` for every request. It doesn't speak GraphQL. 

```graphql
query {
    __typename
    weather {
        temp
    }
}
```

UDG returns the following response for this query because the `__typename` doesn't exist in the response.

```json
{
    "errors": [
        {
            "message": "unable to resolve",
            "locations": [
                {
                    "line": 2,
                    "column": 5
                }
            ]
        }
    ],
    "data": null
}
```

I realized that the `__typename` meta-field should be maintained by the library directly when required. The most simple and feasible way to export the type name from planner to resolver is to add a new field to the `resolver.Field` struct. The other option is to add a type name field to `resolver.Object` but I couldn't find a way to get the root type name. In addition to that, it breaks many tests in resolve and planner packages.

The response after the fix was applied:

```graphql
query {
    __typename
    weather {
        __typename
        temp
    }
}
```

```json
{
    "data": {
        "__typename": "Query",
        "weather": {
            "__typename": "Weather",
            "temp": 44
        }
    }
}
```