### PR TITLE
[TT-8528] Improper handling of non-nullable fields in OpenAPI

### DIFF
--- a/pkg/openapi/fixtures/v3.0.0/EmployeesApi.graphql
+++ b/pkg/openapi/fixtures/v3.0.0/EmployeesApi.graphql
@@ -13,7 +13,7 @@ type Query {
     Get an employee
     Uses the getEmployee Db2 z/OS asset
     """
-    employeesIdGet(id: String): EmployeeBody
+    employeesIdGet(id: String!): EmployeeBody
 }
 
 type Mutation {
@@ -21,12 +21,12 @@ type Mutation {
     Delete an employee
     Uses the deleteEmployee Db2 z/OS asset
     """
-    employeesIdDelete(id: String): EmployeeNumber
+    employeesIdDelete(id: String!): EmployeeNumber
     """
     Update an employee
     Uses the updateEmployee Db2 z/OS asset
     """
-    employeesIdPut(employeeBodyInput: EmployeeBodyInput): EmployeeBody
+    employeesIdPut(employeeBodyInput: EmployeeBodyInput, id: String!): EmployeeBody
     """
     Add an employee
     Uses the addEmployee Db2 z/OS asset

--- a/pkg/openapi/fixtures/v3.0.0/EmployeesApiBasic.graphql
+++ b/pkg/openapi/fixtures/v3.0.0/EmployeesApiBasic.graphql
@@ -10,7 +10,7 @@ type Query {
 
 type Mutation {
     "Uses the updateEmployee Db2 z/OS asset"
-    putEmployeesId(employeeBodyInput: EmployeeBodyInput): EmployeeBody
+    putEmployeesId(employeeBodyInput: EmployeeBodyInput, id: String!): EmployeeBody
 }
 
 type EmployeeBody {

--- a/pkg/openapi/fixtures/v3.0.0/example_oas3.graphql
+++ b/pkg/openapi/fixtures/v3.0.0/example_oas3.graphql
@@ -4,11 +4,11 @@ schema {
 
 type Query {
     "Return an author."
-    author(authorId: String): Author
+    author(authorId: String!): Author
     "Return a book."
-    book(bookId: String): Book
+    book(bookId: String!): Book
     "Return the author's next work."
-    nextWork(authorId: String): NextWork
+    nextWork(authorId: String!): NextWork
 }
 
 "An author"

--- a/pkg/openapi/fixtures/v3.0.0/example_oas7.graphql
+++ b/pkg/openapi/fixtures/v3.0.0/example_oas7.graphql
@@ -5,7 +5,7 @@ schema {
 
 type Query {
     "Find a device by name."
-    findDeviceByName(deviceName: String): Device
+    findDeviceByName(deviceName: String!): Device
     "Return a device collection."
     findDevices: [Device]
     "Return a user."
@@ -14,23 +14,23 @@ type Query {
 
 type Mutation {
     "Create and return a device."
-    createDevice(deviceInput: DeviceInput): Device
+    createDevice(deviceInput: DeviceInput!): Device
     "Replace a device by name."
-    replaceDeviceByName(deviceInput: DeviceInput): Device
+    replaceDeviceByName(deviceInput: DeviceInput!, deviceName: String!): Device
 }
 
 type Device {
     "The device name in the network"
-    name: String
+    name: String!
     status: Boolean
     "The device owner Name"
-    userName: String
+    userName: String!
 }
 
 input DeviceInput {
-    name: String
+    name: String!
     status: Boolean
-    userName: String
+    userName: String!
 }
 
 "A user represents a natural person"

--- a/pkg/openapi/fixtures/v3.0.0/petstore-expanded.graphql
+++ b/pkg/openapi/fixtures/v3.0.0/petstore-expanded.graphql
@@ -5,7 +5,7 @@ schema {
 
 type Query {
     "Returns a user based on a single ID, if the user does not have access to the pet"
-    findPetById(id: Int): Pet
+    findPetById(id: Int!): Pet
     """
     Returns all pets from the system that the user has access to
     Nam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia.
@@ -17,18 +17,18 @@ type Query {
 
 type Mutation {
     "Creates a new pet in the store. Duplicates are allowed"
-    addPet(newPetInput: NewPetInput): Pet
+    addPet(newPetInput: NewPetInput!): Pet
     "deletes a single pet based on the ID supplied"
-    deletePet(id: Int): String
+    deletePet(id: Int!): String
 }
 
 input NewPetInput {
-    name: String
+    name: String!
     tag: String
 }
 
 type Pet {
-    id: Int
-    name: String
+    id: Int!
+    name: String!
     tag: String
 }

--- a/pkg/openapi/fixtures/v3.0.0/petstore.graphql
+++ b/pkg/openapi/fixtures/v3.0.0/petstore.graphql
@@ -7,7 +7,7 @@ type Query {
     "List all pets"
     listPets(limit: Int): [Pet]
     "Info for a specific pet"
-    showPetById(petId: String): Pet
+    showPetById(petId: String!): Pet
 }
 
 type Mutation {
@@ -16,7 +16,7 @@ type Mutation {
 }
 
 type Pet {
-    id: Int
-    name: String
+    id: Int!
+    name: String!
     tag: String
 }


### PR DESCRIPTION
PR for [TT-8528](https://tyktech.atlassian.net/browse/TT-8528)

Now, we can handle non-nullable fields properly. There was also a minor bug in a function that generates mutation type. It was swallowing the parameters if a request body defined for the same operation id. This bug has also been fixed.

[TT-8528]: https://tyktech.atlassian.net/browse/TT-8528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ