### PR TITLE
[TT-7826] Add Query root type

### DIFF
--- a/pkg/asyncapi/fixtures/email-service-2.0.0.graphql
+++ b/pkg/asyncapi/fixtures/email-service-2.0.0.graphql
@@ -1,5 +1,10 @@
 schema {
+    query: Query
     subscription: Subscription
+}
+
+type Query {
+    _: Boolean
 }
 
 type Subscription {

--- a/pkg/asyncapi/fixtures/payment-sample-2.0.0.graphql
+++ b/pkg/asyncapi/fixtures/payment-sample-2.0.0.graphql
@@ -1,5 +1,10 @@
 schema {
+    query: Query
     subscription: Subscription
+}
+
+type Query {
+    _: Boolean
 }
 
 type Subscription {

--- a/pkg/asyncapi/fixtures/payment-system-sample-2.2.0.graphql
+++ b/pkg/asyncapi/fixtures/payment-system-sample-2.2.0.graphql
@@ -1,5 +1,10 @@
 schema {
+    query: Query
     subscription: Subscription
+}
+
+type Query {
+    _: Boolean
 }
 
 type Subscription {

--- a/pkg/asyncapi/fixtures/print-service-api-2.0.0.graphql
+++ b/pkg/asyncapi/fixtures/print-service-api-2.0.0.graphql
@@ -1,5 +1,10 @@
 schema {
+    query: Query
     subscription: Subscription
+}
+
+type Query {
+    _: Boolean
 }
 
 type Subscription {

--- a/pkg/asyncapi/fixtures/streetlights-kafka-2.4.0-and-below.graphql
+++ b/pkg/asyncapi/fixtures/streetlights-kafka-2.4.0-and-below.graphql
@@ -1,5 +1,10 @@
 schema {
+    query: Query
     subscription: Subscription
+}
+
+type Query {
+    _: Boolean
 }
 
 type Subscription {

--- a/pkg/asyncapi/fixtures/trading-sample-2.0.0.graphql
+++ b/pkg/asyncapi/fixtures/trading-sample-2.0.0.graphql
@@ -1,5 +1,10 @@
 schema {
+    query: Query
     subscription: Subscription
+}
+
+type Query {
+    _: Boolean
 }
 
 type Subscription {

--- a/pkg/asyncapi/fixtures/user-api-2.0.0.graphql
+++ b/pkg/asyncapi/fixtures/user-api-2.0.0.graphql
@@ -1,5 +1,10 @@
 schema {
+    query: Query
     subscription: Subscription
+}
+
+type Query {
+    _: Boolean
 }
 
 type Subscription {


### PR DESCRIPTION
This PR adds Query root type to the schemas produced from AsyncAPI documents. It's a mandatory field. It also has a dummy field because empty types are not allowed.


```graphql
schema {
    query: Query
    subscription: Subscription
}

type Query {
    _: Boolean
}
```

This PR also includes small code organization improvements.