### PR TITLE
introduce CustomExecutionEngineV2

### DIFF
--- a/pkg/graphql/execution_engine_v2.go
+++ b/pkg/graphql/execution_engine_v2.go
@@ -139,47 +139,47 @@ func (e *internalExecutionContext) reset() {
 }
 
 type ExecutionEngineV2 struct {
-	logger                       abstractlogger.Logger
-	config                       EngineV2Configuration
-	planner                      *plan.Planner
-	plannerMu                    sync.Mutex
-	resolver                     *resolve.Resolver
-	internalExecutionContextPool sync.Pool
-	executionPlanCache           *lru.Cache
+	logger                        abstractlogger.Logger
+	config                        EngineV2Configuration
+	planner                       *plan.Planner
+	plannerMu                     sync.Mutex
+	resolver                      *resolve.Resolver
+	executionPlanCache            *lru.Cache
+	customExecutionEngineExecutor *CustomExecutionEngineV2Executor
 }
 
 type WebsocketBeforeStartHook interface {
 	OnBeforeStart(reqCtx context.Context, operation *Request) error
 }
 
-type ExecutionOptionsV2 func(ctx *internalExecutionContext)
+type ExecutionOptionsV2 func(postProcessor *postprocess.Processor, resolveContext *resolve.Context)
 
 func WithBeforeFetchHook(hook resolve.BeforeFetchHook) ExecutionOptionsV2 {
-	return func(ctx *internalExecutionContext) {
-		ctx.resolveContext.SetBeforeFetchHook(hook)
+	return func(postProcessor *postprocess.Processor, resolveContext *resolve.Context) {
+		resolveContext.SetBeforeFetchHook(hook)
 	}
 }
 
 func WithUpstreamHeaders(header http.Header) ExecutionOptionsV2 {
-	return func(ctx *internalExecutionContext) {
-		ctx.postProcessor.AddPostProcessor(postprocess.NewProcessInjectHeader(header))
+	return func(postProcessor *postprocess.Processor, resolveContext *resolve.Context) {
+		postProcessor.AddPostProcessor(postprocess.NewProcessInjectHeader(header))
 	}
 }
 
 func WithAfterFetchHook(hook resolve.AfterFetchHook) ExecutionOptionsV2 {
-	return func(ctx *internalExecutionContext) {
-		ctx.resolveContext.SetAfterFetchHook(hook)
+	return func(postProcessor *postprocess.Processor, resolveContext *resolve.Context) {
+		resolveContext.SetAfterFetchHook(hook)
 	}
 }
 
 func WithAdditionalHttpHeaders(headers http.Header, excludeByKeys ...string) ExecutionOptionsV2 {
-	return func(ctx *internalExecutionContext) {
+	return func(postProcessor *postprocess.Processor, resolveContext *resolve.Context) {
 		if len(headers) == 0 {
 			return
 		}
 
-		if ctx.resolveContext.Request.Header == nil {
-			ctx.resolveContext.Request.Header = make(http.Header)
+		if resolveContext.Request.Header == nil {
+			resolveContext.Request.Header = make(http.Header)
 		}
 
 		excludeMap := make(map[string]bool)
@@ -193,7 +193,7 @@ func WithAdditionalHttpHeaders(headers http.Header, excludeByKeys ...string) Exe
 			}
 
 			for _, headerValue := range headerValues {
-				ctx.resolveContext.Request.Header.Add(headerKey, headerValue)
+				resolveContext.Request.Header.Add(headerKey, headerValue)
 			}
 		}
 	}
@@ -216,21 +216,23 @@ func NewExecutionEngineV2(ctx context.Context, logger abstractlogger.Logger, eng
 		engineConfig.AddFieldConfiguration(fieldCfg)
 	}
 
-	return &ExecutionEngineV2{
-		logger:   logger,
-		config:   engineConfig,
-		planner:  plan.NewPlanner(ctx, engineConfig.plannerConfig),
-		resolver: resolve.New(ctx, fetcher, engineConfig.dataLoaderConfig.EnableDataLoader),
-		internalExecutionContextPool: sync.Pool{
-			New: func() interface{} {
-				return newInternalExecutionContext()
-			},
-		},
+	executionEngine := &ExecutionEngineV2{
+		logger:             logger,
+		config:             engineConfig,
+		planner:            plan.NewPlanner(ctx, engineConfig.plannerConfig),
+		resolver:           resolve.New(ctx, fetcher, engineConfig.dataLoaderConfig.EnableDataLoader),
 		executionPlanCache: executionPlanCache,
-	}, nil
+	}
+
+	executor, err := NewCustomExecutionEngineV2Executor(executionEngine)
+	if err != nil {
+		return nil, err
+	}
+	executionEngine.customExecutionEngineExecutor = executor
+	return executionEngine, nil
 }
 
-func (e *ExecutionEngineV2) Execute(ctx context.Context, operation *Request, writer resolve.FlushWriter, options ...ExecutionOptionsV2) error {
+func (e *ExecutionEngineV2) Normalize(operation *Request) error {
 	if !operation.IsNormalized() {
 		result, err := operation.Normalize(e.config.schema)
 		if err != nil {
@@ -241,7 +243,10 @@ func (e *ExecutionEngineV2) Execute(ctx context.Context, operation *Request, wri
 			return result.Errors
 		}
 	}
+	return nil
+}
 
+func (e *ExecutionEngineV2) ValidateForSchema(operation *Request) error {
 	result, err := operation.ValidateForSchema(e.config.schema)
 	if err != nil {
 		return err
@@ -249,27 +254,30 @@ func (e *ExecutionEngineV2) Execute(ctx context.Context, operation *Request, wri
 	if !result.Valid {
 		return result.Errors
 	}
+	return nil
+}
 
-	execContext := e.getExecutionCtx()
-	defer e.putExecutionCtx(execContext)
-
-	execContext.prepare(ctx, operation.Variables, operation.request)
-
+func (e *ExecutionEngineV2) Setup(ctx context.Context, postProcessor *postprocess.Processor, resolveContext *resolve.Context, operation *Request, options ...ExecutionOptionsV2) {
 	for i := range options {
-		options[i](execContext)
+		options[i](postProcessor, resolveContext)
 	}
+}
 
-	var report operationreport.Report
-	cachedPlan := e.getCachedPlan(execContext, &operation.document, &e.config.schema.document, operation.OperationName, &report)
+func (e *ExecutionEngineV2) Plan(postProcessor *postprocess.Processor, operation *Request, report *operationreport.Report) (plan.Plan, error) {
+	cachedPlan := e.getCachedPlan(postProcessor, &operation.document, &e.config.schema.document, operation.OperationName, report)
 	if report.HasErrors() {
-		return report
+		return nil, report
 	}
+	return cachedPlan, nil
+}
 
-	switch p := cachedPlan.(type) {
+func (e *ExecutionEngineV2) Resolve(resolveContext *resolve.Context, planResult plan.Plan, writer resolve.FlushWriter) error {
+	var err error
+	switch p := planResult.(type) {
 	case *plan.SynchronousResponsePlan:
-		err = e.resolver.ResolveGraphQLResponse(execContext.resolveContext, p.Response, nil, writer)
+		err = e.resolver.ResolveGraphQLResponse(resolveContext, p.Response, nil, writer)
 	case *plan.SubscriptionResponsePlan:
-		err = e.resolver.ResolveGraphQLSubscription(execContext.resolveContext, p.Response, writer)
+		err = e.resolver.ResolveGraphQLSubscription(resolveContext, p.Response, writer)
 	default:
 		return errors.New("execution of operation is not possible")
 	}
@@ -277,7 +285,14 @@ func (e *ExecutionEngineV2) Execute(ctx context.Context, operation *Request, wri
 	return err
 }
 
-func (e *ExecutionEngineV2) getCachedPlan(ctx *internalExecutionContext, operation, definition *ast.Document, operationName string, report *operationreport.Report) plan.Plan {
+func (e *ExecutionEngineV2) Teardown() {
+}
+
+func (e *ExecutionEngineV2) Execute(ctx context.Context, operation *Request, writer resolve.FlushWriter, options ...ExecutionOptionsV2) error {
+	return e.customExecutionEngineExecutor.Execute(ctx, operation, writer, options...)
+}
+
+func (e *ExecutionEngineV2) getCachedPlan(postProcessor *postprocess.Processor, operation, definition *ast.Document, operationName string, report *operationreport.Report) plan.Plan {
 
 	hash := pool.Hash64.Get()
 	hash.Reset()
@@ -303,20 +318,11 @@ func (e *ExecutionEngineV2) getCachedPlan(ctx *internalExecutionContext, operati
 		return nil
 	}
 
-	p := ctx.postProcessor.Process(planResult)
+	p := postProcessor.Process(planResult)
 	e.executionPlanCache.Add(cacheKey, p)
 	return p
 }
 
 func (e *ExecutionEngineV2) GetWebsocketBeforeStartHook() WebsocketBeforeStartHook {
 	return e.config.websocketBeforeStartHook
-}
-
-func (e *ExecutionEngineV2) getExecutionCtx() *internalExecutionContext {
-	return e.internalExecutionContextPool.Get().(*internalExecutionContext)
-}
-
-func (e *ExecutionEngineV2) putExecutionCtx(ctx *internalExecutionContext) {
-	ctx.reset()
-	e.internalExecutionContextPool.Put(ctx)
 }

--- a/pkg/graphql/execution_engine_v2.go
+++ b/pkg/graphql/execution_engine_v2.go
@@ -326,3 +326,9 @@ func (e *ExecutionEngineV2) getCachedPlan(postProcessor *postprocess.Processor, 
 func (e *ExecutionEngineV2) GetWebsocketBeforeStartHook() WebsocketBeforeStartHook {
 	return e.config.websocketBeforeStartHook
 }
+
+// Interface Guards
+var (
+	_ CustomExecutionEngineV2   = (*ExecutionEngineV2)(nil)
+	_ ExecutionEngineV2Executor = (*ExecutionEngineV2)(nil)
+)

--- a/pkg/graphql/execution_engine_v2_custom.go
+++ b/pkg/graphql/execution_engine_v2_custom.go
@@ -1,0 +1,144 @@
+package graphql
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/TykTechnologies/graphql-go-tools/pkg/engine/plan"
+	"github.com/TykTechnologies/graphql-go-tools/pkg/engine/resolve"
+	"github.com/TykTechnologies/graphql-go-tools/pkg/operationreport"
+	"github.com/TykTechnologies/graphql-go-tools/pkg/postprocess"
+)
+
+var (
+	ErrRequiredStagesMissing = errors.New("required stages for custom execution engine v2 are missing")
+)
+
+type CustomExecutionEngineV2NormalizerStage interface {
+	Normalize(operation *Request) error
+}
+
+type CustomExecutionEngineV2ValidatorStage interface {
+	ValidateForSchema(operation *Request) error
+}
+
+type CustomExecutionEngineV2ResolverStage interface {
+	Setup(ctx context.Context, operation *Request, options ...ExecutionOptionsV2)
+	Plan(postProcessor *postprocess.Processor, operation *Request, report *operationreport.Report) (plan.Plan, error)
+	Resolve(resolveContext *resolve.Context, plan plan.Plan, writer resolve.FlushWriter) error
+	Teardown()
+}
+
+type CustomExecutionEngineV2 interface {
+	CustomExecutionEngineV2NormalizerStage
+	CustomExecutionEngineV2ValidatorStage
+	CustomExecutionEngineV2ResolverStage
+}
+
+type ExecutionEngineV2Executor interface {
+	Execute(ctx context.Context, operation *Request, writer resolve.FlushWriter, options ...ExecutionOptionsV2) error
+}
+
+type CustomExecutionEngineV2Stages struct {
+	RequiredStages CustomExecutionEngineV2RequiredStages
+	OptionalStages *CustomExecutionEngineV2OptionalStages
+}
+
+func (c *CustomExecutionEngineV2Stages) AllRequiredStagesProvided() bool {
+	if c.RequiredStages.ResolverStage == nil {
+		return false
+	}
+	return true
+}
+
+type CustomExecutionEngineV2RequiredStages struct {
+	ResolverStage CustomExecutionEngineV2ResolverStage
+}
+
+type CustomExecutionEngineV2OptionalStages struct {
+	NormalizerStage CustomExecutionEngineV2NormalizerStage
+	ValidatorStage  CustomExecutionEngineV2ValidatorStage
+}
+
+type CustomExecutionEngineV2Executor struct {
+	ExecutionStages              CustomExecutionEngineV2Stages
+	internalExecutionContextPool sync.Pool
+}
+
+func NewCustomExecutionEngineV2Executor(executionEngineV2 CustomExecutionEngineV2) (*CustomExecutionEngineV2Executor, error) {
+	executionStages := CustomExecutionEngineV2Stages{
+		RequiredStages: CustomExecutionEngineV2RequiredStages{
+			ResolverStage: executionEngineV2,
+		},
+		OptionalStages: &CustomExecutionEngineV2OptionalStages{
+			NormalizerStage: executionEngineV2,
+			ValidatorStage:  executionEngineV2,
+		},
+	}
+
+	return NewCustomExecutionEngineV2ExecutorByStages(executionStages)
+}
+
+func NewCustomExecutionEngineV2ExecutorByStages(executionStages CustomExecutionEngineV2Stages) (*CustomExecutionEngineV2Executor, error) {
+	return &CustomExecutionEngineV2Executor{
+		ExecutionStages: executionStages,
+		internalExecutionContextPool: sync.Pool{
+			New: func() interface{} {
+				return newInternalExecutionContext()
+			},
+		},
+	}, nil
+}
+
+func (c *CustomExecutionEngineV2Executor) getExecutionCtx() *internalExecutionContext {
+	return c.internalExecutionContextPool.Get().(*internalExecutionContext)
+}
+
+func (c *CustomExecutionEngineV2Executor) putExecutionCtx(ctx *internalExecutionContext) {
+	ctx.reset()
+	c.internalExecutionContextPool.Put(ctx)
+}
+
+func (c *CustomExecutionEngineV2Executor) Execute(ctx context.Context, operation *Request, writer resolve.FlushWriter, options ...ExecutionOptionsV2) error {
+	if !c.ExecutionStages.AllRequiredStagesProvided() {
+		return ErrRequiredStagesMissing
+	}
+
+	var err error
+	if c.ExecutionStages.OptionalStages != nil && c.ExecutionStages.OptionalStages.NormalizerStage != nil {
+		err = c.ExecutionStages.OptionalStages.NormalizerStage.Normalize(operation)
+		if err != nil {
+			return err
+		}
+	}
+
+	if c.ExecutionStages.OptionalStages != nil && c.ExecutionStages.OptionalStages.ValidatorStage != nil {
+		err = c.ExecutionStages.OptionalStages.ValidatorStage.ValidateForSchema(operation)
+		if err != nil {
+			return err
+		}
+	}
+
+	c.ExecutionStages.RequiredStages.ResolverStage.Setup(ctx, operation, options...)
+
+	execContext := c.getExecutionCtx()
+	defer c.putExecutionCtx(execContext)
+	execContext.prepare(ctx, operation.Variables, operation.request)
+
+	var report operationreport.Report
+	planResult, err := c.ExecutionStages.RequiredStages.ResolverStage.Plan(execContext.postProcessor, operation, &report)
+	if err != nil {
+		return err
+	} else if report.HasErrors() {
+		return report
+	}
+
+	err = c.ExecutionStages.RequiredStages.ResolverStage.Resolve(execContext.resolveContext, planResult, writer)
+	if err != nil {
+		return err
+	}
+
+	c.ExecutionStages.RequiredStages.ResolverStage.Teardown()
+	return nil
+}

--- a/pkg/graphql/execution_engine_v2_custom.go
+++ b/pkg/graphql/execution_engine_v2_custom.go
@@ -138,3 +138,8 @@ func (c *CustomExecutionEngineV2Executor) Execute(ctx context.Context, operation
 	c.ExecutionStages.RequiredStages.ResolverStage.Teardown()
 	return nil
 }
+
+// Interface Guards
+var (
+	_ ExecutionEngineV2Executor = (*CustomExecutionEngineV2Executor)(nil)
+)

--- a/pkg/graphql/execution_engine_v2_custom.go
+++ b/pkg/graphql/execution_engine_v2_custom.go
@@ -46,10 +46,7 @@ type CustomExecutionEngineV2Stages struct {
 }
 
 func (c *CustomExecutionEngineV2Stages) AllRequiredStagesProvided() bool {
-	if c.RequiredStages.ResolverStage == nil {
-		return false
-	}
-	return true
+	return c.RequiredStages.ResolverStage != nil
 }
 
 type CustomExecutionEngineV2RequiredStages struct {

--- a/pkg/graphql/execution_engine_v2_custom_test.go
+++ b/pkg/graphql/execution_engine_v2_custom_test.go
@@ -168,7 +168,7 @@ func (t testCustomExecutionV2ValidationStage) ValidateForSchema(operation *Reque
 	return nil
 }
 
-func (t testCustomExecutionV2ResolverStage) Setup(ctx context.Context, operation *Request, options ...ExecutionOptionsV2) {
+func (t testCustomExecutionV2ResolverStage) Setup(ctx context.Context, postProcessor *postprocess.Processor, resolveContext *resolve.Context, operation *Request, options ...ExecutionOptionsV2) {
 }
 
 func (t testCustomExecutionV2ResolverStage) Plan(postProcessor *postprocess.Processor, operation *Request, report *operationreport.Report) (plan.Plan, error) {
@@ -182,7 +182,7 @@ func (t testCustomExecutionV2ResolverStage) Plan(postProcessor *postprocess.Proc
 	return &plan.SynchronousResponsePlan{}, nil
 }
 
-func (t testCustomExecutionV2ResolverStage) Resolve(resolveContext *resolve.Context, plan plan.Plan, writer resolve.FlushWriter) error {
+func (t testCustomExecutionV2ResolverStage) Resolve(resolveContext *resolve.Context, planResult plan.Plan, writer resolve.FlushWriter) error {
 	if t.failResolve {
 		return errFailedResolve
 	}

--- a/pkg/graphql/execution_engine_v2_custom_test.go
+++ b/pkg/graphql/execution_engine_v2_custom_test.go
@@ -1,0 +1,192 @@
+package graphql
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/TykTechnologies/graphql-go-tools/pkg/engine/plan"
+	"github.com/TykTechnologies/graphql-go-tools/pkg/engine/resolve"
+	"github.com/TykTechnologies/graphql-go-tools/pkg/operationreport"
+	"github.com/TykTechnologies/graphql-go-tools/pkg/postprocess"
+)
+
+var (
+	errFailedNormalizationStage = errors.New("normalization stage failed")
+	errFailedValidationStage    = errors.New("validation stage failed")
+	errFailedPlanning           = errors.New("planning failed")
+	errFailedResolve            = errors.New("resolve failed")
+)
+
+var (
+	reportPlanError = operationreport.ExternalError{
+		Message:   "planner report error",
+		Path:      nil,
+		Locations: nil,
+	}
+)
+
+func TestCustomExecutionEngineV2Stages_AllRequiredStagesProvided(t *testing.T) {
+	t.Run("should return false when requirements are not met", func(t *testing.T) {
+		stages := CustomExecutionEngineV2Stages{}
+		assert.False(t, stages.AllRequiredStagesProvided())
+	})
+
+	t.Run("should return true when requirements are met", func(t *testing.T) {
+		stages := CustomExecutionEngineV2Stages{
+			RequiredStages: CustomExecutionEngineV2RequiredStages{
+				ResolverStage: testCustomExecutionV2ResolverStage{},
+			},
+		}
+		assert.True(t, stages.AllRequiredStagesProvided())
+	})
+}
+
+func TestExecuteCustomExecutionEngineV2ByStages(t *testing.T) {
+	run := func(stages CustomExecutionEngineV2Stages, expectedErr error) func(t *testing.T) {
+		return func(t *testing.T) {
+			writer := NewEngineResultWriter()
+			executor, err := NewCustomExecutionEngineV2ExecutorByStages(stages)
+			require.NoError(t, err)
+			actualErr := executor.Execute(context.Background(), &Request{}, &writer, nil)
+			assert.Equal(t, expectedErr, actualErr)
+		}
+	}
+
+	t.Run("should return error when requirements are not met", run(
+		CustomExecutionEngineV2Stages{},
+		ErrRequiredStagesMissing,
+	))
+
+	t.Run("should return error when normalization stage fails", run(
+		CustomExecutionEngineV2Stages{
+			RequiredStages: CustomExecutionEngineV2RequiredStages{
+				ResolverStage: testCustomExecutionV2ResolverStage{},
+			},
+			OptionalStages: &CustomExecutionEngineV2OptionalStages{
+				NormalizerStage: testCustomExecutionV2NormalizationStage{
+					failNormalization: true,
+				},
+			},
+		},
+		errFailedNormalizationStage,
+	))
+
+	t.Run("should return error when validation stage fails", run(
+		CustomExecutionEngineV2Stages{
+			RequiredStages: CustomExecutionEngineV2RequiredStages{
+				ResolverStage: testCustomExecutionV2ResolverStage{},
+			},
+			OptionalStages: &CustomExecutionEngineV2OptionalStages{
+				ValidatorStage: testCustomExecutionV2ValidationStage{
+					failValidation: true,
+				},
+			},
+		},
+		errFailedValidationStage,
+	))
+
+	t.Run("should return error when planning fails", run(
+		CustomExecutionEngineV2Stages{
+			RequiredStages: CustomExecutionEngineV2RequiredStages{
+				ResolverStage: testCustomExecutionV2ResolverStage{
+					failPlan: true,
+				},
+			},
+		},
+		errFailedPlanning,
+	))
+
+	t.Run("should return error when planner report has errors", run(
+		CustomExecutionEngineV2Stages{
+			RequiredStages: CustomExecutionEngineV2RequiredStages{
+				ResolverStage: testCustomExecutionV2ResolverStage{
+					planReportHasErrors: true,
+				},
+			},
+		},
+		&operationreport.Report{
+			ExternalErrors: []operationreport.ExternalError{
+				reportPlanError,
+			},
+		},
+	))
+
+	t.Run("should return error when resolve fails", run(
+		CustomExecutionEngineV2Stages{
+			RequiredStages: CustomExecutionEngineV2RequiredStages{
+				ResolverStage: testCustomExecutionV2ResolverStage{
+					failResolve: true,
+				},
+			},
+		},
+		errFailedResolve,
+	))
+
+	t.Run("should not return an error when nothing fails", run(
+		CustomExecutionEngineV2Stages{
+			RequiredStages: CustomExecutionEngineV2RequiredStages{
+				ResolverStage: testCustomExecutionV2ResolverStage{},
+			},
+			OptionalStages: &CustomExecutionEngineV2OptionalStages{
+				NormalizerStage: testCustomExecutionV2NormalizationStage{},
+				ValidatorStage:  testCustomExecutionV2ValidationStage{},
+			},
+		},
+		nil,
+	))
+}
+
+type testCustomExecutionV2NormalizationStage struct {
+	failNormalization bool
+}
+
+func (t testCustomExecutionV2NormalizationStage) Normalize(operation *Request) error {
+	if t.failNormalization {
+		return errFailedNormalizationStage
+	}
+	return nil
+}
+
+type testCustomExecutionV2ResolverStage struct {
+	failPlan            bool
+	planReportHasErrors bool
+	failResolve         bool
+}
+
+type testCustomExecutionV2ValidationStage struct {
+	failValidation bool
+}
+
+func (t testCustomExecutionV2ValidationStage) ValidateForSchema(operation *Request) error {
+	if t.failValidation {
+		return errFailedValidationStage
+	}
+	return nil
+}
+
+func (t testCustomExecutionV2ResolverStage) Setup(ctx context.Context, operation *Request, options ...ExecutionOptionsV2) {
+}
+
+func (t testCustomExecutionV2ResolverStage) Plan(postProcessor *postprocess.Processor, operation *Request, report *operationreport.Report) (plan.Plan, error) {
+	if t.failPlan {
+		return nil, errFailedPlanning
+	}
+	if t.planReportHasErrors {
+		report.AddExternalError(reportPlanError)
+		return nil, report
+	}
+	return &plan.SynchronousResponsePlan{}, nil
+}
+
+func (t testCustomExecutionV2ResolverStage) Resolve(resolveContext *resolve.Context, plan plan.Plan, writer resolve.FlushWriter) error {
+	if t.failResolve {
+		return errFailedResolve
+	}
+	return nil
+}
+
+func (t testCustomExecutionV2ResolverStage) Teardown() {}

--- a/pkg/graphql/execution_engine_v2_custom_test.go
+++ b/pkg/graphql/execution_engine_v2_custom_test.go
@@ -45,7 +45,7 @@ func TestCustomExecutionEngineV2Stages_AllRequiredStagesProvided(t *testing.T) {
 	})
 }
 
-func TestExecuteCustomExecutionEngineV2ByStages(t *testing.T) {
+func TestCustomExecutionEngineV2Executor_Execute(t *testing.T) {
 	run := func(stages CustomExecutionEngineV2Stages, expectedErr error) func(t *testing.T) {
 		return func(t *testing.T) {
 			writer := NewEngineResultWriter()

--- a/pkg/graphql/execution_engine_v2_test.go
+++ b/pkg/graphql/execution_engine_v2_test.go
@@ -6,6 +6,7 @@ import (
 	"compress/gzip"
 	"context"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"

--- a/pkg/graphql/execution_engine_v2_test.go
+++ b/pkg/graphql/execution_engine_v2_test.go
@@ -110,7 +110,7 @@ func TestWithAdditionalHttpHeaders(t *testing.T) {
 		}
 
 		optionsFn := WithAdditionalHttpHeaders(reqHeader)
-		optionsFn(internalExecutionCtx)
+		optionsFn(internalExecutionCtx.postProcessor, internalExecutionCtx.resolveContext)
 
 		assert.Equal(t, reqHeader, internalExecutionCtx.resolveContext.Request.Header)
 	})
@@ -133,7 +133,7 @@ func TestWithAdditionalHttpHeaders(t *testing.T) {
 		}
 
 		optionsFn := WithAdditionalHttpHeaders(reqHeader, excludableRuntimeHeaders...)
-		optionsFn(internalExecutionCtx)
+		optionsFn(internalExecutionCtx.postProcessor, internalExecutionCtx.resolveContext)
 
 		expectedHeaders := http.Header{
 			http.CanonicalHeaderKey("X-Other-Key"): []string{"x-other-value"},
@@ -2041,7 +2041,7 @@ func TestExecutionEngineV2_GetCachedPlan(t *testing.T) {
 		}
 
 		report := operationreport.Report{}
-		cachedPlan := engine.getCachedPlan(firstInternalExecCtx, &gqlRequest.document, &schema.document, gqlRequest.OperationName, &report)
+		cachedPlan := engine.getCachedPlan(firstInternalExecCtx.postProcessor, &gqlRequest.document, &schema.document, gqlRequest.OperationName, &report)
 		_, oldestCachedPlan, _ := engine.executionPlanCache.GetOldest()
 		assert.False(t, report.HasErrors())
 		assert.Equal(t, 1, engine.executionPlanCache.Len())
@@ -2052,7 +2052,7 @@ func TestExecutionEngineV2_GetCachedPlan(t *testing.T) {
 			http.CanonicalHeaderKey("Authorization"): []string{"123abc"},
 		}
 
-		cachedPlan = engine.getCachedPlan(secondInternalExecCtx, &gqlRequest.document, &schema.document, gqlRequest.OperationName, &report)
+		cachedPlan = engine.getCachedPlan(secondInternalExecCtx.postProcessor, &gqlRequest.document, &schema.document, gqlRequest.OperationName, &report)
 		_, oldestCachedPlan, _ = engine.executionPlanCache.GetOldest()
 		assert.False(t, report.HasErrors())
 		assert.Equal(t, 1, engine.executionPlanCache.Len())
@@ -2069,7 +2069,7 @@ func TestExecutionEngineV2_GetCachedPlan(t *testing.T) {
 		}
 
 		report := operationreport.Report{}
-		cachedPlan := engine.getCachedPlan(firstInternalExecCtx, &gqlRequest.document, &schema.document, gqlRequest.OperationName, &report)
+		cachedPlan := engine.getCachedPlan(firstInternalExecCtx.postProcessor, &gqlRequest.document, &schema.document, gqlRequest.OperationName, &report)
 		_, oldestCachedPlan, _ := engine.executionPlanCache.GetOldest()
 		assert.False(t, report.HasErrors())
 		assert.Equal(t, 1, engine.executionPlanCache.Len())
@@ -2080,7 +2080,7 @@ func TestExecutionEngineV2_GetCachedPlan(t *testing.T) {
 			http.CanonicalHeaderKey("Authorization"): []string{"xyz098"},
 		}
 
-		cachedPlan = engine.getCachedPlan(secondInternalExecCtx, &differentGqlRequest.document, &schema.document, differentGqlRequest.OperationName, &report)
+		cachedPlan = engine.getCachedPlan(secondInternalExecCtx.postProcessor, &differentGqlRequest.document, &schema.document, differentGqlRequest.OperationName, &report)
 		_, oldestCachedPlan, _ = engine.executionPlanCache.GetOldest()
 		assert.False(t, report.HasErrors())
 		assert.Equal(t, 2, engine.executionPlanCache.Len())


### PR DESCRIPTION
Changes in this PR are based on @buraksezer 's awesome research in this commit: https://github.com/TykTechnologies/graphql-go-tools/commit/23f7686189d155642aaf2678e0e3a28db37b57c5

This PR introduces interfaces for a `CustomExecutionEngineV2` including execution stages.
By introducing those changes it will be possible to provide its own `ExecutionEngineV2` or decorate the already implemented `ExecutionEngineV2`.

Changes:
 - added a benchmark test for `ExecutionEngineV2.Execute` to track performance impacts with this change (none so far)
 - introduced the following interfaces:
   - `CustomExecutionEngineV2NormalizerStage` (optional)
   - `CustomExecutionEngineV2ValidatorStage` (optional)
   - `CustomExecutionEngineV2ResolverStage` (required)
   - `ExecutionEngineV2Executor`
 - added a default implementation for `ExecutionEngineV2Executor` called `CustomExecutionEngineV2Executor`
 - `ExecutionEngineV2` now implements all interfaces mentioned before and decorates the `CustomExecutionEngineV2Executor` (so it is basically a `CustomExecutionEngineV2`)
 - moved the `internalExecutionContext` to `CustomExecutionEngineV2` as it is an implementation detail
 - `ExecutionOptionsV2` are now decoupled from `internalExecutionContext` so that implementing them outside of the `graphql` package is now possible