### PR TITLE
[TT-7465] Parsing information needed for UDG config from OpenAPI-3 spec

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,8 @@ require (
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/eclipse/paho.mqtt.golang v1.2.0
 	github.com/evanphx/json-patch/v5 v5.1.0
-	github.com/go-test/deep v1.0.4
+	github.com/getkin/kin-openapi v0.89.0
+	github.com/go-test/deep v1.0.8
 	github.com/go-zookeeper/zk v1.0.2
 	github.com/gobwas/ws v1.0.4
 	github.com/golang/mock v1.4.1
@@ -43,7 +44,7 @@ require (
 	github.com/sebdah/goldie v0.0.0-20180424091453-8784dd1ab561
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/viper v1.3.2
-	github.com/stretchr/testify v1.8.0
+	github.com/stretchr/testify v1.8.1
 	github.com/tidwall/gjson v1.11.0
 	github.com/tidwall/sjson v1.0.4
 	github.com/vektah/gqlparser/v2 v2.5.1

--- a/go.sum
+++ b/go.sum
@@ -87,10 +87,18 @@ github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
+github.com/getkin/kin-openapi v0.89.0 h1:p4nagHchUKGn85z/f+pse4aSh50nIBOYjOhMIku2hiA=
+github.com/getkin/kin-openapi v0.89.0/go.mod h1:660oXbgy5JFMKreazJaQTw7o+X00qeSyhcnluiMv+Xg=
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
+github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/gin v1.6.3 h1:ahKqKTFpO5KTPHxWZjEdPScmYaGtLo8Y4DMHoEsnp14=
 github.com/gin-gonic/gin v1.6.3/go.mod h1:75u5sXoLsGZoRN5Sgbi1eraJ4GU3++wFwWzhwvtwp4M=
+github.com/go-openapi/jsonpointer v0.19.5 h1:gZr+CIYByUqjcgeLXnQu2gHYQC9o73G2XUeOFYEICuY=
+github.com/go-openapi/jsonpointer v0.19.5/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
+github.com/go-openapi/swag v0.19.5 h1:lTz6Ys4CmqqCQmZPBlbQENR1/GucA2bzYTE12Pw4tFY=
+github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.13.0 h1:HyWk6mgj5qFqCT5fjGBuRArbVDfE4hi8+e8ceBS/t7Q=
 github.com/go-playground/locales v0.13.0/go.mod h1:taPMhCMXrRLJO55olJkUXHZBHCxTMfnGwq/HNwmWNS8=
@@ -99,8 +107,8 @@ github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+
 github.com/go-playground/validator/v10 v10.2.0 h1:KgJ0snyC2R9VXYN2rneOtQcw5aHQB1Vv0sFl1UcHBOY=
 github.com/go-playground/validator/v10 v10.2.0/go.mod h1:uOYAAleCW8F/7oMFd6aG0GOhaH6EGOAJShg8Id5JGkI=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
-github.com/go-test/deep v1.0.4 h1:u2CU3YKy9I2pmu9pX0eq50wCgjfGIt539SqR7FbHiho=
-github.com/go-test/deep v1.0.4/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
+github.com/go-test/deep v1.0.8 h1:TDsG77qcSprGbC6vTN8OuXp5g+J+b5Pcguhf7Zt61VM=
+github.com/go-test/deep v1.0.8/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/go-zookeeper/zk v1.0.2 h1:4mx0EYENAdX/B/rbunjlt5+4RTA/a9SMHBRuSKdGxPM=
 github.com/go-zookeeper/zk v1.0.2/go.mod h1:nOB03cncLtlp4t+UAkGSV+9beXP/akpekBwL+UX1Qcw=
 github.com/gobwas/httphead v0.0.0-20180130184737-2c6c146eadee h1:s+21KNqlpePfkah2I+gwHF8xmJWRjooY+5248k6m4A0=
@@ -140,6 +148,7 @@ github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLe
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
@@ -208,6 +217,9 @@ github.com/logrusorgru/aurora/v3 v3.0.0 h1:R6zcoZZbvVcGMvDCKo45A9U/lzYyzl5NfYIvz
 github.com/logrusorgru/aurora/v3 v3.0.0/go.mod h1:vsR12bk5grlLvLXAYrBsb5Oc/N+LxAlxggSjiwMnCUc=
 github.com/magiconair/properties v1.8.0 h1:LLgXmsheXeRoUOBOjtwPQCWIYqM/LU1ayDtDePerRcY=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
+github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
+github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e h1:hB2xlXdHp/pmPZq0y3QnmWAArdw9PqbmotexnWx/FU8=
+github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/matryer/moq v0.2.7/go.mod h1:kITsx543GOENm48TUAQyJ9+SAvFSr7iGQXPoth/VUBk=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
@@ -316,6 +328,7 @@ github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DM
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
@@ -323,8 +336,9 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tidwall/gjson v1.11.0 h1:C16pk7tQNiH6VlCrtIXL1w8GaOsi1X3W8KDkE1BuYd4=
 github.com/tidwall/gjson v1.11.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=

--- a/pkg/openapi/fixtures/v3.0.0/EmployeeApi.graphql
+++ b/pkg/openapi/fixtures/v3.0.0/EmployeeApi.graphql
@@ -1,0 +1,87 @@
+schema {
+    query: Query
+    mutation: Mutation
+}
+
+type Query {
+    employeesGet(department: String, job: String): [EmployeeBodyFormatted]
+    employeesIdGet(id: String): EmployeeBody
+}
+
+type Mutation {
+    employeesIdDelete(id: String): EmployeeNumber
+    employeesIdPut(employeeBodyInput: EmployeeBodyInput): EmployeeBody
+    employeesPost(employeeBodyInput: EmployeeBodyInput): EmployeeBody
+}
+
+type EmployeeBody {
+    bonus: Float
+    commission: Float
+    dateOfBirth: String
+    department: String
+    educationLevel: Int
+    employeeNumber: String
+    firstName: String
+    hireDate: String
+    job: String
+    lastName: String
+    middleInitial: String
+    phoneNumber: String
+    salary: Float
+    sex: String
+}
+
+type EmployeeBodyFormatted {
+    personal: EmployeePersonalDetails
+    summary: EmployeeSummary
+    work: EmployeeWorkDetails
+}
+
+input EmployeeBodyInput {
+    bonus: Float
+    commission: Float
+    dateOfBirth: String
+    department: String
+    educationLevel: Int
+    employeeNumber: String
+    firstName: String
+    hireDate: String
+    job: String
+    lastName: String
+    middleInitial: String
+    phoneNumber: String
+    salary: Float
+    sex: String
+}
+
+type EmployeeNumber {
+    message: String
+}
+
+type EmployeePersonalDetails {
+    dateOfBirth: String
+    firstName: String
+    lastName: String
+    middleInitial: String
+    sex: String
+}
+
+type EmployeeSummary {
+    bio: String
+}
+
+type EmployeeWorkDetails {
+    department: String
+    educationLevel: Int
+    employeeNumber: String
+    hireDate: String
+    job: String
+    pay: EmployeeWorkPay
+    phoneNumber: String
+}
+
+type EmployeeWorkPay {
+    bonus: Float
+    commission: Float
+    salary: Float
+}

--- a/pkg/openapi/fixtures/v3.0.0/EmployeesApi.graphql
+++ b/pkg/openapi/fixtures/v3.0.0/EmployeesApi.graphql
@@ -4,13 +4,33 @@ schema {
 }
 
 type Query {
+    """
+    Get all employee details
+    Uses the getEmployees Db2 z/OS asset
+    """
     employeesGet(department: String, job: String): [EmployeeBodyFormatted]
+    """
+    Get an employee
+    Uses the getEmployee Db2 z/OS asset
+    """
     employeesIdGet(id: String): EmployeeBody
 }
 
 type Mutation {
+    """
+    Delete an employee
+    Uses the deleteEmployee Db2 z/OS asset
+    """
     employeesIdDelete(id: String): EmployeeNumber
+    """
+    Update an employee
+    Uses the updateEmployee Db2 z/OS asset
+    """
     employeesIdPut(employeeBodyInput: EmployeeBodyInput): EmployeeBody
+    """
+    Add an employee
+    Uses the addEmployee Db2 z/OS asset
+    """
     employeesPost(employeeBodyInput: EmployeeBodyInput): EmployeeBody
 }
 

--- a/pkg/openapi/fixtures/v3.0.0/EmployeesApi.yaml
+++ b/pkg/openapi/fixtures/v3.0.0/EmployeesApi.yaml
@@ -1,0 +1,415 @@
+openapi: 3.0.0
+info:
+  title: EmployeesApi
+  description: Employee management API for Db2.
+  version: "1.1"
+  license:
+    name: Apache-2.0
+    url: https://opensource.org/licenses/Apache-2.0
+servers:
+  - url: /project
+  - url: http://localhost:9080/
+  - url: https://localhost:9443/
+security:
+  - BasicAuth: []
+  - BearerAuth: []
+paths:
+  /employees/{id}:
+    get:
+      tags:
+        - Edit
+        - Discover
+      summary: Get an employee
+      description: Uses the getEmployee Db2 z/OS asset
+      operationId: employeesIdGet
+      parameters:
+        - name: id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmployeeBody'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmployeeNotFound'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    put:
+      tags:
+        - Edit
+      summary: Update an employee
+      description: Uses the updateEmployee Db2 z/OS asset
+      operationId: employeesIdPut
+      parameters:
+        - name: id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EmployeeBody'
+      responses:
+        "200":
+          description: Updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmployeeBody'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmployeeNotFound'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      tags:
+        - Edit
+      summary: Delete an employee
+      description: Uses the deleteEmployee Db2 z/OS asset
+      operationId: employeesIdDelete
+      parameters:
+        - name: id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Deleted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmployeeNumber'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmployeeNotFound'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /employees:
+    get:
+      tags:
+        - Discover
+      summary: Get all employee details
+      description: Uses the getEmployees Db2 z/OS asset
+      operationId: employeesGet
+      parameters:
+        - name: department
+          in: cookie
+          required: false
+          style: form
+          explode: true
+          schema:
+            $ref: '#/components/schemas/Departments'
+        - name: job
+          in: query
+          required: false
+          style: form
+          explode: true
+          schema:
+            $ref: '#/components/schemas/Job'
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/EmployeeBodyFormatted'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    post:
+      tags:
+        - Edit
+      summary: Add an employee
+      description: Uses the addEmployee Db2 z/OS asset
+      operationId: employeesPost
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EmployeeBody'
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmployeeBody'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+components:
+  schemas:
+    EmployeeBody:
+      type: object
+      properties:
+        employeeNumber:
+          maxLength: 6
+          type: string
+        firstName:
+          maxLength: 12
+          type: string
+        middleInitial:
+          maxLength: 1
+          type: string
+        lastName:
+          maxLength: 15
+          type: string
+        department:
+          maxLength: 3
+          type: string
+        phoneNumber:
+          maxLength: 4
+          minLength: 4
+          type: string
+        hireDate:
+          type: string
+          format: date-time
+        job:
+          maxLength: 8
+          type: string
+        educationLevel:
+          type: integer
+        sex:
+          maxLength: 1
+          minLength: 1
+          type: string
+        dateOfBirth:
+          type: string
+          format: date-time
+        salary:
+          type: number
+          format: double
+        bonus:
+          type: number
+          format: double
+        commission:
+          type: number
+          format: double
+      example:
+        employeeNumber: "000010"
+        firstName: CHRISTINE
+        middleInitial: I
+        lastName: HAAS
+        department: A00
+        phoneNumber: "3978"
+        hireDate: 2000-01-01
+        job: PRES
+        educationLevel: 18
+        sex: F
+        dateOfBirth: 1933-08-14
+        salary: 52750.0
+        bonus: 1000.0
+        commission: 4220.0
+    EmployeeBodyFormatted:
+      type: object
+      properties:
+        summary:
+          $ref: '#/components/schemas/EmployeeSummary'
+        personal:
+          $ref: '#/components/schemas/EmployeePersonalDetails'
+        work:
+          $ref: '#/components/schemas/EmployeeWorkDetails'
+    EmployeeSummary:
+      type: object
+      properties:
+        bio:
+          maxLength: 100
+          type: string
+      example:
+        bio: Christine Haas was hired in 1965 at 32 years old and is paid a total
+          of $57970
+    EmployeePersonalDetails:
+      type: object
+      properties:
+        firstName:
+          maxLength: 12
+          type: string
+        middleInitial:
+          maxLength: 1
+          type: string
+        lastName:
+          maxLength: 15
+          type: string
+        sex:
+          maxLength: 1
+          minLength: 1
+          type: string
+        dateOfBirth:
+          type: string
+          format: date-time
+      example:
+        firstName: CHRISTINE
+        middleInitial: I
+        lastName: HAAS
+        sex: F
+        dateOfBirth: 1933-08-14
+    EmployeeWorkDetails:
+      type: object
+      properties:
+        employeeNumber:
+          maxLength: 6
+          type: string
+        department:
+          maxLength: 3
+          type: string
+        phoneNumber:
+          maxLength: 4
+          minLength: 4
+          type: string
+        hireDate:
+          type: string
+          format: date-time
+        job:
+          maxLength: 8
+          type: string
+        educationLevel:
+          type: integer
+        pay:
+          $ref: '#/components/schemas/EmployeeWorkPay'
+      example:
+        employeeNumber: "000010"
+        department: A00
+        phoneNumber: "3978"
+        hireDate: 2000-01-01
+        job: PRES
+        educationLevel: 18
+        pay:
+          salary: 52750.0
+          bonus: 1000.0
+          commission: 4220.0
+    EmployeeWorkPay:
+      type: object
+      properties:
+        salary:
+          type: number
+          format: double
+        bonus:
+          type: number
+          format: double
+        commission:
+          type: number
+          format: double
+      example:
+        salary: 52750.0
+        bonus: 1000.0
+        commission: 4220.0
+    ErrorResponse:
+      type: object
+      properties:
+        message:
+          type: string
+      example:
+        message: A message describing the error
+    EmployeeNotFound:
+      type: object
+      properties:
+        message:
+          type: string
+      example:
+        message: Employee could not be found
+    EmployeeNumber:
+      type: object
+      properties:
+        message:
+          type: string
+      example:
+        employeeNumber: "000010"
+    Departments:
+      type: string
+      enum:
+        - A00
+        - B01
+        - C01
+        - E01
+        - D11
+        - D21
+        - E11
+        - E21
+    Job:
+      type: string
+      enum:
+        - "FIELDREP"
+        - "OPERATOR"
+        - "CLERK   "
+        - "DESIGNER"
+        - "ANALYST "
+        - "SALESREP"
+        - "MANAGER "
+        - "PRES    "
+  parameters:
+    id:
+      name: id
+      in: path
+      required: true
+      style: simple
+      explode: false
+      schema:
+        type: string
+    department:
+      name: department
+      in: cookie
+      required: false
+      style: form
+      explode: true
+      schema:
+        $ref: '#/components/schemas/Departments'
+    job:
+      name: job
+      in: query
+      required: false
+      style: form
+      explode: true
+      schema:
+        $ref: '#/components/schemas/Job'
+  securitySchemes:
+    BasicAuth:
+      type: http
+      scheme: basic
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT

--- a/pkg/openapi/fixtures/v3.0.0/EmployeesApiBasic.graphql
+++ b/pkg/openapi/fixtures/v3.0.0/EmployeesApiBasic.graphql
@@ -4,10 +4,12 @@ schema {
 }
 
 type Query {
+    "Uses the getEmployees Db2 z/OS asset"
     employees: [EmployeeBody]
 }
 
 type Mutation {
+    "Uses the updateEmployee Db2 z/OS asset"
     putEmployeesId(employeeBodyInput: EmployeeBodyInput): EmployeeBody
 }
 

--- a/pkg/openapi/fixtures/v3.0.0/EmployeesApiBasic.graphql
+++ b/pkg/openapi/fixtures/v3.0.0/EmployeesApiBasic.graphql
@@ -1,0 +1,33 @@
+schema {
+    query: Query
+    mutation: Mutation
+}
+
+type Query {
+    employees: [EmployeeBody]
+    employees: ErrorResponse
+}
+
+type Mutation {
+    putEmployeesId(employeeBodyInput: EmployeeBodyInput): EmployeeBody
+    putEmployeesId(employeeBodyInput: EmployeeBodyInput): ErrorResponse
+    putEmployeesId(employeeBodyInput: EmployeeBodyInput): ErrorResponse
+}
+
+type EmployeeBody {
+    employeeNumber: String
+    firstName: String
+    lastName: String
+    salary: Float
+}
+
+input EmployeeBodyInput {
+    employeeNumber: String
+    firstName: String
+    lastName: String
+    salary: Float
+}
+
+type ErrorResponse {
+    message: String
+}

--- a/pkg/openapi/fixtures/v3.0.0/EmployeesApiBasic.graphql
+++ b/pkg/openapi/fixtures/v3.0.0/EmployeesApiBasic.graphql
@@ -5,13 +5,10 @@ schema {
 
 type Query {
     employees: [EmployeeBody]
-    employees: ErrorResponse
 }
 
 type Mutation {
     putEmployeesId(employeeBodyInput: EmployeeBodyInput): EmployeeBody
-    putEmployeesId(employeeBodyInput: EmployeeBodyInput): ErrorResponse
-    putEmployeesId(employeeBodyInput: EmployeeBodyInput): ErrorResponse
 }
 
 type EmployeeBody {
@@ -26,8 +23,4 @@ input EmployeeBodyInput {
     firstName: String
     lastName: String
     salary: Float
-}
-
-type ErrorResponse {
-    message: String
 }

--- a/pkg/openapi/fixtures/v3.0.0/EmployeesApiBasic.yaml
+++ b/pkg/openapi/fixtures/v3.0.0/EmployeesApiBasic.yaml
@@ -1,0 +1,83 @@
+openapi: 3.0.0
+info:
+  title: EmployeesApi
+  description: Employee management API for Db2.
+  version: "0.2"
+servers:
+  - url: /
+paths:
+  /employees/{id}:
+    put:
+      description: Uses the updateEmployee Db2 z/OS asset
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            example: "000150"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EmployeeBody'
+      responses:
+        "200":
+          description: Updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmployeeBody'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /employees:
+    get:
+      description: Uses the getEmployees Db2 z/OS asset
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/EmployeeBody'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+components:
+  schemas:
+    EmployeeBody:
+      type: object
+      properties:
+        employeeNumber:
+          type: string
+          example: "000150"
+        firstName:
+          type: string
+          example: "BRUCE"
+        lastName:
+          type: string
+          example: "ADAMSON"
+        salary:
+          type: number
+          example: 25280
+    ErrorResponse:
+      type: object
+      properties:
+        message:
+          type: string
+      example: "A message describing the error"

--- a/pkg/openapi/fixtures/v3.0.0/example_oas3.graphql
+++ b/pkg/openapi/fixtures/v3.0.0/example_oas3.graphql
@@ -1,0 +1,36 @@
+schema {
+    query: Query
+}
+
+type Query {
+    "Return an author."
+    author(authorId: String): Author
+    "Return a book."
+    book(bookId: String): Book
+    "Return the author's next work."
+    nextWork(authorId: String): NextWork
+}
+
+"An author"
+type Author {
+    "The artist's bestseller"
+    masterpieceTitle: String
+    "The name of the author"
+    name: String
+}
+
+"A book"
+type Book {
+    "The author of the book"
+    authorName: String
+    "The title of the book"
+    title: String
+}
+
+"A book"
+type NextWork {
+    "The author of the book"
+    authorName: String
+    "The title of the book"
+    title: String
+}

--- a/pkg/openapi/fixtures/v3.0.0/example_oas3.json
+++ b/pkg/openapi/fixtures/v3.0.0/example_oas3.json
@@ -1,0 +1,244 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Example API 3",
+    "description": "An API to test converting Open API Specs 3.0 to GraphQL",
+    "version": "1.0.0",
+    "termsOfService": "http://example.com/terms/",
+    "contact": {
+      "name": "Erik Wittern",
+      "url": "http://www.example.com/support"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "externalDocs": {
+    "url": "http://example.com/docs",
+    "description": "Some more natural language description."
+  },
+  "tags": [
+    {
+      "name": "test",
+      "description": "Indicates this API is for testing"
+    }
+  ],
+  "servers": [
+    {
+      "url": "http://localhost:{port}/{basePath}",
+      "description": "The location of the local test server.",
+      "variables": {
+        "port": {
+          "default": "3003"
+        },
+        "basePath": {
+          "default": "api"
+        }
+      }
+    }
+  ],
+  "paths": {
+    "/authors/{authorId}": {
+      "get": {
+        "operationId": "author",
+        "description": "Return an author.",
+        "parameters": [
+          {
+            "name": "authorId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "A author.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/author"
+                }
+              }
+            },
+            "links": {
+              "masterpiece": {
+                "operationId": "book",
+                "parameters": {
+                  "bookId": "$response.body#/masterpieceTitle"
+                },
+                "description": "Fetches the masterpiece"
+              },
+              "nextWork": {
+                "operationId": "nextWork",
+                "parameters": {
+                  "authorId": "$request.path.authorId"
+                },
+                "description": "Fetches the author's next work"
+              },
+              "employee": {
+                "$ref": "#/components/links/Employee"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/books/{bookId}": {
+      "get": {
+        "operationId": "book",
+        "description": "Return a book.",
+        "parameters": [
+          {
+            "name": "bookId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "A book.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/book"
+                }
+              }
+            },
+            "links": {
+              "author": {
+                "operationId": "author",
+                "parameters": {
+                  "authorId": "$response.body#/authorName"
+                },
+                "description": "Fetches the author"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/nextWorks/{authorId}": {
+      "get": {
+        "operationId": "nextWork",
+        "description": "Return the author's next work.",
+        "parameters": [
+          {
+            "name": "authorId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "An upcoming book.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/nextWork"
+                }
+              }
+            },
+            "links": {
+              "author": {
+                "operationId": "author",
+                "parameters": {
+                  "authorId": "$request.path.authorId"
+                },
+                "description": "Fetches the author"
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "example_api3_key_protocol": []
+          },
+          {
+            "example_api3_basic_protocol": []
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "book": {
+        "type": "object",
+        "description": "A book",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "The title of the book"
+          },
+          "authorName": {
+            "type": "string",
+            "description": "The author of the book"
+          }
+        }
+      },
+      "nextWork": {
+        "type": "object",
+        "description": "A book",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "The title of the book"
+          },
+          "authorName": {
+            "type": "string",
+            "description": "The author of the book"
+          }
+        }
+      },
+      "author": {
+        "type": "object",
+        "description": "An author",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the author"
+          },
+          "masterpieceTitle": {
+            "type": "string",
+            "description": "The artist's bestseller"
+          }
+        }
+      }
+    },
+    "links": {
+      "Employee": {
+        "operationRef": "Example API#/paths/~1users~1{username}/get",
+        "parameters": {
+          "username": "$request.path.authorId"
+        },
+        "description": "Link between two different APIs"
+      }
+    },
+    "securitySchemes": {
+      "example_api3_key_protocol": {
+        "in": "header",
+        "name": "access_token",
+        "type": "apiKey"
+      },
+      "example_api3_key_protocol_2": {
+        "in": "query",
+        "name": "access_token",
+        "type": "apiKey"
+      },
+      "example_api3_basic_protocol": {
+        "type": "http",
+        "scheme": "basic"
+      }
+    }
+  },
+  "security": []
+}

--- a/pkg/openapi/fixtures/v3.0.0/example_oas7.graphql
+++ b/pkg/openapi/fixtures/v3.0.0/example_oas7.graphql
@@ -4,13 +4,18 @@ schema {
 }
 
 type Query {
+    "Find a device by name."
     findDeviceByName(deviceName: String): Device
+    "Return a device collection."
     findDevices: [Device]
+    "Return a user."
     user: User
 }
 
 type Mutation {
+    "Create and return a device."
     createDevice(deviceInput: DeviceInput): Device
+    "Replace a device by name."
     replaceDeviceByName(deviceInput: DeviceInput): Device
 }
 

--- a/pkg/openapi/fixtures/v3.0.0/example_oas7.graphql
+++ b/pkg/openapi/fixtures/v3.0.0/example_oas7.graphql
@@ -1,0 +1,36 @@
+schema {
+    query: Query
+    mutation: Mutation
+}
+
+type Query {
+    findDeviceByName(deviceName: String): Device
+    findDevices: [Device]
+    user: User
+}
+
+type Mutation {
+    createDevice(deviceInput: DeviceInput): Device
+    replaceDeviceByName(deviceInput: DeviceInput): Device
+}
+
+type Device {
+    name: String
+    status: Boolean
+    userName: String
+}
+
+input DeviceInput {
+    name: String
+    status: Boolean
+    userName: String
+}
+
+type Error {
+    code: String
+    message: String
+}
+
+type User {
+    name: String
+}

--- a/pkg/openapi/fixtures/v3.0.0/example_oas7.graphql
+++ b/pkg/openapi/fixtures/v3.0.0/example_oas7.graphql
@@ -26,11 +26,6 @@ input DeviceInput {
     userName: String
 }
 
-type Error {
-    code: String
-    message: String
-}
-
 type User {
     name: String
 }

--- a/pkg/openapi/fixtures/v3.0.0/example_oas7.graphql
+++ b/pkg/openapi/fixtures/v3.0.0/example_oas7.graphql
@@ -20,8 +20,10 @@ type Mutation {
 }
 
 type Device {
+    "The device name in the network"
     name: String
     status: Boolean
+    "The device owner Name"
     userName: String
 }
 
@@ -31,6 +33,8 @@ input DeviceInput {
     userName: String
 }
 
+"A user represents a natural person"
 type User {
+    "The legal name of a user"
     name: String
 }

--- a/pkg/openapi/fixtures/v3.0.0/example_oas7.json
+++ b/pkg/openapi/fixtures/v3.0.0/example_oas7.json
@@ -1,0 +1,295 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Example API 7",
+    "description": "An API to test converting Open API Specs 3.0 to GraphQL",
+    "version": "1.0.0",
+    "termsOfService": "http://example.com/terms/",
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "externalDocs": {
+    "url": "http://example.com/docs",
+    "description": "Some more natural language description."
+  },
+  "tags": [
+    {
+      "name": "test",
+      "description": "Indicates this API is for testing"
+    }
+  ],
+  "servers": [
+    {
+      "url": "http://localhost:{port}/{basePath}",
+      "description": "The location of the local test server.",
+      "variables": {
+        "port": {
+          "default": "3007"
+        },
+        "basePath": {
+          "default": "api"
+        }
+      }
+    },
+    {
+      "url": "mqtt://localhost:{port}/{basePath}",
+      "description": "The location of the local MQTT test broker.",
+      "variables": {
+        "port": {
+          "default": "1885"
+        },
+        "basePath": {
+          "default": "api"
+        }
+      }
+    }
+  ],
+  "paths": {
+    "/user": {
+      "get": {
+        "description": "Return a user.",
+        "responses": {
+          "202": {
+            "description": "A user.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/devices": {
+      "get": {
+        "operationId": "findDevices",
+        "description": "Return a device collection.",
+        "responses": {
+          "200": {
+            "description": "A device collection",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "description": "The device collection",
+                  "items": {
+                    "$ref": "#/components/schemas/Device"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "createDevice",
+        "description": "Create and return a device.",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/DeviceBody"
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/DeviceInstance"
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        },
+        "callbacks": {
+          "deviceCreated": {
+            "$ref": "#/components/callbacks/DevicesEvent"
+          }
+        }
+      }
+    },
+    "/devices/{deviceName}": {
+      "get": {
+        "operationId": "findDeviceByName",
+        "description": "Find a device by name.",
+        "parameters": [
+          {
+            "name": "deviceName",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/DeviceInstance"
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      },
+      "put": {
+        "operationId": "replaceDeviceByName",
+        "description": "Replace a device by name.",
+        "parameters": [
+          {
+            "name": "deviceName",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/DeviceBody"
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/DeviceInstance"
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        },
+        "callbacks": {
+          "deviceUpdated": {
+            "$ref": "#/components/callbacks/DevicesEvent"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "User": {
+        "type": "object",
+        "description": "A user represents a natural person",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The legal name of a user"
+          }
+        }
+      },
+      "Device": {
+        "type": "object",
+        "description": "A device is an object connected to the network",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The device name in the network"
+          },
+          "userName": {
+            "type": "string",
+            "description": "The device owner Name"
+          },
+          "status": {
+            "type": "boolean"
+          }
+        },
+        "required": ["name", "userName"]
+      },
+      "Topic": {
+        "type": "object",
+        "description": "A topic is used to listen events",
+        "properties": {
+          "userName": {
+            "type": "string",
+            "description": "The device owner"
+          },
+          "deviceName": {
+            "type": "string",
+            "description": "The device name"
+          },
+          "method": {
+            "type": "string",
+            "description": "The device method to watch",
+            "example": "Equivalent to HTTP methods"
+          }
+        },
+        "required": ["userName", "method"]
+      },
+      "Error": {
+        "type": "object",
+        "description": "A topic is used to listen an event",
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "Error code"
+          },
+          "message": {
+            "type": "string",
+            "description": "Error message"
+          }
+        },
+        "required": ["code", "message"]
+      }
+    },
+    "requestBodies": {
+      "EventsBody": {
+        "description": "Properties to generate the event path",
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Topic"
+            }
+          }
+        }
+      },
+      "DeviceBody": {
+        "description": "Device instance to update / create",
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Device"
+            }
+          }
+        }
+      }
+    },
+    "responses": {
+      "DeviceInstance": {
+        "description": "Device instance",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Device"
+            }
+          }
+        }
+      },
+      "GeneralError": {
+        "description": "Error reponse",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      }
+    },
+    "callbacks": {
+      "DevicesEvent": {
+        "/api/{$request.body#/userName}/devices/{$request.body#/method}/+": {
+          "post": {
+            "operationId": "devicesEventListener",
+            "description": "Listen all devices events owned by userName",
+            "requestBody": {
+              "$ref": "#/components/requestBodies/EventsBody"
+            },
+            "responses": {
+              "200": {
+                "$ref": "#/components/responses/DeviceInstance"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/pkg/openapi/fixtures/v3.0.0/petstore-expanded.graphql
+++ b/pkg/openapi/fixtures/v3.0.0/petstore-expanded.graphql
@@ -1,5 +1,6 @@
 schema {
     query: Query
+    mutation: Mutation
 }
 
 type Query {

--- a/pkg/openapi/fixtures/v3.0.0/petstore-expanded.graphql
+++ b/pkg/openapi/fixtures/v3.0.0/petstore-expanded.graphql
@@ -4,12 +4,21 @@ schema {
 }
 
 type Query {
+    "Returns a user based on a single ID, if the user does not have access to the pet"
     findPetById(id: Int): Pet
+    """
+    Returns all pets from the system that the user has access to
+    Nam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia.
+
+    Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.
+    """
     findPets(limit: Int, tags: [String]): [Pet]
 }
 
 type Mutation {
+    "Creates a new pet in the store. Duplicates are allowed"
     addPet(newPetInput: NewPetInput): Pet
+    "deletes a single pet based on the ID supplied"
     deletePet(id: Int): String
 }
 

--- a/pkg/openapi/fixtures/v3.0.0/petstore-expanded.graphql
+++ b/pkg/openapi/fixtures/v3.0.0/petstore-expanded.graphql
@@ -9,8 +9,8 @@ type Query {
 }
 
 type Mutation {
-    addPet(newPet: NewPet): Pet
-    deletePet(id: Int): Boolean
+    addPet(newPetInput: NewPetInput): Pet
+    deletePet(id: Int): String
 }
 
 type Error {
@@ -18,7 +18,7 @@ type Error {
     message: String
 }
 
-input NewPet {
+input NewPetInput {
     name: String
     tag: String
 }

--- a/pkg/openapi/fixtures/v3.0.0/petstore-expanded.graphql
+++ b/pkg/openapi/fixtures/v3.0.0/petstore-expanded.graphql
@@ -13,11 +13,6 @@ type Mutation {
     deletePet(id: Int): String
 }
 
-type Error {
-    code: Int
-    message: String
-}
-
 input NewPetInput {
     name: String
     tag: String

--- a/pkg/openapi/fixtures/v3.0.0/petstore-expanded.graphql
+++ b/pkg/openapi/fixtures/v3.0.0/petstore-expanded.graphql
@@ -1,0 +1,29 @@
+schema {
+    query: Query
+}
+
+type Query {
+    findPetById(id: Int): Pet
+    findPets(limit: Int, tags: [String]): [Pet]
+}
+
+type Mutation {
+    addPet(newPet: NewPet): Pet
+    deletePet(id: Int): Boolean
+}
+
+type Error {
+    code: Int
+    message: String
+}
+
+input NewPet {
+    name: String
+    tag: String
+}
+
+type Pet {
+    id: Int
+    name: String
+    tag: String
+}

--- a/pkg/openapi/fixtures/v3.0.0/petstore-expanded.yaml
+++ b/pkg/openapi/fixtures/v3.0.0/petstore-expanded.yaml
@@ -1,0 +1,158 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  description: A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3.0 specification
+  termsOfService: http://swagger.io/terms/
+  contact:
+    name: Swagger API Team
+    email: apiteam@swagger.io
+    url: http://swagger.io
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+servers:
+  - url: http://petstore.swagger.io/api
+paths:
+  /pets:
+    get:
+      description: |
+        Returns all pets from the system that the user has access to
+        Nam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia.
+
+        Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.
+      operationId: findPets
+      parameters:
+        - name: tags
+          in: query
+          description: tags to filter by
+          required: false
+          style: form
+          schema:
+            type: array
+            items:
+              type: string
+        - name: limit
+          in: query
+          description: maximum number of results to return
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    post:
+      description: Creates a new pet in the store. Duplicates are allowed
+      operationId: addPet
+      requestBody:
+        description: Pet to add to the store
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NewPet'
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /pets/{id}:
+    get:
+      description: Returns a user based on a single ID, if the user does not have access to the pet
+      operationId: find pet by id
+      parameters:
+        - name: id
+          in: path
+          description: ID of pet to fetch
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    delete:
+      description: deletes a single pet based on the ID supplied
+      operationId: deletePet
+      parameters:
+        - name: id
+          in: path
+          description: ID of pet to delete
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '204':
+          description: pet deleted
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+components:
+  schemas:
+    Pet:
+      allOf:
+        - $ref: '#/components/schemas/NewPet'
+        - type: object
+          required:
+            - id
+          properties:
+            id:
+              type: integer
+              format: int64
+
+    NewPet:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+        tag:
+          type: string
+
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/pkg/openapi/fixtures/v3.0.0/petstore.graphql
+++ b/pkg/openapi/fixtures/v3.0.0/petstore.graphql
@@ -4,11 +4,14 @@ schema {
 }
 
 type Query {
+    "List all pets"
     listPets(limit: Int): [Pet]
+    "Info for a specific pet"
     showPetById(petId: String): Pet
 }
 
 type Mutation {
+    "Create a pet"
     createPets: String
 }
 

--- a/pkg/openapi/fixtures/v3.0.0/petstore.graphql
+++ b/pkg/openapi/fixtures/v3.0.0/petstore.graphql
@@ -12,11 +12,6 @@ type Mutation {
     createPets: String
 }
 
-type Error {
-    code: Int
-    message: String
-}
-
 type Pet {
     id: Int
     name: String

--- a/pkg/openapi/fixtures/v3.0.0/petstore.graphql
+++ b/pkg/openapi/fixtures/v3.0.0/petstore.graphql
@@ -1,0 +1,24 @@
+schema {
+    query: Query
+    mutation: Mutation
+}
+
+type Query {
+    listPets(limit: Int): [Pet]
+    showPetById(petId: String): Pet
+}
+
+type Mutation {
+    createPets: String
+}
+
+type Error {
+    code: Int
+    message: String
+}
+
+type Pet {
+    id: Int
+    name: String
+    tag: String
+}

--- a/pkg/openapi/fixtures/v3.0.0/petstore.yaml
+++ b/pkg/openapi/fixtures/v3.0.0/petstore.yaml
@@ -1,0 +1,113 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            maximum: 100
+            format: int32
+      responses:
+        '200':
+          description: A paged array of pets
+          headers:
+            x-next:
+              description: A link to the next page of responses
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pets"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      summary: Create a pet
+      operationId: createPets
+      tags:
+        - pets
+      responses:
+        '201':
+          description: Null response
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /pets/{petId}:
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+    Pets:
+      type: array
+      maxItems: 100
+      items:
+        $ref: "#/components/schemas/Pet"
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/pkg/openapi/openapi.go
+++ b/pkg/openapi/openapi.go
@@ -1,0 +1,214 @@
+package openapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/TykTechnologies/graphql-go-tools/pkg/ast"
+	"github.com/TykTechnologies/graphql-go-tools/pkg/introspection"
+	"github.com/TykTechnologies/graphql-go-tools/pkg/lexer/literal"
+	"github.com/TykTechnologies/graphql-go-tools/pkg/operationreport"
+	"github.com/getkin/kin-openapi/openapi3"
+	"sort"
+	"strings"
+)
+
+type converter struct {
+	openapi        *openapi3.T
+	knownFullTypes map[string]struct{}
+	fullTypes      []introspection.FullType
+}
+
+// __TypeKind of introspection is an unexported type. In order to overcome the problem,
+// this function creates and returns a TypeRef for a given kind. kind is a AsyncAPI type.
+func getTypeRef(kind string) (introspection.TypeRef, error) {
+	// See introspection_enum.go
+	switch kind {
+	case "string", "integer", "number", "boolean":
+		return introspection.TypeRef{Kind: 0}, nil
+	case "object":
+		return introspection.TypeRef{Kind: 3}, nil
+	case "array":
+		return introspection.TypeRef{Kind: 1}, nil
+	}
+	return introspection.TypeRef{}, errors.New("unknown type")
+}
+
+func asyncAPITypeToGQLType(asyncAPIType string) (string, error) {
+	// See https://www.asyncapi.com/docs/reference/specification/v2.4.0#dataTypeFormat
+	switch asyncAPIType {
+	case "string":
+		return string(literal.STRING), nil
+	case "integer":
+		return string(literal.INT), nil
+	case "number":
+		return string(literal.FLOAT), nil
+	case "boolean":
+		return string(literal.BOOLEAN), nil
+	default:
+		return "", fmt.Errorf("unknown type: %s", asyncAPIType)
+	}
+}
+
+func extractFullTypeNameFromRef(ref string) string {
+	parsed := strings.Split(ref, "/")
+	return parsed[len(parsed)-1]
+}
+
+func (c *converter) processProperties(ft *introspection.FullType, schemaRef *openapi3.SchemaRef) error {
+	for propertyName, property := range schemaRef.Value.Properties {
+		gqlType, err := asyncAPITypeToGQLType(property.Value.Type)
+		if err != nil {
+			return err
+		}
+		typeRef, err := getTypeRef(property.Value.Type)
+		if err != nil {
+			return err
+		}
+		typeRef.Name = &gqlType
+		f := introspection.Field{
+			Name: propertyName,
+			Type: typeRef,
+		}
+		ft.Fields = append(ft.Fields, f)
+		sort.Slice(ft.Fields, func(i, j int) bool {
+			return ft.Fields[i].Name < ft.Fields[j].Name
+		})
+	}
+	return nil
+}
+
+func (c *converter) processArray(media *openapi3.MediaType) error {
+	fullTypeName := extractFullTypeNameFromRef(media.Schema.Value.Items.Ref)
+	_, ok := c.knownFullTypes[fullTypeName]
+	if ok {
+		return nil
+	}
+	c.knownFullTypes[fullTypeName] = struct{}{}
+
+	ft := introspection.FullType{
+		Kind: introspection.OBJECT,
+		Name: fullTypeName,
+	}
+	for _, item := range media.Schema.Value.Items.Value.AllOf {
+		if item.Value.Type == "object" {
+			err := c.processProperties(&ft, item)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	c.fullTypes = append(c.fullTypes, ft)
+	return nil
+}
+
+func (c *converter) processObject(media *openapi3.MediaType) error {
+	fullTypeName := extractFullTypeNameFromRef(media.Schema.Ref)
+	_, ok := c.knownFullTypes[fullTypeName]
+	if ok {
+		return nil
+	}
+	c.knownFullTypes[fullTypeName] = struct{}{}
+
+	ft := introspection.FullType{
+		Kind: introspection.OBJECT,
+		Name: fullTypeName,
+	}
+	err := c.processProperties(&ft, media.Schema)
+	if err != nil {
+		return err
+	}
+	c.fullTypes = append(c.fullTypes, ft)
+	return nil
+}
+
+func (c *converter) processContent(media *openapi3.MediaType) error {
+	if media.Schema.Value.Type == "array" {
+		return c.processArray(media)
+	} else if media.Schema.Value.Type == "object" {
+		return c.processObject(media)
+	}
+	return nil
+}
+
+func (c *converter) importFullTypes() ([]introspection.FullType, error) {
+	for _, pathValue := range c.openapi.Paths {
+		for _, response := range pathValue.Get.Responses {
+			media, ok := response.Value.Content["application/json"]
+			if !ok {
+				return nil, errors.New("only application/json is supported")
+			}
+			err := c.processContent(media)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+	return c.fullTypes, nil
+}
+
+func (c *converter) importQueryType() (*introspection.FullType, error) {
+	// Query root type must be provided. We add an empty Query type with a dummy field.
+	queryType := &introspection.FullType{
+		Kind: introspection.OBJECT,
+		Name: "Query",
+	}
+	return queryType, nil
+}
+
+func ImportParsedOpenAPIv3Document(document *openapi3.T, report *operationreport.Report) *ast.Document {
+	c := &converter{
+		openapi:        document,
+		knownFullTypes: make(map[string]struct{}),
+		fullTypes:      make([]introspection.FullType, 0),
+	}
+	data := introspection.Data{}
+
+	data.Schema.QueryType = &introspection.TypeName{
+		Name: "Query",
+	}
+	queryType, err := c.importQueryType()
+	if err != nil {
+		report.AddInternalError(err)
+		return nil
+	}
+	data.Schema.Types = append(data.Schema.Types, *queryType)
+
+	fullTypes, err := c.importFullTypes()
+	if err != nil {
+		report.AddInternalError(err)
+		return nil
+	}
+	data.Schema.Types = append(data.Schema.Types, fullTypes...)
+
+	outputPretty, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		report.AddInternalError(err)
+		return nil
+	}
+
+	jc := introspection.JsonConverter{}
+	buf := bytes.NewBuffer(outputPretty)
+	doc, err := jc.GraphQLDocument(buf)
+	if err != nil {
+		report.AddInternalError(err)
+		return nil
+	}
+	return doc
+}
+
+func ImportOpenAPIDocumentByte(input []byte) (*ast.Document, operationreport.Report) {
+	report := operationreport.Report{}
+	loader := openapi3.NewLoader()
+	parsed, err := loader.LoadFromData(input)
+	if err != nil {
+		report.AddInternalError(err)
+		return nil, report
+	}
+	return ImportParsedOpenAPIv3Document(parsed, &report), report
+}
+
+func ImportOpenAPIDocumentString(input string) (*ast.Document, operationreport.Report) {
+	return ImportOpenAPIDocumentByte([]byte(input))
+}

--- a/pkg/openapi/openapi.go
+++ b/pkg/openapi/openapi.go
@@ -386,12 +386,12 @@ func (c *converter) addParameters(name string, schema *openapi3.SchemaRef) (*int
 	}
 
 	if schema.Value.Items != nil {
-		otype := schema.Value.Items.Value.Type
-		ot, err := getParamTypeRef(otype)
+		ofType := schema.Value.Items.Value.Type
+		ofTypeRef, err := getParamTypeRef(ofType)
 		if err != nil {
 			return nil, err
 		}
-		typeRef.OfType = &ot
+		typeRef.OfType = &ofTypeRef
 		gqlType = fmt.Sprintf("[%s]", gqlType)
 	}
 

--- a/pkg/openapi/openapi.go
+++ b/pkg/openapi/openapi.go
@@ -470,9 +470,9 @@ func (c *converter) importMutationType() (*introspection.FullType, error) {
 		Kind: introspection.OBJECT,
 		Name: "Mutation",
 	}
-	for _, openapiPath := range c.openapi.Paths {
+	for key, pathItem := range c.openapi.Paths {
 		for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodDelete} {
-			operation := openapiPath.GetOperation(method)
+			operation := pathItem.GetOperation(method)
 			if operation == nil {
 				continue
 			}
@@ -496,9 +496,17 @@ func (c *converter) importMutationType() (*introspection.FullType, error) {
 					return nil, err
 				}
 				typeRef.Name = &typeName
+
 				f := introspection.Field{
 					Name: strcase.ToLowerCamel(operation.OperationID),
 					Type: typeRef,
+				}
+				if f.Name == "" {
+					key = strings.Replace(key, "/", " ", -1)
+					key = strings.Replace(key, "{", " ", -1)
+					key = strings.Replace(key, "}", " ", -1)
+					key = strings.TrimSpace(key)
+					f.Name = strcase.ToLowerCamel(fmt.Sprintf("%s %s", strings.ToLower(method), key))
 				}
 
 				var inputValue *introspection.InputValue

--- a/pkg/openapi/openapi.go
+++ b/pkg/openapi/openapi.go
@@ -100,7 +100,7 @@ func (c *converter) getGraphQLTypeName(schemaRef *openapi3.SchemaRef) (string, e
 
 func extractFullTypeNameFromRef(ref string) string {
 	parsed := strings.Split(ref, "/")
-	return parsed[len(parsed)-1]
+	return strcase.ToCamel(parsed[len(parsed)-1])
 }
 
 func (c *converter) processSchemaProperties(fullType *introspection.FullType, schemas openapi3.Schemas) error {
@@ -116,8 +116,9 @@ func (c *converter) processSchemaProperties(fullType *introspection.FullType, sc
 		}
 		typeRef.Name = &gqlType
 		field := introspection.Field{
-			Name: name,
-			Type: typeRef,
+			Name:        name,
+			Type:        typeRef,
+			Description: schemaRef.Value.Description,
 		}
 
 		fullType.Fields = append(fullType.Fields, field)
@@ -193,8 +194,9 @@ func (c *converter) processObject(schema *openapi3.SchemaRef) error {
 	c.knownFullTypes[fullTypeName] = struct{}{}
 
 	ft := introspection.FullType{
-		Kind: introspection.OBJECT,
-		Name: fullTypeName,
+		Kind:        introspection.OBJECT,
+		Name:        fullTypeName,
+		Description: schema.Value.Description,
 	}
 	err := c.processSchemaProperties(&ft, schema.Value.Properties)
 	if err != nil {
@@ -261,6 +263,7 @@ func (c *converter) importFullTypes() ([]introspection.FullType, error) {
 				if schema == nil {
 					continue
 				}
+
 				err = c.processSchema(schema)
 				if err != nil {
 					return nil, err

--- a/pkg/openapi/openapi.go
+++ b/pkg/openapi/openapi.go
@@ -5,13 +5,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
+	"strings"
+
 	"github.com/TykTechnologies/graphql-go-tools/pkg/ast"
 	"github.com/TykTechnologies/graphql-go-tools/pkg/introspection"
 	"github.com/TykTechnologies/graphql-go-tools/pkg/lexer/literal"
 	"github.com/TykTechnologies/graphql-go-tools/pkg/operationreport"
 	"github.com/getkin/kin-openapi/openapi3"
-	"sort"
-	"strings"
+	"github.com/iancoleman/strcase"
 )
 
 type converter struct {
@@ -35,9 +37,22 @@ func getTypeRef(kind string) (introspection.TypeRef, error) {
 	return introspection.TypeRef{}, errors.New("unknown type")
 }
 
-func asyncAPITypeToGQLType(asyncAPIType string) (string, error) {
-	// See https://www.asyncapi.com/docs/reference/specification/v2.4.0#dataTypeFormat
-	switch asyncAPIType {
+func getParamTypeRef(kind string) (introspection.TypeRef, error) {
+	// See introspection_enum.go
+	switch kind {
+	case "string", "integer", "number", "boolean":
+		return introspection.TypeRef{Kind: 0}, nil
+	case "object":
+		// InputType
+		return introspection.TypeRef{Kind: 7}, nil
+	case "array":
+		return introspection.TypeRef{Kind: 1}, nil
+	}
+	return introspection.TypeRef{}, errors.New("unknown type")
+}
+
+func openAPITypeToGQLType(openapiType string) (string, error) {
+	switch openapiType {
 	case "string":
 		return string(literal.STRING), nil
 	case "integer":
@@ -47,7 +62,7 @@ func asyncAPITypeToGQLType(asyncAPIType string) (string, error) {
 	case "boolean":
 		return string(literal.BOOLEAN), nil
 	default:
-		return "", fmt.Errorf("unknown type: %s", asyncAPIType)
+		return "", fmt.Errorf("unknown type: %s", openapiType)
 	}
 }
 
@@ -58,7 +73,7 @@ func extractFullTypeNameFromRef(ref string) string {
 
 func (c *converter) processProperties(ft *introspection.FullType, schemaRef *openapi3.SchemaRef) error {
 	for propertyName, property := range schemaRef.Value.Properties {
-		gqlType, err := asyncAPITypeToGQLType(property.Value.Type)
+		gqlType, err := openAPITypeToGQLType(property.Value.Type)
 		if err != nil {
 			return err
 		}
@@ -74,6 +89,30 @@ func (c *converter) processProperties(ft *introspection.FullType, schemaRef *ope
 		ft.Fields = append(ft.Fields, f)
 		sort.Slice(ft.Fields, func(i, j int) bool {
 			return ft.Fields[i].Name < ft.Fields[j].Name
+		})
+	}
+	return nil
+}
+
+func (c *converter) processInputFields(ft *introspection.FullType, schemaRef *openapi3.SchemaRef) error {
+	for propertyName, property := range schemaRef.Value.Properties {
+		gqlType, err := openAPITypeToGQLType(property.Value.Type)
+		if err != nil {
+			return err
+		}
+		typeRef, err := getTypeRef(property.Value.Type)
+		if err != nil {
+			return err
+		}
+
+		typeRef.Name = &gqlType
+		f := introspection.InputValue{
+			Name: propertyName,
+			Type: typeRef,
+		}
+		ft.InputFields = append(ft.InputFields, f)
+		sort.Slice(ft.InputFields, func(i, j int) bool {
+			return ft.InputFields[i].Name < ft.InputFields[j].Name
 		})
 	}
 	return nil
@@ -103,8 +142,8 @@ func (c *converter) processArray(media *openapi3.MediaType) error {
 	return nil
 }
 
-func (c *converter) processObject(media *openapi3.MediaType) error {
-	fullTypeName := extractFullTypeNameFromRef(media.Schema.Ref)
+func (c *converter) processObject(schema *openapi3.SchemaRef) error {
+	fullTypeName := extractFullTypeNameFromRef(schema.Ref)
 	_, ok := c.knownFullTypes[fullTypeName]
 	if ok {
 		return nil
@@ -115,7 +154,27 @@ func (c *converter) processObject(media *openapi3.MediaType) error {
 		Kind: introspection.OBJECT,
 		Name: fullTypeName,
 	}
-	err := c.processProperties(&ft, media.Schema)
+	err := c.processProperties(&ft, schema)
+	if err != nil {
+		return err
+	}
+	c.fullTypes = append(c.fullTypes, ft)
+	return nil
+}
+
+func (c *converter) processInputObject(schema *openapi3.SchemaRef) error {
+	fullTypeName := extractFullTypeNameFromRef(schema.Ref)
+	_, ok := c.knownFullTypes[fullTypeName]
+	if ok {
+		return nil
+	}
+	c.knownFullTypes[fullTypeName] = struct{}{}
+
+	ft := introspection.FullType{
+		Kind: introspection.INPUTOBJECT,
+		Name: fullTypeName,
+	}
+	err := c.processInputFields(&ft, schema)
 	if err != nil {
 		return err
 	}
@@ -127,25 +186,55 @@ func (c *converter) processContent(media *openapi3.MediaType) error {
 	if media.Schema.Value.Type == "array" {
 		return c.processArray(media)
 	} else if media.Schema.Value.Type == "object" {
-		return c.processObject(media)
+		return c.processObject(media.Schema)
 	}
 	return nil
 }
 
 func (c *converter) importFullTypes() ([]introspection.FullType, error) {
-	for _, pathValue := range c.openapi.Paths {
-		for _, response := range pathValue.Get.Responses {
-			media, ok := response.Value.Content["application/json"]
-			if !ok {
+	for _, openapiPaths := range c.openapi.Paths {
+		for _, response := range openapiPaths.Get.Responses {
+			mediaType := response.Value.Content.Get("application/json")
+			if mediaType == nil {
 				return nil, errors.New("only application/json is supported")
 			}
-			err := c.processContent(media)
+			err := c.processContent(mediaType)
 			if err != nil {
 				return nil, err
 			}
 		}
 	}
+	sort.Slice(c.fullTypes, func(i, j int) bool {
+		return c.fullTypes[i].Name < c.fullTypes[j].Name
+	})
 	return c.fullTypes, nil
+}
+
+func extractTypeName(status int, operation *openapi3.Operation) string {
+	response := operation.Responses.Get(status)
+	if response == nil {
+		// Nil response?
+		return ""
+	}
+	schema := response.Value.Content.Get("application/json")
+	if schema == nil && len(response.Value.Content) == 0 {
+		return ""
+	}
+	if schema.Schema.Value.Type == "array" {
+		return extractFullTypeNameFromRef(schema.Schema.Value.Items.Ref)
+	}
+	return extractFullTypeNameFromRef(schema.Schema.Ref)
+}
+
+func getJSONSchema(status int, operation *openapi3.Operation) *openapi3.SchemaRef {
+	var schema *openapi3.SchemaRef
+	for _, contentType := range []string{"application/json", "application/geo+json"} {
+		content := operation.Responses.Get(status).Value.Content.Get(contentType)
+		if content != nil {
+			return content.Schema
+		}
+	}
+	return schema
 }
 
 func (c *converter) importQueryType() (*introspection.FullType, error) {
@@ -154,7 +243,180 @@ func (c *converter) importQueryType() (*introspection.FullType, error) {
 		Kind: introspection.OBJECT,
 		Name: "Query",
 	}
+	for _, openapiPath := range c.openapi.Paths {
+		for _, method := range []string{"GET"} {
+			operation := openapiPath.GetOperation(method)
+			if operation == nil {
+				continue
+			}
+			kind := getJSONSchema(200, operation).Value.Type
+			if kind == "" {
+				kind = "object"
+			}
+			typeName := strcase.ToCamel(extractTypeName(200, operation))
+
+			typeRef, err := getTypeRef(kind)
+			if err != nil {
+				return nil, err
+			}
+			if kind == "array" {
+				typeRef.OfType = &introspection.TypeRef{Kind: 3, Name: &typeName}
+			}
+
+			typeRef.Name = &typeName
+			f := introspection.Field{
+				Name: strcase.ToLowerCamel(operation.OperationID),
+				Type: typeRef,
+			}
+
+			for _, parameter := range operation.Parameters {
+				paramType := parameter.Value.Schema.Value.Type
+				if paramType == "array" {
+					paramType = parameter.Value.Schema.Value.Items.Value.Type
+				}
+
+				typeRef, err := getTypeRef(paramType)
+				if err != nil {
+					return nil, err
+				}
+
+				gqlType, err := openAPITypeToGQLType(paramType)
+				if err != nil {
+					return nil, err
+				}
+
+				if parameter.Value.Schema.Value.Items != nil {
+					otype := parameter.Value.Schema.Value.Items.Value.Type
+					ot, err := getTypeRef(otype)
+					if err != nil {
+						return nil, err
+					}
+					typeRef.OfType = &ot
+					gqlType = fmt.Sprintf("[%s]", gqlType)
+				}
+
+				typeRef.Name = &gqlType
+				iv := introspection.InputValue{
+					Name: parameter.Value.Name,
+					Type: typeRef,
+				}
+				f.Args = append(f.Args, iv)
+				sort.Slice(f.Args, func(i, j int) bool {
+					return f.Args[i].Name < f.Args[j].Name
+				})
+			}
+			queryType.Fields = append(queryType.Fields, f)
+		}
+	}
+	sort.Slice(queryType.Fields, func(i, j int) bool {
+		return queryType.Fields[i].Name < queryType.Fields[j].Name
+	})
 	return queryType, nil
+}
+
+func (c *converter) addParameters(name string, schema *openapi3.SchemaRef) (*introspection.InputValue, error) {
+	paramType := schema.Value.Type
+	if paramType == "array" {
+		paramType = schema.Value.Items.Value.Type
+	}
+
+	typeRef, err := getParamTypeRef(paramType)
+	if err != nil {
+		return nil, err
+	}
+
+	gqlType := name
+	if paramType != "object" {
+		gqlType, err = openAPITypeToGQLType(paramType)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		err = c.processInputObject(schema)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if schema.Value.Items != nil {
+		otype := schema.Value.Items.Value.Type
+		ot, err := getParamTypeRef(otype)
+		if err != nil {
+			return nil, err
+		}
+		typeRef.OfType = &ot
+		gqlType = fmt.Sprintf("[%s]", gqlType)
+	}
+
+	typeRef.Name = &gqlType
+	return &introspection.InputValue{
+		Name: strcase.ToLowerCamel(name),
+		Type: typeRef,
+	}, nil
+}
+
+func (c *converter) importMutationType() (*introspection.FullType, error) {
+	// Query root type must be provided. We add an empty Query type with a dummy field.
+	mutationType := &introspection.FullType{
+		Kind: introspection.OBJECT,
+		Name: "Mutation",
+	}
+	for _, openapiPath := range c.openapi.Paths {
+		for _, method := range []string{"POST", "PUT", "DELETE"} {
+			operation := openapiPath.GetOperation(method)
+			if operation == nil {
+				continue
+			}
+			// TODO: We can pick only one response type in UDG.
+			status := 200
+			if method == "DELETE" {
+				status = 204
+			}
+			typeName := strcase.ToCamel(extractTypeName(status, operation))
+			if typeName == "" {
+				// TODO: https://stackoverflow.com/questions/44737043/is-it-possible-to-not-return-any-data-when-using-a-graphql-mutation/44773532#44773532
+				typeName = "Boolean"
+			}
+
+			typeRef, err := getTypeRef("object")
+			if err != nil {
+				return nil, err
+			}
+			typeRef.Name = &typeName
+			f := introspection.Field{
+				Name: strcase.ToLowerCamel(operation.OperationID),
+				Type: typeRef,
+			}
+
+			var inputValue *introspection.InputValue
+			if operation.RequestBody != nil {
+				// TODO: Find a new way to get schema
+				content := operation.RequestBody.Value.Content.Get("application/json")
+				if content == nil {
+					content = operation.RequestBody.Value.Content.Get("application/x-www-form-urlencoded")
+				}
+				schema := content.Schema
+				inputValue, err = c.addParameters(extractFullTypeNameFromRef(schema.Ref), schema)
+				if err != nil {
+					return nil, err
+				}
+				f.Args = append(f.Args, *inputValue)
+			} else {
+				for _, parameter := range operation.Parameters {
+					inputValue, err = c.addParameters(parameter.Value.Name, parameter.Value.Schema)
+					if err != nil {
+						return nil, err
+					}
+					f.Args = append(f.Args, *inputValue)
+				}
+			}
+			sort.Slice(f.Args, func(i, j int) bool {
+				return f.Args[i].Name < f.Args[j].Name
+			})
+			mutationType.Fields = append(mutationType.Fields, f)
+		}
+	}
+	return mutationType, nil
 }
 
 func ImportParsedOpenAPIv3Document(document *openapi3.T, report *operationreport.Report) *ast.Document {
@@ -174,6 +436,13 @@ func ImportParsedOpenAPIv3Document(document *openapi3.T, report *operationreport
 		return nil
 	}
 	data.Schema.Types = append(data.Schema.Types, *queryType)
+
+	mutationType, err := c.importMutationType()
+	if err != nil {
+		report.AddInternalError(err)
+		return nil
+	}
+	data.Schema.Types = append(data.Schema.Types, *mutationType)
 
 	fullTypes, err := c.importFullTypes()
 	if err != nil {
@@ -201,6 +470,7 @@ func ImportParsedOpenAPIv3Document(document *openapi3.T, report *operationreport
 func ImportOpenAPIDocumentByte(input []byte) (*ast.Document, operationreport.Report) {
 	report := operationreport.Report{}
 	loader := openapi3.NewLoader()
+	loader.IsExternalRefsAllowed = true
 	parsed, err := loader.LoadFromData(input)
 	if err != nil {
 		report.AddInternalError(err)

--- a/pkg/openapi/openapi_test.go
+++ b/pkg/openapi/openapi_test.go
@@ -24,6 +24,8 @@ func testFixtureFile(t *testing.T, version, name string) {
 	err = astprinter.PrintIndent(doc, nil, []byte("  "), w)
 	require.NoError(t, err)
 
+	fmt.Println(w.String())
+
 	name = strings.Trim(strings.Trim(name, ".yaml"), ".json")
 	graphqlDoc, err := os.ReadFile(fmt.Sprintf("./fixtures/%s/%s.graphql", version, name))
 	require.NoError(t, err)
@@ -47,5 +49,10 @@ func TestOpenAPI_v3_0_0(t *testing.T) {
 	t.Run("EmployeesApiBasic.yaml", func(t *testing.T) {
 		// Source https://github.com/zosconnect/test-samples/blob/main/oas/EmployeesApiBasic.yaml
 		testFixtureFile(t, "v3.0.0", "EmployeesApiBasic.yaml")
+	})
+
+	t.Run("EmployeesApi.yaml", func(t *testing.T) {
+		// Source https://github.com/zosconnect/test-samples/blob/main/oas/EmployeesApiBasic.yaml
+		testFixtureFile(t, "v3.0.0", "EmployeesApi.yaml")
 	})
 }

--- a/pkg/openapi/openapi_test.go
+++ b/pkg/openapi/openapi_test.go
@@ -45,6 +45,7 @@ func TestOpenAPI_v3_0_0(t *testing.T) {
 	})
 
 	t.Run("EmployeesApiBasic.yaml", func(t *testing.T) {
+		// Source https://github.com/zosconnect/test-samples/blob/main/oas/EmployeesApiBasic.yaml
 		testFixtureFile(t, "v3.0.0", "EmployeesApiBasic.yaml")
 	})
 }

--- a/pkg/openapi/openapi_test.go
+++ b/pkg/openapi/openapi_test.go
@@ -44,4 +44,7 @@ func TestOpenAPI_v3_0_0(t *testing.T) {
 		testFixtureFile(t, "v3.0.0", "example_oas7.json")
 	})
 
+	t.Run("EmployeesApiBasic.yaml", func(t *testing.T) {
+		testFixtureFile(t, "v3.0.0", "EmployeesApiBasic.yaml")
+	})
 }

--- a/pkg/openapi/openapi_test.go
+++ b/pkg/openapi/openapi_test.go
@@ -53,4 +53,10 @@ func TestOpenAPI_v3_0_0(t *testing.T) {
 		// Source https://github.com/zosconnect/test-samples/blob/main/oas/EmployeesApiBasic.yaml
 		testFixtureFile(t, "v3.0.0", "EmployeesApi.yaml")
 	})
+
+	t.Run("example_oas3.json", func(t *testing.T) {
+		// Source: https://github.com/IBM/openapi-to-graphql/blob/master/packages/openapi-to-graphql/test/fixtures/example_oas3.json
+		testFixtureFile(t, "v3.0.0", "example_oas3.json")
+	})
+
 }

--- a/pkg/openapi/openapi_test.go
+++ b/pkg/openapi/openapi_test.go
@@ -1,0 +1,24 @@
+package openapi
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/TykTechnologies/graphql-go-tools/pkg/astprinter"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenAPIv3(t *testing.T) {
+	input, err := os.ReadFile("./fixtures/v3.0.0/petstore-expanded.yaml")
+	require.NoError(t, err)
+
+	doc, err := ImportOpenAPIDocumentByte(input)
+	fmt.Println(err)
+
+	w := &bytes.Buffer{}
+	err = astprinter.PrintIndent(doc, nil, []byte("  "), w)
+	require.NoError(t, err)
+	fmt.Println(w.String())
+}

--- a/pkg/openapi/openapi_test.go
+++ b/pkg/openapi/openapi_test.go
@@ -24,8 +24,6 @@ func testFixtureFile(t *testing.T, version, name string) {
 	err = astprinter.PrintIndent(doc, nil, []byte("  "), w)
 	require.NoError(t, err)
 
-	fmt.Println(w.String())
-
 	name = strings.Trim(strings.Trim(name, ".yaml"), ".json")
 	graphqlDoc, err := os.ReadFile(fmt.Sprintf("./fixtures/%s/%s.graphql", version, name))
 	require.NoError(t, err)

--- a/pkg/openapi/openapi_test.go
+++ b/pkg/openapi/openapi_test.go
@@ -2,7 +2,6 @@ package openapi
 
 import (
 	"bytes"
-	"fmt"
 	"os"
 	"testing"
 
@@ -14,11 +13,16 @@ func TestOpenAPIv3(t *testing.T) {
 	input, err := os.ReadFile("./fixtures/v3.0.0/petstore-expanded.yaml")
 	require.NoError(t, err)
 
-	doc, err := ImportOpenAPIDocumentByte(input)
-	fmt.Println(err)
+	doc, report := ImportOpenAPIDocumentByte(input)
+	if report.HasErrors() {
+		t.Fatal(report.Error())
+	}
 
 	w := &bytes.Buffer{}
 	err = astprinter.PrintIndent(doc, nil, []byte("  "), w)
 	require.NoError(t, err)
-	fmt.Println(w.String())
+
+	graphqlDoc, err := os.ReadFile("./fixtures/v3.0.0/petstore-expanded.graphql")
+	require.NoError(t, err)
+	require.Equal(t, string(graphqlDoc), w.String())
 }

--- a/pkg/openapi/openapi_test.go
+++ b/pkg/openapi/openapi_test.go
@@ -2,27 +2,46 @@ package openapi
 
 import (
 	"bytes"
+	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/TykTechnologies/graphql-go-tools/pkg/astprinter"
 	"github.com/stretchr/testify/require"
 )
 
-func TestOpenAPIv3(t *testing.T) {
-	input, err := os.ReadFile("./fixtures/v3.0.0/petstore-expanded.yaml")
+func testFixtureFile(t *testing.T, version, name string) {
+	asyncapiDoc, err := os.ReadFile(fmt.Sprintf("./fixtures/%s/%s", version, name))
 	require.NoError(t, err)
 
-	doc, report := ImportOpenAPIDocumentByte(input)
+	doc, report := ImportOpenAPIDocumentString(string(asyncapiDoc))
 	if report.HasErrors() {
 		t.Fatal(report.Error())
 	}
-
+	require.NoError(t, err)
 	w := &bytes.Buffer{}
 	err = astprinter.PrintIndent(doc, nil, []byte("  "), w)
 	require.NoError(t, err)
 
-	graphqlDoc, err := os.ReadFile("./fixtures/v3.0.0/petstore-expanded.graphql")
+	name = strings.Trim(strings.Trim(name, ".yaml"), ".json")
+	graphqlDoc, err := os.ReadFile(fmt.Sprintf("./fixtures/%s/%s.graphql", version, name))
 	require.NoError(t, err)
 	require.Equal(t, string(graphqlDoc), w.String())
+}
+
+func TestOpenAPI_v3_0_0(t *testing.T) {
+	t.Run("petstore-expanded.yaml", func(t *testing.T) {
+		testFixtureFile(t, "v3.0.0", "petstore-expanded.yaml")
+	})
+
+	t.Run("petstore.yaml", func(t *testing.T) {
+		testFixtureFile(t, "v3.0.0", "petstore.yaml")
+	})
+
+	t.Run("example_oas7.json", func(t *testing.T) {
+		// Source: https://github.com/IBM/openapi-to-graphql/blob/master/packages/openapi-to-graphql/test/fixtures/example_oas7.json
+		testFixtureFile(t, "v3.0.0", "example_oas7.json")
+	})
+
 }


### PR DESCRIPTION
This PR implements an OpenAPI to GraphQL converter. Currently, it only supports OpenAPI v3.0.0 `getkin/kin-openapi` provides a different parser for OpenAPI 2.0.0 but it is based on OpenAPI 3.0.0. v2.0.0 support should be planned and tested separately. 

Known issues and missing features:

* Cannot properly handle field arguments if the type is an array.
* Doesn't support [links](https://swagger.io/docs/specification/links/).
* Doesn't support non-null fields.
* Doesn't support [HTTP response ranges](https://swagger.io/docs/specification/describing-responses/?sbsearch=range)(for example, 2XX). 
* It's not clear how to handle non-JSON responses, for example, `application/geo+json` or `text/plain`.

Example documents and their GraphQL counterparts can be found under `openapi/fixtures/v3.0.0`. We can successfully parse the `petstore.yaml` and `petstore-expanded.yaml` files. 
 
