### PR TITLE
[TT-9882]: close graphql-ws protocol coonnections on error timeout

### DIFF
--- a/pkg/subscription/engine.go
+++ b/pkg/subscription/engine.go
@@ -224,7 +224,10 @@ func (e *ExecutorEngine) executeWithBackOff(executor Executor, buf *graphql.Engi
 		}
 		time.Sleep(nextRetry)
 	}
-	return &ErrorTimeoutExecutingSubscription{err}
+	if err != nil {
+		return &ErrorTimeoutExecutingSubscription{err}
+	}
+	return nil
 }
 
 func (e *ExecutorEngine) handleNonSubscriptionOperation(ctx context.Context, id string, executor Executor, eventHandler EventHandler) {

--- a/pkg/subscription/engine.go
+++ b/pkg/subscription/engine.go
@@ -35,6 +35,18 @@ type Engine interface {
 	TerminateAllSubscriptions(eventHandler EventHandler) error
 }
 
+type ErrorTimeoutExecutingSubscription struct {
+	err error
+}
+
+func (e *ErrorTimeoutExecutingSubscription) Error() string {
+	return fmt.Sprintf("error executing subsctiption: %v", e.err)
+}
+
+func (e *ErrorTimeoutExecutingSubscription) Unwrap() error {
+	return e.err
+}
+
 // ExecutorEngine is an implementation of Engine and works with subscription.Executor.
 type ExecutorEngine struct {
 	logger abstractlogger.Logger
@@ -212,7 +224,7 @@ func (e *ExecutorEngine) executeWithBackOff(executor Executor, buf *graphql.Engi
 		}
 		time.Sleep(nextRetry)
 	}
-	return err
+	return &ErrorTimeoutExecutingSubscription{err}
 }
 
 func (e *ExecutorEngine) handleNonSubscriptionOperation(ctx context.Context, id string, executor Executor, eventHandler EventHandler) {

--- a/pkg/subscription/engine_test.go
+++ b/pkg/subscription/engine_test.go
@@ -49,7 +49,7 @@ func TestExecutorEngine_StartExecutionBackoff(t *testing.T) {
 		executorPoolMock := NewMockExecutorPool(ctrl)
 
 		eventHandlerMock := NewMockEventHandler(ctrl)
-		eventHandlerMock.EXPECT().Emit(EventTypeOnError, "testID", gomock.AssignableToTypeOf([]byte{}), sampleErr).AnyTimes()
+		eventHandlerMock.EXPECT().Emit(EventTypeOnError, "testID", gomock.AssignableToTypeOf([]byte{}), gomock.AssignableToTypeOf(&ErrorTimeoutExecutingSubscription{})).AnyTimes()
 
 		engine := ExecutorEngine{
 			logger:           abstractlogger.Noop{},
@@ -89,7 +89,7 @@ func TestExecutorEngine_StartExecutionBackoff(t *testing.T) {
 		executorPoolMock.EXPECT().Put(gomock.Eq(executorMock))
 		var gottenError bool
 		eventHandlerMock := NewMockEventHandler(ctrl)
-		eventHandlerMock.EXPECT().Emit(EventTypeOnError, "testID", gomock.AssignableToTypeOf([]byte{}), gomock.AssignableToTypeOf(sampleErr)).Times(1).Do(func(arg0, arg1, arg2, arg3 interface{}) {
+		eventHandlerMock.EXPECT().Emit(EventTypeOnError, "testID", gomock.AssignableToTypeOf([]byte{}), gomock.AssignableToTypeOf(&ErrorTimeoutExecutingSubscription{})).Times(1).Do(func(arg0, arg1, arg2, arg3 interface{}) {
 			gottenError = true
 		})
 

--- a/pkg/subscription/websocket/protocol_graphql_ws.go
+++ b/pkg/subscription/websocket/protocol_graphql_ws.go
@@ -17,12 +17,6 @@ import (
 // GraphQLWSMessageType is a type that defines graphql-ws message type names.
 type GraphQLWSMessageType string
 
-// disconnectClientI is an interface that the GraphqlWs protocol implementation uses to kill connections after continously
-// failing to execute
-type disconnectClientI interface {
-	DisconnectWithReason(reason interface{}) error
-}
-
 const (
 	GraphQLWSMessageTypeConnectionInit      GraphQLWSMessageType = "connection_init"
 	GraphQLWSMessageTypeConnectionAck       GraphQLWSMessageType = "connection_ack"
@@ -167,9 +161,8 @@ func (g *GraphQLWSMessageWriter) write(message *GraphQLWSMessage) error {
 
 // GraphQLWSWriteEventHandler can be used to handle subscription events and forward them to a GraphQLWSMessageWriter.
 type GraphQLWSWriteEventHandler struct {
-	logger     abstractlogger.Logger
-	Writer     GraphQLWSMessageWriter
-	disconnect disconnectClientI
+	logger abstractlogger.Logger
+	Writer GraphQLWSMessageWriter
 }
 
 // Emit is an implementation of subscription.EventHandler. It forwards events to the HandleWriteEvent.
@@ -209,7 +202,7 @@ func (g *GraphQLWSWriteEventHandler) HandleWriteEvent(messageType GraphQLWSMessa
 		err = g.Writer.WriteError(id, graphql.RequestErrorsFromError(providedErr))
 		var timeoutErr *subscription.ErrorTimeoutExecutingSubscription
 		if errors.As(providedErr, &timeoutErr) {
-			err = g.disconnect.DisconnectWithReason(NewCloseReason(1011, timeoutErr.Error()))
+			err = g.Writer.Client.DisconnectWithReason(NewCloseReason(1011, timeoutErr.Error()))
 		}
 	case GraphQLWSMessageTypeConnectionError:
 		err = g.Writer.WriteConnectionError(providedErr.Error())
@@ -273,7 +266,6 @@ func NewProtocolGraphQLWSHandlerWithOptions(client subscription.TransportClient,
 				Client: client,
 				mu:     &sync.Mutex{},
 			},
-			disconnect: client,
 		},
 		initFunc: opts.WebSocketInitFunc,
 	}

--- a/pkg/subscription/websocket/protocol_graphql_ws_test.go
+++ b/pkg/subscription/websocket/protocol_graphql_ws_test.go
@@ -279,6 +279,12 @@ func TestGraphQLWSWriteEventHandler_HandleWriteEvent(t *testing.T) {
 		expectedMessage := []byte(`{"type":"connection_ack"}`)
 		assert.Equal(t, expectedMessage, testClient.readMessageToClient())
 	})
+	t.Run("should write timout error and disconnect", func(t *testing.T) {
+		testClient := NewTestClient(true)
+		writeEventHandler := NewTestGraphQLWSWriteEventHandler(testClient)
+		writeEventHandler.HandleWriteEvent(GraphQLWSMessageTypeError, "", nil, &subscription.ErrorTimeoutExecutingSubscription{})
+		assert.Equal(t, false, testClient.isConnected)
+	})
 }
 
 func TestProtocolGraphQLWSHandler_Handle(t *testing.T) {


### PR DESCRIPTION
This PR closes the connection in the graphql-ws protocol implementation if the backoff threshold for the subscription execution has been hit