### PR TITLE
[TT-6137] Can't close all subscriptions when more than one are opened…

### DIFF
--- a/pkg/subscription/context.go
+++ b/pkg/subscription/context.go
@@ -2,6 +2,7 @@ package subscription
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 )
 
@@ -19,10 +20,15 @@ func NewInitialHttpRequestContext(r *http.Request) *InitialHttpRequestContext {
 
 type subscriptionCancellations map[string]context.CancelFunc
 
-func (sc subscriptionCancellations) Add(id string) context.Context {
+func (sc subscriptionCancellations) Add(id string) (context.Context, error) {
+	_, ok := sc[id]
+	if ok {
+		return nil, fmt.Errorf("subscriber for %s already exists", id)
+	}
+
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	sc[id] = cancelFunc
-	return ctx
+	return ctx, nil
 }
 
 func (sc subscriptionCancellations) Cancel(id string) (ok bool) {

--- a/pkg/subscription/context_test.go
+++ b/pkg/subscription/context_test.go
@@ -26,11 +26,13 @@ func TestNewInitialHttpRequestContext(t *testing.T) {
 func TestSubscriptionCancellations(t *testing.T) {
 	cancellations := subscriptionCancellations{}
 	var ctx context.Context
+	var err error
 
 	t.Run("should add a cancellation func to map", func(t *testing.T) {
 		require.Equal(t, 0, len(cancellations))
 
-		ctx = cancellations.Add("1")
+		ctx, err = cancellations.Add("1")
+		assert.Nil(t, err)
 		assert.Equal(t, 1, len(cancellations))
 		assert.NotNil(t, ctx)
 	})
@@ -47,4 +49,25 @@ func TestSubscriptionCancellations(t *testing.T) {
 		assert.True(t, ok)
 		assert.Equal(t, 0, len(cancellations))
 	})
+}
+
+func TestSubscriptionIdsShouldBeUnique(t *testing.T) {
+	cancellations := subscriptionCancellations{}
+	var ctx context.Context
+	var err error
+
+	ctx, err = cancellations.Add("1")
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(cancellations))
+	assert.NotNil(t, ctx)
+
+	ctx, err = cancellations.Add("2")
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(cancellations))
+	assert.NotNil(t, ctx)
+
+	ctx, err = cancellations.Add("2")
+	assert.NotNil(t, err)
+	assert.Equal(t, 2, len(cancellations))
+	assert.Nil(t, ctx)
 }

--- a/pkg/subscription/handler.go
+++ b/pkg/subscription/handler.go
@@ -197,7 +197,11 @@ func (h *Handler) handleStart(id string, payload []byte) {
 	}
 
 	if executor.OperationType() == ast.OperationTypeSubscription {
-		ctx := h.subCancellations.Add(id)
+		ctx, subsErr := h.subCancellations.Add(id)
+		if subsErr != nil {
+			h.handleError(id, graphql.RequestErrorsFromError(subsErr))
+			return
+		}
 		go h.startSubscription(ctx, id, executor)
 		return
 	}


### PR DESCRIPTION
… (#325)

PR for
[TT-6137](https://tyktech.atlassian.net/jira/software/c/projects/TT/boards/26?modal=detail&selectedIssue=TT-6137).

Currently, we implement `graphql-ws` protocol for the communication between GW and the clients. This protocol supports running many subscriptions on a single WebSocket connection. It utilizes subscription ids to implement that feature. In our implementation, we don’t consider about the uniqueness of the message ids.

Our implementation keeps ids per connection. So the ids are not global. See the following code snippet from the library:

**handleStart**:

```go
if executor.OperationType() == ast.OperationTypeSubscription {
		ctx := h.subCancellations.Add(id)
		go h.startSubscription(ctx, id, executor)
		return
}
```

**Add**:

```go
func (sc subscriptionCancellations) Add(id string) context.Context {
	ctx, cancelFunc := context.WithCancel(context.Background())
	sc[id] = cancelFunc
	return ctx
}
```

When you send a message with an id that’s used before, the library doesn’t check the previous subscriptions, creates a new context, and inserts it into the map.

_The protocol doesn’t specify any behavior to keep the previous subscriptions but we definitely lost control over the existing subscriptions._

See `GQL_START` message definition in the deprecated protocol: [subscriptions-transport-ws/PROTOCOL.md at master · apollographql/subscriptions-transport-ws](https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md#gql_start)

`graphqls-transport-ws` protocol (the new one) defines a condition for message id uniqueness. See the following clause:

> If there is already an active subscriber for an operation matching the
provided ID, regardless of the operation type, the server must close the socket immediately with the event 4409: Subscriber for <unique-operation-id> already exists.

**Solution**

`graphql-ws` protocol doesn’t clearly define a condition for id collision but it definitely creates a huge problem. We should check the message id before creating a subscription and return an error message if there is a collision.

Now we return the following error message if a subscription id collides with a previous one:

```json
[{"message":"subscriber for 1 already exists"}]
```

**Follow up task:**

We should update the documentation and advise our users to use **UUID4** or **UUID1** to generate a message-id to prevent a collision.

This fix doesn't break the playground app in Tyk Dashboard. It opens a new connection for every subscription request. The problem arises when you want to run more than one subscriptions using a single WebSocket connection.

[TT-6137]: https://tyktech.atlassian.net/browse/TT-6137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TT-6137]: https://tyktech.atlassian.net/browse/TT-6137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ