### PR TITLE
[TT-10604] Handling arrays of objects in endpoint responses

### DIFF
--- a/pkg/openapi/fixtures/v3.0.0/carts-api-oas_tt_10604.graphql
+++ b/pkg/openapi/fixtures/v3.0.0/carts-api-oas_tt_10604.graphql
@@ -1,5 +1,6 @@
 schema {
     query: Query
+    mutation: Mutation
 }
 
 type Query {
@@ -9,7 +10,17 @@ type Query {
     getCarts: [Cart]
 }
 
+type Mutation {
+    "Creates new Cart"
+    createCart(cartInput: CartInput!): Cart
+}
+
 type Cart {
+    id: Int
+    products: [ProductsListItem]
+}
+
+input CartInput {
     id: Int
     products: [ProductsListItem]
 }

--- a/pkg/openapi/fixtures/v3.0.0/carts-api-oas_tt_10604.graphql
+++ b/pkg/openapi/fixtures/v3.0.0/carts-api-oas_tt_10604.graphql
@@ -22,9 +22,13 @@ type Cart {
 
 input CartInput {
     id: Int
-    products: [ProductsListItem]
+    products: [ProductsListItemInput]
 }
 
 type ProductsListItem {
+    product_id: Int
+}
+
+type ProductsListItemInput {
     product_id: Int
 }

--- a/pkg/openapi/fixtures/v3.0.0/carts-api-oas_tt_10604.yaml
+++ b/pkg/openapi/fixtures/v3.0.0/carts-api-oas_tt_10604.yaml
@@ -1,0 +1,71 @@
+openapi: "3.0.0"
+info:
+  title: Carts API
+  version: 1.0.0
+servers:
+  - url: http://localhost:3004/
+paths:
+  /carts:
+    get:
+      description: Returns list of all carts
+      operationId: getCarts
+      responses:
+        '200':
+          description: carts response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Cart'
+    post:
+      description: Creates new Cart
+      operationId: createCart
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Cart'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Cart'
+  /carts/{id}:
+    get:
+      description: Get single cart by its id
+      operationId: getCartById
+      parameters:
+        - name: id
+          in: path
+          description: ID of user to fetch
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: cart response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Cart'
+components:
+  schemas:
+    Cart:
+      type: object
+      properties:
+        id:
+          type: integer
+        products:
+          type: array
+          items:
+            type: object
+            properties:
+              product_id:
+                type: integer

--- a/pkg/openapi/openapi.go
+++ b/pkg/openapi/openapi.go
@@ -119,6 +119,8 @@ func getParamTypeRef(kind string) (introspection.TypeRef, error) {
 	return introspection.TypeRef{}, fmt.Errorf("unknown type: %s", kind)
 }
 
+var errNotPrimitiveType = errors.New("not a primitive type")
+
 func getPrimitiveGraphQLTypeName(openapiType string) (string, error) {
 	switch openapiType {
 	case "string":
@@ -130,7 +132,7 @@ func getPrimitiveGraphQLTypeName(openapiType string) (string, error) {
 	case "boolean":
 		return string(literal.BOOLEAN), nil
 	default:
-		return "", fmt.Errorf("unknown type: %s", openapiType)
+		return "", fmt.Errorf("%w: %s", errNotPrimitiveType, openapiType)
 	}
 }
 
@@ -160,44 +162,51 @@ func makeTypeNameFromPropertyName(name string, schemaRef *openapi3.SchemaRef) (s
 	return "", fmt.Errorf("error while making type name from property name: %s is a unsupported type", name)
 }
 
+func (c *converter) makeTypeRefFromSchemaRef(schemaRef *openapi3.SchemaRef, name string, required bool) (*introspection.TypeRef, error) {
+	name = strcase.ToLowerCamel(name)
+
+	graphQLTypeName, err := c.getGraphQLTypeName(schemaRef)
+	if errors.Is(err, errTypeNameExtractionImpossible) {
+		graphQLTypeName, err = makeTypeNameFromPropertyName(name, schemaRef)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	switch schemaRef.Value.Type {
+	case "object":
+		err = c.processObject(schemaRef)
+	case "array":
+		err = c.processArrayWithFullTypeName(graphQLTypeName, schemaRef)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	typeRef, err := getTypeRef(schemaRef.Value.Type)
+	if err != nil {
+		return nil, err
+	}
+	typeRef.Name = &graphQLTypeName
+	if required {
+		typeRef = convertToNonNull(&typeRef)
+	}
+
+	if schemaRef.Value.Type == "array" {
+		typeRef.OfType = &introspection.TypeRef{Kind: 3, Name: &graphQLTypeName}
+	}
+	return &typeRef, nil
+}
+
 func (c *converter) processSchemaProperties(fullType *introspection.FullType, schema openapi3.Schema) error {
 	for name, schemaRef := range schema.Properties {
-		name = strcase.ToLowerCamel(name)
-
-		graphQLTypeName, err := c.getGraphQLTypeName(schemaRef)
-		if errors.Is(err, errTypeNameExtractionImpossible) {
-			graphQLTypeName, err = makeTypeNameFromPropertyName(name, schemaRef)
-		}
+		typeRef, err := c.makeTypeRefFromSchemaRef(schemaRef, name, isNonNullable(name, schema.Required))
 		if err != nil {
 			return err
 		}
-
-		switch schemaRef.Value.Type {
-		case "object":
-			err = c.processObject(schemaRef)
-		case "array":
-			err = c.processArrayWithFullTypeName(graphQLTypeName, schemaRef)
-		}
-		if err != nil {
-			return err
-		}
-
-		typeRef, err := getTypeRef(schemaRef.Value.Type)
-		if err != nil {
-			return err
-		}
-		typeRef.Name = &graphQLTypeName
-		if isNonNullable(name, schema.Required) {
-			typeRef = convertToNonNull(&typeRef)
-		}
-
-		if schemaRef.Value.Type == "array" {
-			typeRef.OfType = &introspection.TypeRef{Kind: 3, Name: &graphQLTypeName}
-		}
-
 		field := introspection.Field{
 			Name:        name,
-			Type:        typeRef,
+			Type:        *typeRef,
 			Description: schemaRef.Value.Description,
 		}
 
@@ -210,22 +219,14 @@ func (c *converter) processSchemaProperties(fullType *introspection.FullType, sc
 }
 
 func (c *converter) processInputFields(ft *introspection.FullType, schemaRef *openapi3.SchemaRef) error {
-	for propertyName, property := range schemaRef.Value.Properties {
-		gqlType, err := getPrimitiveGraphQLTypeName(property.Value.Type)
+	for name, property := range schemaRef.Value.Properties {
+		typeRef, err := c.makeTypeRefFromSchemaRef(property, name, isNonNullable(name, schemaRef.Value.Required))
 		if err != nil {
 			return err
-		}
-		typeRef, err := getTypeRef(property.Value.Type)
-		if err != nil {
-			return err
-		}
-		typeRef.Name = &gqlType
-		if isNonNullable(propertyName, schemaRef.Value.Required) {
-			typeRef = convertToNonNull(&typeRef)
 		}
 		f := introspection.InputValue{
-			Name: propertyName,
-			Type: typeRef,
+			Name: name,
+			Type: *typeRef,
 		}
 		ft.InputFields = append(ft.InputFields, f)
 		sort.Slice(ft.InputFields, func(i, j int) bool {

--- a/pkg/openapi/openapi_test.go
+++ b/pkg/openapi/openapi_test.go
@@ -73,4 +73,8 @@ func TestOpenAPI_v3_0_0(t *testing.T) {
 	t.Run("unnamed-object.yaml", func(t *testing.T) {
 		testFixtureFile(t, "v3.0.0", "unnamed-object.yaml")
 	})
+
+	t.Run("carts-api-oas_tt_10604.yaml", func(t *testing.T) {
+		testFixtureFile(t, "v3.0.0", "carts-api-oas_tt_10604.yaml")
+	})
 }


### PR DESCRIPTION
PR for [TT-10604](https://tyktech.atlassian.net/browse/TT-10604)

OAS converter can now process input types that define unnamed arrays.  It also creates new types to use as input instead of reusing the existing user-defined types. It's a best practice in the GQL ecosystem. For example, it creates `ProductsListItemInput` instead of reusing the existing `ProductsListItem` type. [IBM/openapi-to-graphql](https://github.com/IBM/openapi-to-graphql) follows the same practice.