### PR TITLE
[TT-7468] Configuring UDG Schema based on info parsed from AsyncAPI spec

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/gorilla/websocket v1.5.0
 	github.com/gotestyourself/gotestyourself v1.4.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.4
-	github.com/iancoleman/strcase v0.0.0-20191112232945-16388991a334
+	github.com/iancoleman/strcase v0.2.0
 	github.com/jensneuse/abstractlogger v0.0.4
 	github.com/jensneuse/byte-template v0.0.0-20200214152254-4f3cf06e5c68
 	github.com/jensneuse/diffview v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -156,8 +156,8 @@ github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huandu/xstrings v1.2.1 h1:v6IdmkCnDhJG/S0ivr58PeIfg+tyhqQYy4YsCsQ0Pdc=
 github.com/huandu/xstrings v1.2.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
-github.com/iancoleman/strcase v0.0.0-20191112232945-16388991a334 h1:VHgatEHNcBFEB7inlalqfNqw65aNkM1lGX2yt3NmbS8=
-github.com/iancoleman/strcase v0.0.0-20191112232945-16388991a334/go.mod h1:SK73tn/9oHe+/Y0h39VT4UCxmurVJkR5NA7kMEAOgSE=
+github.com/iancoleman/strcase v0.2.0 h1:05I4QRnGpI0m37iZQRuskXh+w77mr6Z41lwQzuHLwW0=
+github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.8 h1:CGgOkSJeqMRmt0D9XLWExdT4m4F1vd3FV3VPt+0VxkQ=
 github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=

--- a/pkg/asyncapi/asyncapi_test.go
+++ b/pkg/asyncapi/asyncapi_test.go
@@ -13,6 +13,9 @@ var expectedAsyncAPI220andBelow = &AsyncAPI{
 	Channels: map[string]*ChannelItem{
 		"smartylighting.streetlights.1.0.action.{streetlightId}.dim": {
 			OperationID: "dimLight",
+			Parameters: map[string]string{
+				"streetlightId": "string",
+			},
 			Traits: []*OperationTrait{
 				{
 					Bindings: map[string]map[string]*Binding{
@@ -53,6 +56,9 @@ var expectedAsyncAPI220andBelow = &AsyncAPI{
 		},
 		"smartylighting.streetlights.1.0.action.{streetlightId}.turn.off": {
 			OperationID: "turnOff",
+			Parameters: map[string]string{
+				"streetlightId": "string",
+			},
 			Traits: []*OperationTrait{
 				{
 					Bindings: map[string]map[string]*Binding{
@@ -101,6 +107,9 @@ var expectedAsyncAPI220andBelow = &AsyncAPI{
 		},
 		"smartylighting.streetlights.1.0.action.{streetlightId}.turn.on": {
 			OperationID: "turnOn",
+			Parameters: map[string]string{
+				"streetlightId": "string",
+			},
 			Traits: []*OperationTrait{
 				{
 					Bindings: map[string]map[string]*Binding{
@@ -163,6 +172,9 @@ var expectedAsyncAPI240AndBelow = &AsyncAPI{
 		"smartylighting.streetlights.1.0.action.{streetlightId}.dim": {
 			OperationID: "dimLight",
 			Traits:      []*OperationTrait{{Bindings: map[string]map[string]*Binding{}}},
+			Parameters: map[string]string{
+				"streetlightId": "string",
+			},
 			Message: &Message{
 				Name:    "dimLight",
 				Summary: "Command a particular streetlight to dim the lights.",
@@ -188,6 +200,9 @@ var expectedAsyncAPI240AndBelow = &AsyncAPI{
 		"smartylighting.streetlights.1.0.action.{streetlightId}.turn.off": {
 			OperationID: "turnOff",
 			Traits:      []*OperationTrait{{Bindings: map[string]map[string]*Binding{}}},
+			Parameters: map[string]string{
+				"streetlightId": "string",
+			},
 			Message: &Message{
 				Name:    "turnOnOff",
 				Summary: "Command a particular streetlight to turn the lights on or off.",
@@ -221,6 +236,9 @@ var expectedAsyncAPI240AndBelow = &AsyncAPI{
 		"smartylighting.streetlights.1.0.action.{streetlightId}.turn.on": {
 			OperationID: "turnOn",
 			Traits:      []*OperationTrait{{Bindings: map[string]map[string]*Binding{}}},
+			Parameters: map[string]string{
+				"streetlightId": "string",
+			},
 			Message: &Message{
 				Name:    "turnOnOff",
 				Summary: "Command a particular streetlight to turn the lights on or off.",
@@ -291,6 +309,9 @@ func TestAsyncAPIStreetLightsKafkaSecurity(t *testing.T) {
 				OperationID: "dimLight",
 				Servers:     []string{"test_oauth"},
 				Traits:      []*OperationTrait{{Bindings: map[string]map[string]*Binding{}}},
+				Parameters: map[string]string{
+					"streetlightId": "string",
+				},
 				Message: &Message{
 					Name:    "dimLight",
 					Summary: "Command a particular streetlight to dim the lights.",
@@ -317,6 +338,9 @@ func TestAsyncAPIStreetLightsKafkaSecurity(t *testing.T) {
 				OperationID: "turnOff",
 				Servers:     []string{"test_oauth"},
 				Traits:      []*OperationTrait{{Bindings: map[string]map[string]*Binding{}}},
+				Parameters: map[string]string{
+					"streetlightId": "string",
+				},
 				Message: &Message{
 					Name:    "turnOnOff",
 					Summary: "Command a particular streetlight to turn the lights on or off.",
@@ -351,6 +375,9 @@ func TestAsyncAPIStreetLightsKafkaSecurity(t *testing.T) {
 				OperationID: "turnOn",
 				Servers:     []string{"test_oauth"},
 				Traits:      []*OperationTrait{{Bindings: map[string]map[string]*Binding{}}},
+				Parameters: map[string]string{
+					"streetlightId": "string",
+				},
 				Message: &Message{
 					Name:    "turnOnOff",
 					Summary: "Command a particular streetlight to turn the lights on or off.",

--- a/pkg/asyncapi/converter.go
+++ b/pkg/asyncapi/converter.go
@@ -1,0 +1,249 @@
+package asyncapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/TykTechnologies/graphql-go-tools/pkg/ast"
+	"github.com/TykTechnologies/graphql-go-tools/pkg/introspection"
+	"github.com/TykTechnologies/graphql-go-tools/pkg/lexer/literal"
+	"github.com/TykTechnologies/graphql-go-tools/pkg/operationreport"
+	"github.com/buger/jsonparser"
+	"github.com/iancoleman/strcase"
+)
+
+type converter struct {
+	asyncapi          *AsyncAPI
+	introspectionData *introspection.Data
+	knownEnums        map[string]struct{}
+	knownTypes        map[string]struct{}
+}
+
+// __TypeKind of introspection is an unexported type. In order to overcome the problem,
+// this function creates and returns a TypeRef for a given kind. kind is a AsyncAPI type.
+func getTypeRef(kind string) (introspection.TypeRef, error) {
+	// See introspection_enum.go
+	switch kind {
+	case "string", "integer", "number", "boolean":
+		return introspection.TypeRef{Kind: 0}, nil
+	case "object":
+		return introspection.TypeRef{Kind: 3}, nil
+	case "array":
+		return introspection.TypeRef{Kind: 1}, nil
+	}
+	return introspection.TypeRef{}, errors.New("unknown type")
+}
+
+func asyncAPITypeToGQLType(asyncAPIType string) (string, error) {
+	// See https://www.asyncapi.com/docs/reference/specification/v2.4.0#dataTypeFormat
+	switch asyncAPIType {
+	case "string":
+		return string(literal.STRING), nil
+	case "integer":
+		return string(literal.INT), nil
+	case "number":
+		return string(literal.FLOAT), nil
+	case "boolean":
+		return string(literal.BOOLEAN), nil
+	default:
+		return "", fmt.Errorf("unknown type: %s", asyncAPIType)
+	}
+}
+
+func (c *converter) importEnumType(name string, enums []*Enum) *introspection.FullType {
+	enumName := strcase.ToCamel(name)
+	_, ok := c.knownEnums[enumName]
+	if ok {
+		return nil
+	}
+
+	enumType := &introspection.FullType{
+		Kind: introspection.ENUM,
+		Name: enumName,
+	}
+	for _, enum := range enums {
+		if enum.ValueType == jsonparser.String {
+			enumType.EnumValues = append(enumType.EnumValues, introspection.EnumValue{
+				Name: strings.ToUpper(strcase.ToSnake(string(enum.Value))),
+			})
+		}
+	}
+	c.knownEnums[name] = struct{}{}
+	return enumType
+}
+
+func (c *converter) importFullTypes() ([]introspection.FullType, error) {
+	fullTypes := make([]introspection.FullType, 0)
+	for _, channelItem := range c.asyncapi.Channels {
+		msg := channelItem.Message
+
+		fullTypeName := strcase.ToCamel(msg.Name)
+		if _, ok := c.knownTypes[fullTypeName]; ok {
+			continue
+		}
+
+		var sb = strings.Builder{}
+		sb.WriteString(msg.Title)
+		sb.WriteString("\n")
+		sb.WriteString(msg.Summary)
+		sb.WriteString("\n")
+		sb.WriteString(msg.Description)
+		ft := introspection.FullType{
+			Kind:        introspection.OBJECT,
+			Name:        fullTypeName,
+			Description: strings.TrimSpace(sb.String()),
+		}
+
+		for name, prop := range msg.Payload.Properties {
+			var f introspection.Field
+			if prop.Enum == nil {
+				gqlType, err := asyncAPITypeToGQLType(prop.Type)
+				if err != nil {
+					return nil, err
+				}
+				typeRef, err := getTypeRef(prop.Type)
+				if err != nil {
+					return nil, err
+				}
+				typeRef.Name = &gqlType
+				f = introspection.Field{
+					Name:        name,
+					Description: prop.Description,
+					Type:        typeRef,
+				}
+			} else {
+				// ENUM type and its fields.
+				enumType := c.importEnumType(name, prop.Enum)
+				if enumType != nil {
+					fullTypes = append(fullTypes, *enumType)
+				}
+				enumTypeName := strcase.ToCamel(name)
+				typeRef, err := getTypeRef(prop.Type)
+				if err != nil {
+					return nil, err
+				}
+				typeRef.Name = &enumTypeName
+				f = introspection.Field{
+					Name:        name,
+					Description: prop.Description,
+					Type:        typeRef,
+				}
+			}
+			ft.Fields = append(ft.Fields, f)
+			sort.Slice(ft.Fields, func(i, j int) bool {
+				return ft.Fields[i].Name < ft.Fields[j].Name
+			})
+		}
+
+		c.knownTypes[fullTypeName] = struct{}{}
+		fullTypes = append(fullTypes, ft)
+		sort.Slice(fullTypes, func(i, j int) bool {
+			return fullTypes[i].Name < fullTypes[j].Name
+		})
+	}
+	return fullTypes, nil
+}
+
+func (c *converter) importSubscriptionType() (*introspection.FullType, error) {
+	subscriptionType := &introspection.FullType{
+		Kind: introspection.OBJECT,
+		Name: "Subscription",
+	}
+	for _, channelItem := range c.asyncapi.Channels {
+		typeName := strcase.ToCamel(channelItem.Message.Name)
+		typeRef, err := getTypeRef("object")
+		if err != nil {
+			return nil, err
+		}
+		typeRef.Name = &typeName
+		f := introspection.Field{
+			Name: channelItem.OperationID,
+			Type: typeRef,
+		}
+		for paramName, paramType := range channelItem.Parameters {
+			gqlType, err := asyncAPITypeToGQLType(paramType)
+			if err != nil {
+				return nil, err
+			}
+
+			paramTypeRef, err := getTypeRef(paramType)
+			if err != nil {
+				return nil, err
+			}
+			paramTypeRef.Name = &gqlType
+
+			iv := introspection.InputValue{
+				Name: paramName,
+				Type: paramTypeRef,
+			}
+			f.Args = append(f.Args, iv)
+			sort.Slice(f.Args, func(i, j int) bool {
+				return f.Args[i].Name < f.Args[j].Name
+			})
+		}
+
+		subscriptionType.Fields = append(subscriptionType.Fields, f)
+		sort.Slice(subscriptionType.Fields, func(i, j int) bool {
+			return subscriptionType.Fields[i].Name < subscriptionType.Fields[j].Name
+		})
+	}
+	return subscriptionType, nil
+}
+
+func ImportAsyncAPIDocumentByte(input []byte) (*ast.Document, operationreport.Report) {
+	report := operationreport.Report{}
+	asyncapi, err := ParseAsyncAPIDocument(input)
+	if err != nil {
+		report.AddInternalError(err)
+		return nil, report
+	}
+
+	// A parsed AsyncAPI document may include the same enum type name more than once.
+	// In order to prevent from duplicated types in the resulting schema, we save the names.
+	c := &converter{
+		asyncapi:   asyncapi,
+		knownEnums: make(map[string]struct{}),
+		knownTypes: make(map[string]struct{}),
+	}
+
+	data := introspection.Data{}
+	data.Schema.SubscriptionType = &introspection.TypeName{
+		Name: "Subscription",
+	}
+	subscriptionType, err := c.importSubscriptionType()
+	if err != nil {
+		report.AddInternalError(err)
+		return nil, report
+	}
+	data.Schema.Types = append(data.Schema.Types, *subscriptionType)
+
+	fullTypes, err := c.importFullTypes()
+	if err != nil {
+		report.AddInternalError(err)
+		return nil, report
+	}
+	data.Schema.Types = append(data.Schema.Types, fullTypes...)
+
+	outputPretty, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		report.AddInternalError(err)
+		return nil, report
+	}
+
+	converter := introspection.JsonConverter{}
+	buf := bytes.NewBuffer(outputPretty)
+	doc, err := converter.GraphQLDocument(buf)
+	if err != nil {
+		report.AddInternalError(err)
+		return nil, report
+	}
+	return doc, report
+}
+
+func ImportAsyncAPIDocumentString(input string) (*ast.Document, operationreport.Report) {
+	return ImportAsyncAPIDocumentByte([]byte(input))
+}

--- a/pkg/asyncapi/converter.go
+++ b/pkg/asyncapi/converter.go
@@ -160,7 +160,7 @@ func (c *converter) importSubscriptionType() (*introspection.FullType, error) {
 		}
 		typeRef.Name = &typeName
 		f := introspection.Field{
-			Name: channelItem.OperationID,
+			Name: strcase.ToLowerCamel(channelItem.OperationID),
 			Type: typeRef,
 		}
 		for paramName, paramType := range channelItem.Parameters {

--- a/pkg/asyncapi/converter.go
+++ b/pkg/asyncapi/converter.go
@@ -17,10 +17,9 @@ import (
 )
 
 type converter struct {
-	asyncapi          *AsyncAPI
-	introspectionData *introspection.Data
-	knownEnums        map[string]struct{}
-	knownTypes        map[string]struct{}
+	asyncapi   *AsyncAPI
+	knownEnums map[string]struct{}
+	knownTypes map[string]struct{}
 }
 
 // __TypeKind of introspection is an unexported type. In order to overcome the problem,

--- a/pkg/asyncapi/converter_test.go
+++ b/pkg/asyncapi/converter_test.go
@@ -46,3 +46,37 @@ func TestImportAsyncAPIDocumentString_EmailService(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, string(graphqlDoc), w.String())
 }
+
+func TestImportAsyncAPIDocumentString_PaymentSystemSample(t *testing.T) {
+	asyncapiDoc, err := os.ReadFile("./fixtures/payment-system-sample-2.2.0.yaml")
+	require.NoError(t, err)
+	doc, report := ImportAsyncAPIDocumentString(string(asyncapiDoc))
+	if report.HasErrors() {
+		t.Fatal(report.Error())
+	}
+	require.NoError(t, err)
+	w := &bytes.Buffer{}
+	err = astprinter.PrintIndent(doc, nil, []byte("  "), w)
+	require.NoError(t, err)
+
+	graphqlDoc, err := os.ReadFile("./fixtures/payment-system-sample-2.2.0.graphql")
+	require.NoError(t, err)
+	require.Equal(t, string(graphqlDoc), w.String())
+}
+
+func TestImportAsyncAPIDocumentString_PaymentSample(t *testing.T) {
+	asyncapiDoc, err := os.ReadFile("./fixtures/payment-sample-2.0.0.yaml")
+	require.NoError(t, err)
+	doc, report := ImportAsyncAPIDocumentString(string(asyncapiDoc))
+	if report.HasErrors() {
+		t.Fatal(report.Error())
+	}
+	require.NoError(t, err)
+	w := &bytes.Buffer{}
+	err = astprinter.PrintIndent(doc, nil, []byte("  "), w)
+	require.NoError(t, err)
+
+	graphqlDoc, err := os.ReadFile("./fixtures/payment-sample-2.0.0.graphql")
+	require.NoError(t, err)
+	require.Equal(t, string(graphqlDoc), w.String())
+}

--- a/pkg/asyncapi/converter_test.go
+++ b/pkg/asyncapi/converter_test.go
@@ -1,0 +1,31 @@
+package asyncapi
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/TykTechnologies/graphql-go-tools/pkg/astprinter"
+	"github.com/stretchr/testify/require"
+)
+
+func TestImportAsyncAPIDocumentByte(t *testing.T) {
+	versions := []string{"2.0.0", "2.1.0", "2.2.0", "2.3.0", "2.4.0"}
+	for _, version := range versions {
+		asyncapiDoc, err := os.ReadFile(fmt.Sprintf("./fixtures/streetlights-kafka-%s.yaml", version))
+		require.NoError(t, err)
+		doc, report := ImportAsyncAPIDocumentByte(asyncapiDoc)
+		if report.HasErrors() {
+			t.Fatal(report.Error())
+		}
+		require.NoError(t, err)
+		w := &bytes.Buffer{}
+		err = astprinter.PrintIndent(doc, nil, []byte("  "), w)
+		require.NoError(t, err)
+
+		graphqlDoc, err := os.ReadFile("./fixtures/streetlights-kafka-2.4.0-and-below.graphql")
+		require.NoError(t, err)
+		require.Equal(t, string(graphqlDoc), w.String())
+	}
+}

--- a/pkg/asyncapi/converter_test.go
+++ b/pkg/asyncapi/converter_test.go
@@ -97,3 +97,20 @@ func TestImportAsyncAPIDocumentString_TradingSample(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, string(graphqlDoc), w.String())
 }
+
+func TestImportAsyncAPIDocumentString_PrintServiceAPI(t *testing.T) {
+	asyncapiDoc, err := os.ReadFile("./fixtures/print-service-api-2.0.0.yaml")
+	require.NoError(t, err)
+	doc, report := ImportAsyncAPIDocumentString(string(asyncapiDoc))
+	if report.HasErrors() {
+		t.Fatal(report.Error())
+	}
+	require.NoError(t, err)
+	w := &bytes.Buffer{}
+	err = astprinter.PrintIndent(doc, nil, []byte("  "), w)
+	require.NoError(t, err)
+
+	graphqlDoc, err := os.ReadFile("./fixtures/print-service-api-2.0.0.graphql")
+	require.NoError(t, err)
+	require.Equal(t, string(graphqlDoc), w.String())
+}

--- a/pkg/asyncapi/converter_test.go
+++ b/pkg/asyncapi/converter_test.go
@@ -10,6 +10,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func testFixtureFile(t *testing.T, name string) {
+	asyncapiDoc, err := os.ReadFile(fmt.Sprintf("./fixtures/%s.yaml", name))
+	require.NoError(t, err)
+	doc, report := ImportAsyncAPIDocumentString(string(asyncapiDoc))
+	if report.HasErrors() {
+		t.Fatal(report.Error())
+	}
+	require.NoError(t, err)
+	w := &bytes.Buffer{}
+	err = astprinter.PrintIndent(doc, nil, []byte("  "), w)
+	require.NoError(t, err)
+
+	graphqlDoc, err := os.ReadFile(fmt.Sprintf("./fixtures/%s.graphql", name))
+	require.NoError(t, err)
+	require.Equal(t, string(graphqlDoc), w.String())
+}
+
 func TestImportAsyncAPIDocumentString(t *testing.T) {
 	versions := []string{"2.0.0", "2.1.0", "2.2.0", "2.3.0", "2.4.0"}
 	for _, version := range versions {
@@ -30,104 +47,28 @@ func TestImportAsyncAPIDocumentString(t *testing.T) {
 	}
 }
 
-func TestImportAsyncAPIDocumentString_EmailService(t *testing.T) {
-	asyncapiDoc, err := os.ReadFile("./fixtures/email-service-2.0.0.yaml")
-	require.NoError(t, err)
-	doc, report := ImportAsyncAPIDocumentString(string(asyncapiDoc))
-	if report.HasErrors() {
-		t.Fatal(report.Error())
-	}
-	require.NoError(t, err)
-	w := &bytes.Buffer{}
-	err = astprinter.PrintIndent(doc, nil, []byte("  "), w)
-	require.NoError(t, err)
+func TestImportAsyncAPIDocumentString_Fixtures(t *testing.T) {
+	t.Run("email-service-2.0.0.yaml", func(t *testing.T) {
+		testFixtureFile(t, "email-service-2.0.0")
+	})
 
-	graphqlDoc, err := os.ReadFile("./fixtures/email-service-2.0.0.graphql")
-	require.NoError(t, err)
-	require.Equal(t, string(graphqlDoc), w.String())
-}
+	t.Run("payment-system-sample-2.2.0.yaml", func(t *testing.T) {
+		testFixtureFile(t, "payment-system-sample-2.2.0")
+	})
 
-func TestImportAsyncAPIDocumentString_PaymentSystemSample(t *testing.T) {
-	asyncapiDoc, err := os.ReadFile("./fixtures/payment-system-sample-2.2.0.yaml")
-	require.NoError(t, err)
-	doc, report := ImportAsyncAPIDocumentString(string(asyncapiDoc))
-	if report.HasErrors() {
-		t.Fatal(report.Error())
-	}
-	require.NoError(t, err)
-	w := &bytes.Buffer{}
-	err = astprinter.PrintIndent(doc, nil, []byte("  "), w)
-	require.NoError(t, err)
+	t.Run("payment-sample-2.0.0.yaml", func(t *testing.T) {
+		testFixtureFile(t, "payment-sample-2.0.0")
+	})
 
-	graphqlDoc, err := os.ReadFile("./fixtures/payment-system-sample-2.2.0.graphql")
-	require.NoError(t, err)
-	require.Equal(t, string(graphqlDoc), w.String())
-}
+	t.Run("trading-sample-2.0.0.yaml", func(t *testing.T) {
+		testFixtureFile(t, "trading-sample-2.0.0")
+	})
 
-func TestImportAsyncAPIDocumentString_PaymentSample(t *testing.T) {
-	asyncapiDoc, err := os.ReadFile("./fixtures/payment-sample-2.0.0.yaml")
-	require.NoError(t, err)
-	doc, report := ImportAsyncAPIDocumentString(string(asyncapiDoc))
-	if report.HasErrors() {
-		t.Fatal(report.Error())
-	}
-	require.NoError(t, err)
-	w := &bytes.Buffer{}
-	err = astprinter.PrintIndent(doc, nil, []byte("  "), w)
-	require.NoError(t, err)
+	t.Run("print-service-api-2.0.0.yaml", func(t *testing.T) {
+		testFixtureFile(t, "print-service-api-2.0.0")
+	})
 
-	graphqlDoc, err := os.ReadFile("./fixtures/payment-sample-2.0.0.graphql")
-	require.NoError(t, err)
-	require.Equal(t, string(graphqlDoc), w.String())
-}
-
-func TestImportAsyncAPIDocumentString_TradingSample(t *testing.T) {
-	asyncapiDoc, err := os.ReadFile("./fixtures/trading-sample-2.0.0.yaml")
-	require.NoError(t, err)
-	doc, report := ImportAsyncAPIDocumentString(string(asyncapiDoc))
-	if report.HasErrors() {
-		t.Fatal(report.Error())
-	}
-	require.NoError(t, err)
-	w := &bytes.Buffer{}
-	err = astprinter.PrintIndent(doc, nil, []byte("  "), w)
-	require.NoError(t, err)
-
-	graphqlDoc, err := os.ReadFile("./fixtures/trading-sample-2.0.0.graphql")
-	require.NoError(t, err)
-	require.Equal(t, string(graphqlDoc), w.String())
-}
-
-func TestImportAsyncAPIDocumentString_PrintServiceAPI(t *testing.T) {
-	asyncapiDoc, err := os.ReadFile("./fixtures/print-service-api-2.0.0.yaml")
-	require.NoError(t, err)
-	doc, report := ImportAsyncAPIDocumentString(string(asyncapiDoc))
-	if report.HasErrors() {
-		t.Fatal(report.Error())
-	}
-	require.NoError(t, err)
-	w := &bytes.Buffer{}
-	err = astprinter.PrintIndent(doc, nil, []byte("  "), w)
-	require.NoError(t, err)
-
-	graphqlDoc, err := os.ReadFile("./fixtures/print-service-api-2.0.0.graphql")
-	require.NoError(t, err)
-	require.Equal(t, string(graphqlDoc), w.String())
-}
-
-func TestImportAsyncAPIDocumentString_UserAPI(t *testing.T) {
-	asyncapiDoc, err := os.ReadFile("./fixtures/user-api-2.0.0.yaml")
-	require.NoError(t, err)
-	doc, report := ImportAsyncAPIDocumentString(string(asyncapiDoc))
-	if report.HasErrors() {
-		t.Fatal(report.Error())
-	}
-	require.NoError(t, err)
-	w := &bytes.Buffer{}
-	err = astprinter.PrintIndent(doc, nil, []byte("  "), w)
-	require.NoError(t, err)
-
-	graphqlDoc, err := os.ReadFile("./fixtures/user-api-2.0.0.graphql")
-	require.NoError(t, err)
-	require.Equal(t, string(graphqlDoc), w.String())
+	t.Run("user-api-2.0.0.yaml", func(t *testing.T) {
+		testFixtureFile(t, "user-api-2.0.0")
+	})
 }

--- a/pkg/asyncapi/converter_test.go
+++ b/pkg/asyncapi/converter_test.go
@@ -10,12 +10,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestImportAsyncAPIDocumentByte(t *testing.T) {
+func TestImportAsyncAPIDocumentString(t *testing.T) {
 	versions := []string{"2.0.0", "2.1.0", "2.2.0", "2.3.0", "2.4.0"}
 	for _, version := range versions {
 		asyncapiDoc, err := os.ReadFile(fmt.Sprintf("./fixtures/streetlights-kafka-%s.yaml", version))
 		require.NoError(t, err)
-		doc, report := ImportAsyncAPIDocumentByte(asyncapiDoc)
+		doc, report := ImportAsyncAPIDocumentString(string(asyncapiDoc))
 		if report.HasErrors() {
 			t.Fatal(report.Error())
 		}

--- a/pkg/asyncapi/converter_test.go
+++ b/pkg/asyncapi/converter_test.go
@@ -80,3 +80,20 @@ func TestImportAsyncAPIDocumentString_PaymentSample(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, string(graphqlDoc), w.String())
 }
+
+func TestImportAsyncAPIDocumentString_TradingSample(t *testing.T) {
+	asyncapiDoc, err := os.ReadFile("./fixtures/trading-sample-2.0.0.yaml")
+	require.NoError(t, err)
+	doc, report := ImportAsyncAPIDocumentString(string(asyncapiDoc))
+	if report.HasErrors() {
+		t.Fatal(report.Error())
+	}
+	require.NoError(t, err)
+	w := &bytes.Buffer{}
+	err = astprinter.PrintIndent(doc, nil, []byte("  "), w)
+	require.NoError(t, err)
+
+	graphqlDoc, err := os.ReadFile("./fixtures/trading-sample-2.0.0.graphql")
+	require.NoError(t, err)
+	require.Equal(t, string(graphqlDoc), w.String())
+}

--- a/pkg/asyncapi/converter_test.go
+++ b/pkg/asyncapi/converter_test.go
@@ -29,3 +29,20 @@ func TestImportAsyncAPIDocumentString(t *testing.T) {
 		require.Equal(t, string(graphqlDoc), w.String())
 	}
 }
+
+func TestImportAsyncAPIDocumentString_EmailService(t *testing.T) {
+	asyncapiDoc, err := os.ReadFile("./fixtures/email-service-2.0.0.yaml")
+	require.NoError(t, err)
+	doc, report := ImportAsyncAPIDocumentString(string(asyncapiDoc))
+	if report.HasErrors() {
+		t.Fatal(report.Error())
+	}
+	require.NoError(t, err)
+	w := &bytes.Buffer{}
+	err = astprinter.PrintIndent(doc, nil, []byte("  "), w)
+	require.NoError(t, err)
+
+	graphqlDoc, err := os.ReadFile("./fixtures/email-service-2.0.0.graphql")
+	require.NoError(t, err)
+	require.Equal(t, string(graphqlDoc), w.String())
+}

--- a/pkg/asyncapi/converter_test.go
+++ b/pkg/asyncapi/converter_test.go
@@ -114,3 +114,20 @@ func TestImportAsyncAPIDocumentString_PrintServiceAPI(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, string(graphqlDoc), w.String())
 }
+
+func TestImportAsyncAPIDocumentString_UserAPI(t *testing.T) {
+	asyncapiDoc, err := os.ReadFile("./fixtures/user-api-2.0.0.yaml")
+	require.NoError(t, err)
+	doc, report := ImportAsyncAPIDocumentString(string(asyncapiDoc))
+	if report.HasErrors() {
+		t.Fatal(report.Error())
+	}
+	require.NoError(t, err)
+	w := &bytes.Buffer{}
+	err = astprinter.PrintIndent(doc, nil, []byte("  "), w)
+	require.NoError(t, err)
+
+	graphqlDoc, err := os.ReadFile("./fixtures/user-api-2.0.0.graphql")
+	require.NoError(t, err)
+	require.Equal(t, string(graphqlDoc), w.String())
+}

--- a/pkg/asyncapi/fixtures/email-service-2.0.0.graphql
+++ b/pkg/asyncapi/fixtures/email-service-2.0.0.graphql
@@ -1,0 +1,21 @@
+schema {
+    subscription: Subscription
+}
+
+type Subscription {
+    emitUserSignUpEvent: UserSignedUp
+}
+
+"""
+User signed up event
+Inform about a new user registration in the system
+"""
+type UserSignedUp {
+    createdAt: String
+    "baz"
+    email: String
+    "foo"
+    firstName: String
+    "bar"
+    lastName: String
+}

--- a/pkg/asyncapi/fixtures/email-service-2.0.0.yaml
+++ b/pkg/asyncapi/fixtures/email-service-2.0.0.yaml
@@ -1,0 +1,50 @@
+asyncapi: 2.0.0
+info:
+  title: Account Service
+  version: '1.0.0'
+  description: |
+    Manages user accounts in the system.
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
+
+servers:
+  production:
+    url: mqtt://test.mosquitto.org
+    protocol: mqtt
+    description: Test MQTT broker
+
+channels:
+  user/signedup:
+    subscribe:
+      operationId: emitUserSignUpEvent
+      message:
+        $ref : '#/components/messages/UserSignedUp'
+
+components:
+  messages:
+    UserSignedUp:
+      name: userSignedUp
+      title: User signed up event
+      summary: Inform about a new user registration in the system
+      contentType: application/json
+      payload:
+        $ref: '#/components/schemas/userSignedUpPayload'
+
+  schemas:
+    userSignedUpPayload:
+      type: object
+      properties:
+        firstName:
+          type: string
+          description: "foo"
+        lastName:
+          type: string
+          description: "bar"
+        email:
+          type: string
+          format: email
+          description: "baz"
+        createdAt:
+          type: string
+          format: date-time

--- a/pkg/asyncapi/fixtures/email-service-2.0.0.yaml
+++ b/pkg/asyncapi/fixtures/email-service-2.0.0.yaml
@@ -1,3 +1,4 @@
+# source: https://www.asyncapi.com/blog/understanding-asyncapis
 asyncapi: 2.0.0
 info:
   title: Account Service

--- a/pkg/asyncapi/fixtures/payment-sample-2.0.0.graphql
+++ b/pkg/asyncapi/fixtures/payment-sample-2.0.0.graphql
@@ -1,0 +1,20 @@
+schema {
+    subscription: Subscription
+}
+
+type Subscription {
+    paymentApproved: Paymentapproved
+    paymentFailed: Paymentfailed
+}
+
+type Paymentapproved {
+    "Payment ID"
+    paymentId: String
+}
+
+type Paymentfailed {
+    "Payment ID"
+    paymentId: String
+    "Payment failure reason"
+    reason: String
+}

--- a/pkg/asyncapi/fixtures/payment-sample-2.0.0.yaml
+++ b/pkg/asyncapi/fixtures/payment-sample-2.0.0.yaml
@@ -1,3 +1,4 @@
+# source: https://ambassadorpatryk.com/2022/02/async-api-is-a-way-to-describe-event-driven-apis/
 asyncapi: 2.0.0
 info:
   title: Payment Service

--- a/pkg/asyncapi/fixtures/payment-sample-2.0.0.yaml
+++ b/pkg/asyncapi/fixtures/payment-sample-2.0.0.yaml
@@ -1,0 +1,61 @@
+asyncapi: 2.0.0
+info:
+  title: Payment Service
+  version: v1
+  description: This service is in charge of processing payments
+servers:
+  test:
+    url: test-broker.ambassadorpatryk.com
+    protocol: jms
+    description: This is JMS broker dedicated to test environments such as DEV/SIT
+  prod:
+    url: broker.ambassadorpatryk.com
+    protocol: jms
+    description: This is JMS broker dedicated to production
+channels:
+  payment/failed:
+    subscribe:
+      operationId: "paymentFailed"
+      message:
+        $ref: '#/components/messages/PaymentFailed'
+  payment/approved:
+    subscribe:
+      operationId: "paymentApproved"
+      message:
+        $ref: '#/components/messages/PaymentApproved'
+  payment:
+    publish:
+      summary: Create new payment
+      message:
+        $ref: '#/components/messages/Payment'
+components:
+  messages:
+    Payment:
+      payload:
+        type: object
+        properties:
+          paymentId:
+            type: string
+            description: Payment ID
+          amount:
+            type: number
+            description: Payment amount
+          description:
+            type: string
+    PaymentApproved:
+      payload:
+        type: object
+        properties:
+          paymentId:
+            type: string
+            description: Payment ID
+    PaymentFailed:
+      payload:
+        type: object
+        properties:
+          paymentId:
+            type: string
+            description: Payment ID
+          reason:
+            type: string
+            description: Payment failure reason

--- a/pkg/asyncapi/fixtures/payment-system-sample-2.2.0.graphql
+++ b/pkg/asyncapi/fixtures/payment-system-sample-2.2.0.graphql
@@ -1,0 +1,72 @@
+schema {
+    subscription: Subscription
+}
+
+type Subscription {
+    paymentFailedSub: PaymentFailed
+    paymentSucceededSub: PaymentSucceeded
+    userRegisteredSub: UserRegistered
+    userSubscribedSub: UserSubscribed
+    userUnsubscribedSub: UserUnsubscribed
+}
+
+type PaymentFailed {
+    "Timestamp of payment"
+    created_at: String
+    "ID of payment"
+    id: Int
+    "ID of plan"
+    plan_id: Int
+    "ID of user"
+    user_id: Int
+    "Value of payment"
+    value: Float
+}
+
+type PaymentSucceeded {
+    "Timestamp of payment"
+    created_at: String
+    "ID of payment"
+    id: Int
+    "ID of plan"
+    plan_id: Int
+    "ID of user"
+    user_id: Int
+    "Value of payment"
+    value: Float
+}
+
+type UserRegistered {
+    "E-mail of user"
+    email: String
+    "ID of user"
+    id: Int
+    "Name of user"
+    name: String
+    "Password of user"
+    password: String
+    "Timestamp of registration"
+    registered_at: String
+}
+
+type UserSubscribed {
+    "ID of subscription"
+    id: Int
+    "ID of plan"
+    plan_id: Int
+    "Name of plan"
+    plan_name: String
+    "Value of plan"
+    plan_value: Float
+    "Timestamp of subscription"
+    subscribed_at: String
+    "ID of user"
+    user_id: Int
+}
+
+type UserUnsubscribed {
+    "ID of subscription"
+    id: Int
+    "Timestamp of unsubscription"
+    unsubscribed_at: String
+}

--- a/pkg/asyncapi/fixtures/payment-system-sample-2.2.0.graphql
+++ b/pkg/asyncapi/fixtures/payment-system-sample-2.2.0.graphql
@@ -12,26 +12,26 @@ type Subscription {
 
 type PaymentFailed {
     "Timestamp of payment"
-    created_at: String
+    createdAt: String
     "ID of payment"
     id: Int
     "ID of plan"
-    plan_id: Int
+    planId: Int
     "ID of user"
-    user_id: Int
+    userId: Int
     "Value of payment"
     value: Float
 }
 
 type PaymentSucceeded {
     "Timestamp of payment"
-    created_at: String
+    createdAt: String
     "ID of payment"
     id: Int
     "ID of plan"
-    plan_id: Int
+    planId: Int
     "ID of user"
-    user_id: Int
+    userId: Int
     "Value of payment"
     value: Float
 }
@@ -46,27 +46,27 @@ type UserRegistered {
     "Password of user"
     password: String
     "Timestamp of registration"
-    registered_at: String
+    registeredAt: String
 }
 
 type UserSubscribed {
     "ID of subscription"
     id: Int
     "ID of plan"
-    plan_id: Int
+    planId: Int
     "Name of plan"
-    plan_name: String
+    planName: String
     "Value of plan"
-    plan_value: Float
+    planValue: Float
     "Timestamp of subscription"
-    subscribed_at: String
+    subscribedAt: String
     "ID of user"
-    user_id: Int
+    userId: Int
 }
 
 type UserUnsubscribed {
     "ID of subscription"
     id: Int
     "Timestamp of unsubscription"
-    unsubscribed_at: String
+    unsubscribedAt: String
 }

--- a/pkg/asyncapi/fixtures/payment-system-sample-2.2.0.yaml
+++ b/pkg/asyncapi/fixtures/payment-system-sample-2.2.0.yaml
@@ -1,0 +1,233 @@
+asyncapi: 2.2.0
+info:
+  title: AsyncAPI Sample
+  version: 1.0.0
+servers:
+  rabbitmq-dev:
+    url: localhost:5672
+    description: Local RabbitMQ
+    protocol: amqp
+    protocolVersion: "0.9.1"
+  rabbitmq-staging:
+    url: staging-rabbitmq.server.saas.com:5672
+    description: Staging RabbitMQ
+    protocol: amqp
+    protocolVersion: "0.9.1"
+  rabbitmq-prod:
+    url: rabbitmq.server.saas.com:5672
+    description: Production RabbitMQ
+    protocol: amqp
+    protocolVersion: "0.9.1"
+channels:
+  user-registered:
+    publish:
+      operationId: userRegisteredPub
+      description: The payload of user registration
+      message:
+        $ref: "#/components/messages/user"
+      bindings:
+        amqp:
+          timestamp: true
+          ack: false
+          bindingVersion: 0.2.0
+    subscribe:
+      operationId: userRegisteredSub
+      description: The payload of user registration
+      message:
+        $ref: "#/components/messages/user"
+    bindings:
+      amqp:
+        is: routingKey
+        exchange:
+          name: userExchange
+          type: direct
+          durable: true
+          vhost: /
+        bindingVersion: 0.2.0
+  user-subscribed:
+    publish:
+      operationId: userSubscribedPub
+      description: The payload of user subscription
+      message:
+        $ref: "#/components/messages/subscription"
+      bindings:
+        amqp:
+          timestamp: true
+          ack: false
+          bindingVersion: 0.2.0
+    subscribe:
+      operationId: userSubscribedSub
+      description: The payload of user subscription
+      message:
+        $ref: "#/components/messages/subscription"
+    bindings:
+      amqp:
+        is: routingKey
+        exchange:
+          name: subscriptionExchange
+          type: direct
+          durable: true
+          vhost: /
+        bindingVersion: 0.2.0
+  user-unsubscribed:
+    publish:
+      operationId: userUnsubscribedPub
+      description: The payload of user unsubscription
+      message:
+        $ref: "#/components/messages/unsubscription"
+      bindings:
+        amqp:
+          timestamp: true
+          ack: false
+          bindingVersion: 0.2.0
+    subscribe:
+      operationId: userUnsubscribedSub
+      description: The payload of user unsubscription
+      message:
+        $ref: "#/components/messages/unsubscription"
+    bindings:
+      amqp:
+        is: routingKey
+        exchange:
+          name: unsubscriptionExchange
+          type: direct
+          durable: true
+          vhost: /
+        bindingVersion: 0.2.0
+  payment-succeeded:
+    publish:
+      operationId: paymentSucceededPub
+      description: The payload of successful payment
+      message:
+        $ref: "#/components/messages/payment"
+      bindings:
+        amqp:
+          timestamp: true
+          ack: false
+          bindingVersion: 0.2.0
+    subscribe:
+      operationId: paymentSucceededSub
+      description: The payload of successful payment
+      message:
+        $ref: "#/components/messages/payment"
+    bindings:
+      amqp:
+        is: routingKey
+        exchange:
+          name: paymentSucceededExchange
+          type: direct
+          durable: true
+          vhost: /
+        bindingVersion: 0.2.0
+  payment-failed:
+    publish:
+      operationId: paymentFailedPub
+      description: The payload of failed payment
+      message:
+        $ref: "#/components/messages/payment"
+      bindings:
+        amqp:
+          timestamp: true
+          ack: false
+          bindingVersion: 0.2.0
+    subscribe:
+      operationId: paymentFailedSub
+      description: The payload of failed payment
+      message:
+        $ref: "#/components/messages/payment"
+    bindings:
+      amqp:
+        is: routingKey
+        exchange:
+          name: paymentFailedExchange
+          type: direct
+          durable: true
+          vhost: /
+        bindingVersion: 0.2.0
+components:
+  messages:
+    user:
+      payload:
+        type: object
+        properties:
+          id:
+            type: integer
+            format: int64
+            description: ID of user
+          name:
+            type: string
+            description: Name of user
+          email:
+            type: string
+            description: E-mail of user
+          password:
+            type: string
+            format: password
+            description: Password of user
+          registered_at:
+            type: string
+            format: date-time
+            description: Timestamp of registration
+    subscription:
+      payload:
+        type: object
+        properties:
+          id:
+            type: integer
+            format: int64
+            description: ID of subscription
+          user_id:
+            type: integer
+            format: int64
+            description: ID of user
+          plan_id:
+            type: integer
+            format: int64
+            description: ID of plan
+          plan_name:
+            type: string
+            description: Name of plan
+          plan_value:
+            type: number
+            format: float
+            description: Value of plan
+          subscribed_at:
+            type: string
+            format: date-time
+            description: Timestamp of subscription
+    unsubscription:
+      payload:
+        type: object
+        properties:
+          id:
+            type: integer
+            format: int64
+            description: ID of subscription
+          unsubscribed_at:
+            type: string
+            format: date-time
+            description: Timestamp of unsubscription
+    payment:
+      payload:
+        type: object
+        properties:
+          id:
+            type: integer
+            format: int64
+            description: ID of payment
+          user_id:
+            type: integer
+            format: int64
+            description: ID of user
+          plan_id:
+            type: integer
+            format: int64
+            description: ID of plan
+          value:
+            type: number
+            format: float
+            description: Value of payment
+          created_at:
+            type: string
+            format: date-time
+            description: Timestamp of payment

--- a/pkg/asyncapi/fixtures/payment-system-sample-2.2.0.yaml
+++ b/pkg/asyncapi/fixtures/payment-system-sample-2.2.0.yaml
@@ -1,3 +1,4 @@
+# source: https://eltonminetto.dev/en/post/2022-01-30-asyncapi/
 asyncapi: 2.2.0
 info:
   title: AsyncAPI Sample

--- a/pkg/asyncapi/fixtures/print-service-api-2.0.0.graphql
+++ b/pkg/asyncapi/fixtures/print-service-api-2.0.0.graphql
@@ -1,0 +1,13 @@
+schema {
+    subscription: Subscription
+}
+
+type Subscription {
+    printJobEvent(jobId: String): PrintJobEvent
+}
+
+"Print job event."
+type PrintJobEvent {
+    jobId: String
+    status: String
+}

--- a/pkg/asyncapi/fixtures/print-service-api-2.0.0.yaml
+++ b/pkg/asyncapi/fixtures/print-service-api-2.0.0.yaml
@@ -1,0 +1,249 @@
+# source: https://github.com/jcmellado/markdown-template/blob/master/examples/asyncapi.yml
+asyncapi: 2.0.0
+
+id: urn:com:example:print:api
+
+info:
+  title: Print Service API
+  version: 1.0.0
+  description: |-
+    Allows you to interact with printers. Using it you can:
+    * Create a print job
+    * Receive events on the print job
+  termsOfService: http://www.example.com/terms
+  contact:
+    name: API Support
+    url: https://www.example.com/support
+    email: support@example.com
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
+
+tags:
+  - name: asyncapi
+    description: The industry standard for defining asynchronous APIs.
+    externalDocs:
+      description: AsyncAPI specification 2.0.0
+      url: https://www.asyncapi.com/docs/specifications/2.0.0
+
+servers:
+
+  "Production":
+    url: https://api.print.example.com
+    protocol: amqp
+    protocolVersion: 0-9-1
+    description: Production server.
+    security:
+      - "OAuth 2":
+          - "read:user"
+          - "write:user"
+
+  "Staging":
+    url: mqtt://staging.api.print.example.com:{port}
+    protocol: mqtt
+    protocolVersion: v3.1.1
+    description: Staging server.
+    variables:
+      port:
+        enum:
+          - "1883"
+          - "8883"
+        default: "1883"
+        description: Secure connection (TLS) is available through port 8883.
+        examples:
+          - mqtt://staging.api.print.example.com
+          - mqtt://staging.api.print.example.com:1883
+          - mqtt://staging.api.print.example.com:8883
+    security:
+      - "API Key": []
+    bindings:
+      mqtt:
+        clientId: guest
+        cleanSession: false
+        lastWill:
+          topic: /last-wills
+          qos: 2
+          retain: false
+        keepAlive: 60
+        bindingVersion: 0.1.0
+
+defaultContentType: application/json
+
+channels:
+
+  commands/{queueId}:
+    description: The topic on which commands can be sent to a print queue.
+    publish:
+      operationId: printQueueCommand
+      summary: Sends commands to a print queue.
+      description: |-
+        Available commands:
+        * Create a print job
+        * Cancel a print job
+      externalDocs:
+        description: Print Queue Commands Documentation.
+        url: https://www.example.com/docs/api/queues/commands
+      message:
+        oneOf:
+          - $ref: "#/components/messages/createPrintJob"
+          - $ref: "#/components/messages/cancelPrintJob"
+    parameters:
+      queueId:
+        description: The identifier of the print queue.
+        schema:
+          type: string
+
+  events/{jobId}:
+    description: The queue on which print job events can be consumed.
+    subscribe:
+      operationId: printJobEvent
+      summary: Consumes print job events.
+      description: |-
+        Available events:
+        * Print job created
+        * Print job started
+        * Print job finished
+        * Print job canceled
+      tags:
+        - name: event
+          externalDocs:
+            description: Print job event.
+            url: https://www.example.com/docs/api/jobs/events
+        - name: queue
+          externalDocs:
+            description: Print queue.
+            url: https://www.example.com/docs/api/queues
+      externalDocs:
+        description: Print Job Events Documentation.
+        url: https://www.example.com/docs/api/jobs/events
+      bindings:
+        amqp:
+          expiration: 60
+          userId: guest
+          cc: ["user.log", "support.log"]
+          priority: 10
+          deliveryMode: 2
+          mandatory: false
+          bcc: ["external.audit"]
+          replyTo: user.reply
+          timestamp: true
+          ack: true
+          bindingVersion: 0.1.0
+      message:
+        $ref: "#/components/messages/printJobEvent"
+    parameters:
+      jobId:
+        description: The identifier of the print job.
+        schema:
+          type: string
+    bindings:
+      amqp:
+        is: queue
+        queue:
+          name: events/jobs
+          durable: true
+          exclusive: false
+          autoDelete: false
+          vhost: /
+        bindingVersion: 0.1.0
+
+components:
+
+  messages:
+
+    createPrintJob:
+      name: createPrintJob
+      title: Creates a print job.
+      summary: Use this message to create a print job.
+      description: |-
+        The job Id can be used to get the status of the job or cancel it.
+      externalDocs:
+        description: Print Jobs Documentation.
+        url: https://www.example.com/docs/api/jobs
+      payload:
+        type: object
+        properties:
+          jobId:
+            type: string
+            title: Job Id.
+          userId:
+            type: string
+            title: User Id.
+          documentName:
+            type: string
+            title: Document name.
+            deprecated: true
+          priority:
+            type: string
+            title: Priority.
+            enum:
+              - low
+              - medium
+              - high
+            externalDocs:
+              description: Print Job Priority Documentation.
+              url: https://www.example.com/docs/api/jobs/priority
+      headers:
+        type: object
+        properties:
+          x-api-key:
+            type: string
+            description: API Key.
+          x-correlation-id:
+            type: string
+            description: Correlation ID.
+      correlationId:
+        description: |-
+          Identifier used for message tracing and correlation.
+        location: $message.header#/x-correlation-id
+
+    cancelPrintJob:
+      name: cancelPrintJob
+      title: Cancels a print job.
+      payload:
+        type: object
+        properties:
+          jobId:
+            type: string
+            title: Job Id.
+          force:
+            type: boolean
+            title: Force cancellation.
+            default: false
+        required:
+          - jobId
+      headers:
+        type: object
+        properties:
+          x-api-key:
+            type: string
+            title: API Key.
+          x-correlation-id:
+            type: string
+            title: Correlation ID.
+      correlationId:
+        description: |-
+          Identifier used for message tracing and correlation.
+        location: $message.header#/x-correlation-id
+      tags:
+        - name: job
+          externalDocs:
+            description: Print job.
+            url: https://www.example.com/docs/api/jobs
+      bindings:
+        amqp:
+          contentEncoding: gzip
+          messageType: job.create
+          bindingVersion: 0.1.0
+
+    printJobEvent:
+      name: printJobEvent
+      title: Print job event.
+      payload:
+        type: object
+        properties:
+          jobId:
+            type: string
+            title: Job Id.
+          status:
+            type: string

--- a/pkg/asyncapi/fixtures/streetlights-kafka-2.4.0-and-below.graphql
+++ b/pkg/asyncapi/fixtures/streetlights-kafka-2.4.0-and-below.graphql
@@ -1,0 +1,36 @@
+schema {
+    subscription: Subscription
+}
+
+type Subscription {
+    dimLight(streetlightId: String): DimLight
+    turnOff(streetlightId: String): TurnOnOff
+    turnOn(streetlightId: String): TurnOnOff
+}
+
+enum Command {
+    ON
+    OFF
+}
+
+"""
+Dim light
+Command a particular streetlight to dim the lights.
+"""
+type DimLight {
+    "Percentage to which the light should be dimmed to."
+    percentage: Int
+    "Date and time when the message was sent."
+    sentAt: String
+}
+
+"""
+Turn on/off
+Command a particular streetlight to turn the lights on or off.
+"""
+type TurnOnOff {
+    "Whether to turn on or off the light."
+    command: Command
+    "Date and time when the message was sent."
+    sentAt: String
+}

--- a/pkg/asyncapi/fixtures/trading-sample-2.0.0.graphql
+++ b/pkg/asyncapi/fixtures/trading-sample-2.0.0.graphql
@@ -1,0 +1,22 @@
+schema {
+    subscription: Subscription
+}
+
+type Subscription {
+    tradeResult: TradeResult
+}
+
+type TradeResult {
+    "the number of shares to be traded."
+    tradeAmount: Float
+    "the order id of the message coming"
+    tradeId: Int
+    "PENDING, PROCESSED and FAILED"
+    tradeStatus: String
+    "ticker symbol of the stock."
+    tradeSymbol: String
+    "date and time of the order."
+    tradeTime: String
+    "BUY or SELL"
+    tradeType: String
+}

--- a/pkg/asyncapi/fixtures/trading-sample-2.0.0.yaml
+++ b/pkg/asyncapi/fixtures/trading-sample-2.0.0.yaml
@@ -1,0 +1,60 @@
+asyncapi: 2.0.0
+info:
+  title: Async Request/Trade API
+  version: 0.1.0
+
+channels:
+  book_trade:
+    publish:
+      operationId: bookTrade
+      message:
+        payload:
+          type: object
+          properties:
+            trade-id:
+              type: integer
+              minimum: 0
+              description: the order id of the message coming
+            trade-symbol:
+              type: string
+              minimum: 0
+              Description: ticker symbol of the stock.
+            trade-type:
+              type: string
+              format: string
+              description: BUY or SELL
+            trade-amount:
+              type: number
+              format: float
+              description: the number of shares to be traded.
+  trade_result:
+    subscribe:
+      operationId: tradeResult
+      message:
+        payload:
+          type: object
+          properties:
+            trade-id:
+              type: integer
+              minimum: 0
+              description: the order id of the message coming
+            trade-symbol:
+              type: string
+              format: string
+              description: ticker symbol of the stock.
+            trade-time:
+              type: string
+              format: date-time
+              description: date and time of the order.
+            trade-amount:
+              type: number
+              format: float
+              description: the number of shares to be traded.
+            trade-type:
+              type: string
+              format: string
+              description: BUY or SELL
+            trade-status:
+              type: string
+              format: string
+              description: PENDING, PROCESSED and FAILED

--- a/pkg/asyncapi/fixtures/trading-sample-2.0.0.yaml
+++ b/pkg/asyncapi/fixtures/trading-sample-2.0.0.yaml
@@ -1,3 +1,4 @@
+# source: https://docs.mulesoft.com/release-notes/platform/event-driven-api
 asyncapi: 2.0.0
 info:
   title: Async Request/Trade API

--- a/pkg/asyncapi/fixtures/user-api-2.0.0.graphql
+++ b/pkg/asyncapi/fixtures/user-api-2.0.0.graphql
@@ -1,0 +1,17 @@
+schema {
+    subscription: Subscription
+}
+
+type Subscription {
+    receiveUserUpdate: UserUpdate
+}
+
+"""
+User Update
+Inform about users updates
+"""
+type UserUpdate {
+    age: Int
+    id: String
+    name: String
+}

--- a/pkg/asyncapi/fixtures/user-api-2.0.0.yaml
+++ b/pkg/asyncapi/fixtures/user-api-2.0.0.yaml
@@ -1,3 +1,4 @@
+# source: https://github.com/dutradda/asyncapi-python
 asyncapi: 2.0.0
 
 info:

--- a/pkg/asyncapi/fixtures/user-api-2.0.0.yaml
+++ b/pkg/asyncapi/fixtures/user-api-2.0.0.yaml
@@ -1,0 +1,43 @@
+asyncapi: 2.0.0
+
+info:
+  title: User API
+  version: '1.0.0'
+  description: API to manage users
+
+servers:
+  development:
+    url: localhost
+    protocol: redis
+    description: Development Broker Server
+
+channels:
+  user/update:
+    description: Topic for user updates
+    subscribe:
+      operationId: receive_user_update
+      message:
+        $ref: '#/components/messages/UserUpdate'
+    publish:
+      message:
+        $ref: '#/components/messages/UserUpdate'
+
+components:
+  messages:
+    UserUpdate:
+      name: userUpdate
+      title: User Update
+      summary: Inform about users updates
+      payload:
+        type: object
+        required:
+          - id
+        properties:
+          id:
+            type: string
+          name:
+            type: string
+          age:
+            type: integer
+
+defaultContentType: application/json


### PR DESCRIPTION
PR for [TT-7468](https://tyktech.atlassian.net/jira/software/c/projects/TT/boards/26?modal=detail&selectedIssue=TT-7468)

`ImportAsyncAPIDocumentByte` has been added to produce a GraphQL schema from a parsed AsyncAPI document. The implementation uses `introspection.JsonConverter` to build a GraphQL schema. Introspection was used as an intermediate format between GQL and AsyncAPI documents. This way, we avoid implementing a clone of `introspection.JsonConverter` for AsyncAPI. 

A few things to consider:

* `introspection.__TypeKind` is an unexported type but the implementation requires it. As a workaround, I added a function that returns `introspection.TypeRef` directly. We can export `__TypeKind` from the introspection package but this is a breaking change.
* The parsed AsyncAPI document uses built-in maps to store data. We iterate over these maps to create an introspection JSON. Because the iteration order in a map is random, every iteration produces a different GQL schema. In order to overcome this problem, I sort the slices by name (it can be any field). 

`operationId` is required to construct the `Subscription` type. Otherwise, the converter produces the following result:

```graphql
type Subscription {
   : PaymentFailed
   : PaymentSucceeded
   : UserRegistered
   : UserSubscribed
   : UserUnsubscribed
}
```

The following sample contains the `operationId` for subscriptions. 

```yaml
  payment-failed:
    subscribe:
      operationId: paymentFailedSub
      description: The payload of failed payment
      message:
        $ref: "#/components/messages/payment"
```

The result looks like the following:

```graphql
type Subscription {
    paymentFailedSub: PaymentFailed
    paymentSucceededSub: PaymentSucceeded
    userRegisteredSub: UserRegistered
    userSubscribedSub: UserSubscribed
    userUnsubscribedSub: UserUnsubscribed
}
```

[TT-7468]: https://tyktech.atlassian.net/browse/TT-7468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ