### PR TITLE
cherry pick changes from wundergraph

### DIFF
--- a/pkg/engine/datasource/graphql_datasource/graphql_datasource.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_datasource.go
@@ -225,8 +225,9 @@ type FederationConfiguration struct {
 }
 
 type SubscriptionConfiguration struct {
-	URL    string
-	UseSSE bool
+	URL           string
+	UseSSE        bool
+	SSEMethodPost bool
 }
 
 type FetchConfiguration struct {
@@ -308,6 +309,9 @@ func (p *Planner) ConfigureSubscription() plan.SubscriptionConfiguration {
 	input = httpclient.SetInputURL(input, []byte(p.config.Subscription.URL))
 	if p.config.Subscription.UseSSE {
 		input = httpclient.SetInputFlag(input, httpclient.USESSE)
+		if p.config.Subscription.SSEMethodPost {
+			input = httpclient.SetInputFlag(input, httpclient.SSEMETHODPOST)
+		}
 	}
 
 	header, err := json.Marshal(p.config.Fetch.Header)
@@ -1329,10 +1333,11 @@ type GraphQLSubscriptionClient interface {
 }
 
 type GraphQLSubscriptionOptions struct {
-	URL    string      `json:"url"`
-	Body   GraphQLBody `json:"body"`
-	Header http.Header `json:"header"`
-	UseSSE bool        `json:"use_sse"`
+	URL           string      `json:"url"`
+	Body          GraphQLBody `json:"body"`
+	Header        http.Header `json:"header"`
+	UseSSE        bool        `json:"use_sse"`
+	SSEMethodPost bool        `json:"sse_method_post"`
 }
 
 type GraphQLBody struct {

--- a/pkg/engine/datasource/graphql_datasource/graphql_datasource.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_datasource.go
@@ -10,13 +10,13 @@ import (
 
 	"github.com/buger/jsonparser"
 	"github.com/tidwall/sjson"
-	"github.com/wundergraph/graphql-go-tools/pkg/astvalidation"
 
 	"github.com/TykTechnologies/graphql-go-tools/pkg/ast"
 	"github.com/TykTechnologies/graphql-go-tools/pkg/astnormalization"
 	"github.com/TykTechnologies/graphql-go-tools/pkg/astparser"
 	"github.com/TykTechnologies/graphql-go-tools/pkg/astprinter"
 	"github.com/TykTechnologies/graphql-go-tools/pkg/asttransform"
+	"github.com/TykTechnologies/graphql-go-tools/pkg/astvalidation"
 	"github.com/TykTechnologies/graphql-go-tools/pkg/engine/datasource/httpclient"
 	"github.com/TykTechnologies/graphql-go-tools/pkg/engine/plan"
 	"github.com/TykTechnologies/graphql-go-tools/pkg/engine/resolve"

--- a/pkg/engine/datasource/graphql_datasource/graphql_datasource.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_datasource.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/buger/jsonparser"
 	"github.com/tidwall/sjson"
+	"github.com/wundergraph/graphql-go-tools/pkg/astvalidation"
 
 	"github.com/TykTechnologies/graphql-go-tools/pkg/ast"
 	"github.com/TykTechnologies/graphql-go-tools/pkg/astnormalization"
@@ -766,7 +767,7 @@ func (p *Planner) configureArgument(upstreamFieldRef, downstreamFieldRef int, fi
 
 	switch argumentConfiguration.SourceType {
 	case plan.FieldArgumentSource:
-		p.configureFieldArgumentSource(upstreamFieldRef, downstreamFieldRef, argumentConfiguration.Name, argumentConfiguration.SourcePath)
+		p.configureFieldArgumentSource(upstreamFieldRef, downstreamFieldRef, argumentConfiguration)
 	case plan.ObjectFieldSource:
 		p.configureObjectFieldSource(upstreamFieldRef, downstreamFieldRef, fieldConfig, argumentConfiguration)
 	}
@@ -775,21 +776,21 @@ func (p *Planner) configureArgument(upstreamFieldRef, downstreamFieldRef int, fi
 }
 
 // configureFieldArgumentSource - creates variables for a plain argument types, in case object or list types goes deep and calls applyInlineFieldArgument
-func (p *Planner) configureFieldArgumentSource(upstreamFieldRef, downstreamFieldRef int, argumentName string, sourcePath []string) {
-	fieldArgument, ok := p.visitor.Operation.FieldArgument(downstreamFieldRef, []byte(argumentName))
+func (p *Planner) configureFieldArgumentSource(upstreamFieldRef, downstreamFieldRef int, argumentConfiguration plan.ArgumentConfiguration) {
+	fieldArgument, ok := p.visitor.Operation.FieldArgument(downstreamFieldRef, []byte(argumentConfiguration.Name))
 	if !ok {
 		return
 	}
 	value := p.visitor.Operation.ArgumentValue(fieldArgument)
 	if value.Kind != ast.ValueKindVariable {
-		p.applyInlineFieldArgument(upstreamFieldRef, downstreamFieldRef, argumentName, sourcePath)
+		p.applyInlineFieldArgument(upstreamFieldRef, downstreamFieldRef, argumentConfiguration.Name, argumentConfiguration.SourcePath)
 		return
 	}
 	variableName := p.visitor.Operation.VariableValueNameBytes(value.Ref)
 	variableNameStr := p.visitor.Operation.VariableValueNameString(value.Ref)
 
 	fieldName := p.visitor.Operation.FieldNameBytes(downstreamFieldRef)
-	argumentDefinition := p.visitor.Definition.NodeFieldDefinitionArgumentDefinitionByName(p.visitor.Walker.EnclosingTypeDefinition, fieldName, []byte(argumentName))
+	argumentDefinition := p.visitor.Definition.NodeFieldDefinitionArgumentDefinitionByName(p.visitor.Walker.EnclosingTypeDefinition, fieldName, []byte(argumentConfiguration.Name))
 
 	if argumentDefinition == -1 {
 		return
@@ -807,7 +808,7 @@ func (p *Planner) configureFieldArgumentSource(upstreamFieldRef, downstreamField
 	}
 
 	contextVariableName, exists := p.variables.AddVariable(contextVariable)
-	variableValueRef, argRef := p.upstreamOperation.AddVariableValueArgument([]byte(argumentName), variableName) // add the argument to the field, but don't redefine it
+	variableValueRef, argRef := p.upstreamOperation.AddVariableValueArgument([]byte(argumentConfiguration.Name), variableName) // add the argument to the field, but don't redefine it
 	p.upstreamOperation.AddArgumentToField(upstreamFieldRef, argRef)
 
 	if exists { // if the variable exists we don't have to put it onto the variables declaration again, skip
@@ -821,6 +822,9 @@ func (p *Planner) configureFieldArgumentSource(upstreamFieldRef, downstreamField
 		}
 		typeName := p.visitor.Operation.ResolveTypeNameString(p.visitor.Operation.VariableDefinitions[i].Type)
 		typeName = p.visitor.Config.Types.RenameTypeNameOnMatchStr(typeName)
+		if argumentConfiguration.RenameTypeTo != "" {
+			typeName = argumentConfiguration.RenameTypeTo
+		}
 		importedType := p.visitor.Importer.ImportTypeWithRename(p.visitor.Operation.VariableDefinitions[i].Type, p.visitor.Operation, p.upstreamOperation, typeName)
 		p.upstreamOperation.AddVariableDefinitionToOperationDefinition(p.nodes[0].Ref, variableValueRef, importedType)
 
@@ -950,6 +954,9 @@ func (p *Planner) configureObjectFieldSource(upstreamFieldRef, downstreamFieldRe
 
 	typeName := p.visitor.Operation.ResolveTypeNameString(argumentType)
 	typeName = p.visitor.Config.Types.RenameTypeNameOnMatchStr(typeName)
+	if argumentConfiguration.RenameTypeTo != "" {
+		typeName = argumentConfiguration.RenameTypeTo
+	}
 
 	importedType := p.visitor.Importer.ImportTypeWithRename(argumentType, p.visitor.Definition, p.upstreamOperation, typeName)
 	p.upstreamOperation.AddVariableDefinitionToOperationDefinition(p.nodes[0].Ref, variableValue, importedType)
@@ -1041,6 +1048,13 @@ func (p *Planner) printOperation() []byte {
 	// normalize upstream operation
 	if !p.normalizeOperation(operation, definition, report) {
 		p.stopWithError(normalizationFailedErrMsg)
+		return nil
+	}
+
+	validator := astvalidation.DefaultOperationValidator()
+	validator.Validate(operation, definition, report)
+	if report.HasErrors() {
+		p.stopWithError("validation failed: %s", report.Error())
 		return nil
 	}
 

--- a/pkg/engine/datasource/graphql_datasource/graphql_sse_handler_test.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_sse_handler_test.go
@@ -2,7 +2,9 @@ package graphql_datasource
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -53,6 +55,71 @@ func TestGraphQLSubscriptionClientSubscribe_SSE(t *testing.T) {
 			Query: `subscription {messageAdded(roomName: "room"){text}}`,
 		},
 		UseSSE: true,
+	}, next)
+	assert.NoError(t, err)
+
+	first := <-next
+	second := <-next
+	assert.Equal(t, `{"data":{"messageAdded":{"text":"first"}}}`, string(first))
+	assert.Equal(t, `{"data":{"messageAdded":{"text":"second"}}}`, string(second))
+
+	clientCancel()
+	assert.Eventuallyf(t, func() bool {
+		<-serverDone
+		return true
+	}, time.Second, time.Millisecond*10, "server did not close")
+	serverCancel()
+}
+
+func TestGraphQLSubscriptionClientSubscribe_SSE_POST(t *testing.T) {
+	postReqBody := GraphQLBody{
+		Query: `subscription {messageAdded(roomName: "room"){text}}`,
+	}
+	expectedReqBody, err := json.Marshal(postReqBody)
+	assert.NoError(t, err)
+
+	serverDone := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+
+		actualReqBody, err := ioutil.ReadAll(r.Body)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedReqBody, actualReqBody)
+
+		// Make sure that the writer supports flushing.
+		flusher, ok := w.(http.Flusher)
+		require.True(t, ok)
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+
+		_, _ = fmt.Fprintf(w, "data: %s\n\n", `{"data":{"messageAdded":{"text":"first"}}}`)
+		flusher.Flush()
+
+		_, _ = fmt.Fprintf(w, "data: %s\n\n", `{"data":{"messageAdded":{"text":"second"}}}`)
+		flusher.Flush()
+
+		close(serverDone)
+	}))
+	defer server.Close()
+
+	serverCtx, serverCancel := context.WithCancel(context.Background())
+
+	ctx, clientCancel := context.WithCancel(context.Background())
+
+	client := NewGraphQLSubscriptionClient(http.DefaultClient, http.DefaultClient, serverCtx,
+		WithReadTimeout(time.Millisecond),
+		WithLogger(logger()),
+	)
+
+	next := make(chan []byte)
+	err = client.Subscribe(ctx, GraphQLSubscriptionOptions{
+		URL:           server.URL,
+		Body:          postReqBody,
+		UseSSE:        true,
+		SSEMethodPost: true,
 	}, next)
 	assert.NoError(t, err)
 
@@ -345,4 +412,61 @@ func TestGraphQLSubscriptionClientSubscribe_SSE_Upstream_Dies(t *testing.T) {
 		return true
 	}, time.Second, time.Millisecond*10, "server did not close")
 	serverCancel()
+}
+
+func TestBuildPOSTRequestSSE(t *testing.T) {
+	subscriptionOptions := GraphQLSubscriptionOptions{
+		URL: "test",
+		Body: GraphQLBody{
+			Query:         `subscription($a: Int!){countdown(from: $a)}`,
+			OperationName: "CountDown",
+			Variables:     []byte(`{"a":5}`),
+			Extensions:    []byte(`{"persistedQuery":{"version":1,"sha256Hash":"d41d8cd98f00b204e9800998ecf8427e"}}`),
+		},
+	}
+
+	h := gqlSSEConnectionHandler{
+		options: subscriptionOptions,
+	}
+
+	req, err := h.buildPOSTRequest(context.Background())
+	assert.NoError(t, err)
+
+	expectedReqBody, err := json.Marshal(subscriptionOptions.Body)
+	assert.NoError(t, err)
+
+	assert.Equal(t, http.MethodPost, req.Method)
+
+	actualReqBody, err := ioutil.ReadAll(req.Body)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedReqBody, actualReqBody)
+}
+
+func TestBuildGETRequestSSE(t *testing.T) {
+	subscriptionOptions := GraphQLSubscriptionOptions{
+		URL: "test",
+		Body: GraphQLBody{
+			Query:         `subscription($a: Int!){countdown(from: $a)}`,
+			OperationName: "CountDown",
+			Variables:     []byte(`{"a":5}`),
+			Extensions:    []byte(`{"persistedQuery":{"version":1,"sha256Hash":"d41d8cd98f00b204e9800998ecf8427e"}}`),
+		},
+	}
+
+	h := gqlSSEConnectionHandler{
+		options: subscriptionOptions,
+	}
+
+	req, err := h.buildGETRequest(context.Background())
+	assert.NoError(t, err)
+
+	assert.Equal(t, http.MethodGet, req.Method)
+
+	urlQuery := req.URL.Query()
+	assert.Equal(t, subscriptionOptions.Body.Query, urlQuery.Get("query"))
+	assert.Equal(t, subscriptionOptions.Body.OperationName, urlQuery.Get("operationName"))
+
+	assert.Equal(t, string(subscriptionOptions.Body.Variables), urlQuery.Get("variables"))
+	assert.Equal(t, string(subscriptionOptions.Body.Extensions), urlQuery.Get("extensions"))
+
 }

--- a/pkg/engine/datasource/httpclient/httpclient.go
+++ b/pkg/engine/datasource/httpclient/httpclient.go
@@ -24,9 +24,9 @@ const (
 	HEADER        = "header"
 	QUERYPARAMS   = "query_params"
 	USESSE        = "use_sse"
-
-	SCHEME = "scheme"
-	HOST   = "host"
+	SSEMETHODPOST = "sse_method_post"
+	SCHEME        = "scheme"
+	HOST          = "host"
 )
 
 var (

--- a/pkg/engine/plan/plan.go
+++ b/pkg/engine/plan/plan.go
@@ -1046,13 +1046,14 @@ func (v *Visitor) resolveInputTemplates(config objectFetchConfiguration, input *
 			if !exists {
 				break
 			}
+
 			var variablePath []string
-			switch node.Kind {
-			case ast.NodeKindInputObjectTypeDefinition:
-				variablePath = append(variablePath, path...)
-			default:
-				variablePath = append(variablePath, variableValue)
+			if len(parts) > 2 && node.Kind == ast.NodeKindInputObjectTypeDefinition {
+					variablePath = append(variablePath, path...)
+			} else {
+					variablePath = append(variablePath, variableValue)
 			}
+
 			variable := &resolve.ContextVariable{
 				Path: variablePath,
 			}

--- a/pkg/engine/plan/plan.go
+++ b/pkg/engine/plan/plan.go
@@ -151,6 +151,7 @@ type ArgumentConfiguration struct {
 	SourceType   SourceType
 	SourcePath   []string
 	RenderConfig ArgumentRenderConfig
+	RenameTypeTo string
 }
 
 type DataSourceConfiguration struct {

--- a/pkg/graphql/execution_engine_v2_test.go
+++ b/pkg/graphql/execution_engine_v2_test.go
@@ -551,7 +551,16 @@ func TestExecutionEngineV2_Execute(t *testing.T) {
 			dataSources: []plan.DataSourceConfiguration{
 				{
 					RootNodes: []plan.TypeField{
-						{TypeName: "Query", FieldNames: []string{"hero"}},
+						{
+							TypeName:   "Query",
+							FieldNames: []string{"hero"},
+						},
+					},
+					ChildNodes: []plan.TypeField{
+						{
+							TypeName:   "Character",
+							FieldNames: []string{"name"},
+						},
 					},
 					Factory: &graphql_datasource.Factory{
 						HTTPClient: testNetHttpClient(t, roundTripperTestCase{
@@ -586,7 +595,16 @@ func TestExecutionEngineV2_Execute(t *testing.T) {
 			dataSources: []plan.DataSourceConfiguration{
 				{
 					RootNodes: []plan.TypeField{
-						{TypeName: "Query", FieldNames: []string{"hero"}},
+						{
+							TypeName:   "Query",
+							FieldNames: []string{"hero"},
+						},
+					},
+					ChildNodes: []plan.TypeField{
+						{
+							TypeName:   "Character",
+							FieldNames: []string{"name"},
+						},
 					},
 					Factory: &graphql_datasource.Factory{
 						HTTPClient: testNetHttpClient(t, roundTripperTestCase{
@@ -617,7 +635,16 @@ func TestExecutionEngineV2_Execute(t *testing.T) {
 			dataSources: []plan.DataSourceConfiguration{
 				{
 					RootNodes: []plan.TypeField{
-						{TypeName: "Query", FieldNames: []string{"droid"}},
+						{
+							TypeName:   "Query",
+							FieldNames: []string{"droid"},
+						},
+					},
+					ChildNodes: []plan.TypeField{
+						{
+							TypeName:   "Droid",
+							FieldNames: []string{"name"},
+						},
 					},
 					Factory: &graphql_datasource.Factory{
 						HTTPClient: testNetHttpClient(t, roundTripperTestCase{
@@ -636,7 +663,20 @@ func TestExecutionEngineV2_Execute(t *testing.T) {
 					}),
 				},
 			},
-			fields:           []plan.FieldConfiguration{},
+			fields: []plan.FieldConfiguration{
+				{
+					TypeName:  "Query",
+					FieldName: "droid",
+					Path:      []string{"droid"},
+					Arguments: []plan.ArgumentConfiguration{
+						{
+							Name:         "id",
+							SourceType:   plan.FieldArgumentSource,
+							RenderConfig: plan.RenderArgumentAsGraphQLValue,
+						},
+					},
+				},
+			},
 			expectedResponse: `{"data":{"droid":{"name":"R2D2"}}}`,
 		},
 	))
@@ -708,13 +748,22 @@ func TestExecutionEngineV2_Execute(t *testing.T) {
 		dataSources: []plan.DataSourceConfiguration{
 			{
 				RootNodes: []plan.TypeField{
-					{TypeName: "Query", FieldNames: []string{"charactersByIds"}},
+					{
+						TypeName:   "Query",
+						FieldNames: []string{"charactersByIds"},
+					},
+				},
+				ChildNodes: []plan.TypeField{
+					{
+						TypeName:   "Character",
+						FieldNames: []string{"name"},
+					},
 				},
 				Factory: &graphql_datasource.Factory{
 					HTTPClient: testNetHttpClient(t, roundTripperTestCase{
 						expectedHost:     "example.com",
 						expectedPath:     "/",
-						expectedBody:     `{"query":"query($a: [Int]){charactersByIds(ids: $a)}","variables":{"a":[1]}}`,
+						expectedBody:     `{"query":"query($a: [Int]){charactersByIds(ids: $a){name}}","variables":{"a":[1]}}`,
 						sendResponseBody: `{"data":{"charactersByIds":[{"name": "Luke"}]}}`,
 						sendStatusCode:   200,
 					}),
@@ -734,8 +783,9 @@ func TestExecutionEngineV2_Execute(t *testing.T) {
 				Path:      []string{"charactersByIds"},
 				Arguments: []plan.ArgumentConfiguration{
 					{
-						Name:       "ids",
-						SourceType: plan.FieldArgumentSource,
+						Name:         "ids",
+						SourceType:   plan.FieldArgumentSource,
+						RenderConfig: plan.RenderArgumentAsGraphQLValue,
 					},
 				},
 			},
@@ -757,13 +807,22 @@ func TestExecutionEngineV2_Execute(t *testing.T) {
 		dataSources: []plan.DataSourceConfiguration{
 			{
 				RootNodes: []plan.TypeField{
-					{TypeName: "Query", FieldNames: []string{"charactersByIds"}},
+					{
+						TypeName:   "Query",
+						FieldNames: []string{"charactersByIds"},
+					},
+				},
+				ChildNodes: []plan.TypeField{
+					{
+						TypeName:   "Character",
+						FieldNames: []string{"name"},
+					},
 				},
 				Factory: &graphql_datasource.Factory{
 					HTTPClient: testNetHttpClient(t, roundTripperTestCase{
 						expectedHost:     "example.com",
 						expectedPath:     "/",
-						expectedBody:     `{"query":"query($ids: [Int]){charactersByIds(ids: $ids)}","variables":{"ids":[1]}}`,
+						expectedBody:     `{"query":"query($ids: [Int]){charactersByIds(ids: $ids){name}}","variables":{"ids":[1]}}`,
 						sendResponseBody: `{"data":{"charactersByIds":[{"name": "Luke"}]}}`,
 						sendStatusCode:   200,
 					}),
@@ -783,8 +842,9 @@ func TestExecutionEngineV2_Execute(t *testing.T) {
 				Path:      []string{"charactersByIds"},
 				Arguments: []plan.ArgumentConfiguration{
 					{
-						Name:       "ids",
-						SourceType: plan.FieldArgumentSource,
+						Name:         "ids",
+						SourceType:   plan.FieldArgumentSource,
+						RenderConfig: plan.RenderArgumentAsGraphQLValue,
 					},
 				},
 			},
@@ -799,7 +859,16 @@ func TestExecutionEngineV2_Execute(t *testing.T) {
 			dataSources: []plan.DataSourceConfiguration{
 				{
 					RootNodes: []plan.TypeField{
-						{TypeName: "Query", FieldNames: []string{"droid"}},
+						{
+							TypeName:   "Query",
+							FieldNames: []string{"droid"},
+						},
+					},
+					ChildNodes: []plan.TypeField{
+						{
+							TypeName:   "Droid",
+							FieldNames: []string{"name"},
+						},
 					},
 					Factory: &graphql_datasource.Factory{
 						HTTPClient: testNetHttpClient(t, roundTripperTestCase{
@@ -818,7 +887,19 @@ func TestExecutionEngineV2_Execute(t *testing.T) {
 					}),
 				},
 			},
-			fields:           []plan.FieldConfiguration{},
+			fields: []plan.FieldConfiguration{
+				{
+					TypeName:  "Query",
+					FieldName: "droid",
+					Arguments: []plan.ArgumentConfiguration{
+						{
+							Name:         "id",
+							SourceType:   plan.FieldArgumentSource,
+							RenderConfig: plan.RenderArgumentAsGraphQLValue,
+						},
+					},
+				},
+			},
 			expectedResponse: `{"data":{"droid":{"name":"R2D2"}}}`,
 		},
 	))
@@ -1461,7 +1542,16 @@ func TestExecutionWithOptions(t *testing.T) {
 		dataSources: []plan.DataSourceConfiguration{
 			{
 				RootNodes: []plan.TypeField{
-					{TypeName: "Query", FieldNames: []string{"hero"}},
+					{
+						TypeName:   "Query",
+						FieldNames: []string{"hero"},
+					},
+				},
+				ChildNodes: []plan.TypeField{
+					{
+						TypeName:   "Character",
+						FieldNames: []string{"name"},
+					},
 				},
 				Factory: &graphql_datasource.Factory{
 					HTTPClient: testNetHttpClient(t, roundTripperTestCase{
@@ -1501,7 +1591,7 @@ func TestExecutionWithOptions(t *testing.T) {
 	resultWriter := NewEngineResultWriter()
 	err = engine.Execute(context.Background(), &operation, &resultWriter, WithBeforeFetchHook(before), WithAfterFetchHook(after))
 
-	assert.Equal(t, `{"method":"GET","url":"https://example.com/","body":{"query":"{hero}"}}`, before.input)
+	assert.Equal(t, `{"method":"GET","url":"https://example.com/","body":{"query":"{hero {name}}"}}`, before.input)
 	assert.Equal(t, `{"hero":{"name":"Luke Skywalker"}}`, after.data)
 	assert.Equal(t, "", after.err)
 	assert.NoError(t, err)


### PR DESCRIPTION
This PR contains changes from:

 - Custom Scalar Replacement: https://github.com/wundergraph/graphql-go-tools/pull/456
 - Add support for requests in SSE Subscriptions: https://github.com/wundergraph/graphql-go-tools/pull/449
 - Fix planning variable path: https://github.com/wundergraph/graphql-go-tools/pull/464

Use commit view to review single commits.