### PR TITLE
add MarshalRequest functions and omit empties

### DIFF
--- a/pkg/graphql/request.go
+++ b/pkg/graphql/request.go
@@ -34,8 +34,8 @@ var (
 )
 
 type Request struct {
-	OperationName string          `json:"operationName"`
-	Variables     json.RawMessage `json:"variables"`
+	OperationName string          `json:"operationName,omitempty"`
+	Variables     json.RawMessage `json:"variables,omitempty"`
 	Query         string          `json:"query"`
 
 	document     ast.Document
@@ -62,6 +62,18 @@ func UnmarshalRequest(reader io.Reader, request *Request) error {
 func UnmarshalHttpRequest(r *http.Request, request *Request) error {
 	request.request.Header = r.Header
 	return UnmarshalRequest(r.Body, request)
+}
+
+func MarshalRequest(graphqlRequest Request) ([]byte, error) {
+	return json.Marshal(graphqlRequest)
+}
+
+func MarshalRequestString(graphqlRequest Request) (string, error) {
+	result, err := MarshalRequest(graphqlRequest)
+	if err != nil {
+		return "", err
+	}
+	return string(result), nil
 }
 
 func (r *Request) SetHeader(header http.Header) {

--- a/pkg/graphql/request_test.go
+++ b/pkg/graphql/request_test.go
@@ -35,6 +35,31 @@ func TestUnmarshalRequest(t *testing.T) {
 	})
 }
 
+func TestMarshalRequestString(t *testing.T) {
+	t.Run("should omit empties", func(t *testing.T) {
+		gqlRequest := Request{
+			OperationName: "",
+			Query:         "query { hello }",
+			Variables:     nil,
+		}
+		result, err := MarshalRequestString(gqlRequest)
+		expected := `{"query":"query { hello }"}`
+		assert.NoError(t, err)
+		assert.Equal(t, expected, result)
+	})
+	t.Run("should marshal all fields", func(t *testing.T) {
+		gqlRequest := Request{
+			OperationName: "MyQuery",
+			Query:         "query MyQuery { hello }",
+			Variables:     []byte(`{"variable":"value"}`),
+		}
+		result, err := MarshalRequestString(gqlRequest)
+		expected := `{"operationName":"MyQuery","variables":{"variable":"value"},"query":"query MyQuery { hello }"}`
+		assert.NoError(t, err)
+		assert.Equal(t, expected, result)
+	})
+}
+
 func TestRequest_Print(t *testing.T) {
 	query := "query Hello { hello }"
 	request := Request{


### PR DESCRIPTION
This PR adds a `MarshalRequest` and a `MarshalRequestString` function to the `graphql` package.
It also adds `omitempty` to `OperationName` and `Variables` fields.