### PR TITLE
fix: resolve, do not resolve fetch if ctx is cancelled (#518)

### DIFF
--- a/pkg/engine/resolve/resolve.go
+++ b/pkg/engine/resolve/resolve.go
@@ -1239,6 +1239,10 @@ func (r *Resolver) freeResultSet(set *resultSet) {
 }
 
 func (r *Resolver) resolveFetch(ctx *Context, fetch Fetch, data []byte, set *resultSet) (err error) {
+	// if context is cancelled, we should not resolve the fetch
+	if errors.Is(ctx.Err(), context.Canceled) {
+		return nil
+	}
 
 	switch f := fetch.(type) {
 	case *SingleFetch:


### PR DESCRIPTION
PR from WG: https://github.com/wundergraph/graphql-go-tools/pull/518