### PR TITLE
fix full type details not being able to be updated

### DIFF
--- a/pkg/openapi/fixtures/v3.0.0/example_oas7.graphql
+++ b/pkg/openapi/fixtures/v3.0.0/example_oas7.graphql
@@ -19,6 +19,7 @@ type Mutation {
     replaceDeviceByName(deviceInput: DeviceInput!, deviceName: String!): Device
 }
 
+"A device is an object connected to the network"
 type Device {
     "The device name in the network"
     name: String!


### PR DESCRIPTION
This PR fixes an issue where it could happen that the OAS converter picks up a full type without all the details before reaching the full definition. This caused the converter to not pick up descriptions.

To fix this I introduced an details cache that only tracks if a detail is already stored or not.