### PR TITLE
[TT-10483] Handle arrays of objects in OpenAPI documents 

### DIFF
--- a/pkg/openapi/fixtures/v3.0.0/carts-api-oas.graphql
+++ b/pkg/openapi/fixtures/v3.0.0/carts-api-oas.graphql
@@ -1,0 +1,19 @@
+schema {
+    query: Query
+}
+
+type Query {
+    "Get single cart by its id"
+    getCartById(id: Int!): Cart
+    "Returns list of all carts"
+    getCarts: [Cart]
+}
+
+type Cart {
+    id: Int
+    products: [ProductsListItem]
+}
+
+type ProductsListItem {
+    productId: Int
+}

--- a/pkg/openapi/fixtures/v3.0.0/carts-api-oas.yaml
+++ b/pkg/openapi/fixtures/v3.0.0/carts-api-oas.yaml
@@ -1,0 +1,53 @@
+openapi: "3.0.0"
+info:
+  title: Carts API
+  version: 1.0.0
+servers:
+  - url: http://localhost:3004/
+paths:
+  /carts:
+    get:
+      description: Returns list of all carts
+      operationId: getCarts
+      responses:
+        '200':
+          description: carts response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Cart'
+  /carts/{id}:
+    get:
+      description: Get single cart by its id
+      operationId: getCartById
+      parameters:
+        - name: id
+          in: path
+          description: ID of user to fetch
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: cart response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Cart'
+components:
+  schemas:
+    Cart:
+      type: object
+      properties:
+        id:
+          type: integer
+        products:
+          type: array
+          items:
+            type: object
+            properties:
+              product_id:
+                type: integer

--- a/pkg/openapi/openapi_test.go
+++ b/pkg/openapi/openapi_test.go
@@ -24,7 +24,14 @@ func testFixtureFile(t *testing.T, version, name string) {
 	err = astprinter.PrintIndent(doc, nil, []byte("  "), w)
 	require.NoError(t, err)
 
-	name = strings.Trim(strings.Trim(name, ".yaml"), ".json")
+	if strings.HasSuffix(name, ".yaml") {
+		name = strings.Trim(name, ".yaml")
+	} else if strings.HasSuffix(name, ".json") {
+		name = strings.Trim(name, ".json")
+	} else {
+		require.Fail(t, "unrecognized file: %s", name)
+	}
+
 	graphqlDoc, err := os.ReadFile(fmt.Sprintf("./fixtures/%s/%s.graphql", version, name))
 	require.NoError(t, err)
 	require.Equal(t, string(graphqlDoc), w.String())
@@ -59,4 +66,7 @@ func TestOpenAPI_v3_0_0(t *testing.T) {
 		testFixtureFile(t, "v3.0.0", "example_oas3.json")
 	})
 
+	t.Run("carts-api-oas.yaml", func(t *testing.T) {
+		testFixtureFile(t, "v3.0.0", "carts-api-oas.yaml")
+	})
 }


### PR DESCRIPTION
PR for [TT-10483](https://tyktech.atlassian.net/browse/TT-10483)

OpenAPI-to-GraphQL converter can now create a GraphQL type from an unnamed object and create an array of that type.

```yaml
components:
  schemas:
    Cart:
      type: object
      properties:
        id:
          type: integer
        products:
          type: array
          items:
            type: object
            properties:
              product_id:
                type: integer
```

Previously, we could not produce the correct GQL types  for `Cart`. With this PR, we can produce the following types:

```graphql

type Cart {
    id: Int
    products: [ProductsListItem]
}

type ProductsListItem {
    productId: Int
}
```

`ProductsListItem` type name has been produced by our converter tool. The naming style has been borrowed from [IBM/openapi-to-graphql](https://github.com/IBM/openapi-to-graphql) tool. 


[TT-10483]: https://tyktech.atlassian.net/browse/TT-10483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ