### PR TITLE
[TT-10604] Handling arrays of objects in endpoint responses - engine v2

### DIFF
--- a/v2/pkg/openapi/fixtures/v3.0.0/carts-api-oas_tt_10604.graphql
+++ b/v2/pkg/openapi/fixtures/v3.0.0/carts-api-oas_tt_10604.graphql
@@ -1,5 +1,6 @@
 schema {
     query: Query
+    mutation: Mutation
 }
 
 type Query {
@@ -9,11 +10,25 @@ type Query {
     getCarts: [Cart]
 }
 
+type Mutation {
+    "Creates new Cart"
+    createCart(cartInput: CartInput!): Cart
+}
+
 type Cart {
     id: Int
     products: [ProductsListItem]
 }
 
+input CartInput {
+    id: Int
+    products: [ProductsListItemInput]
+}
+
 type ProductsListItem {
+    product_id: Int
+}
+
+type ProductsListItemInput {
     product_id: Int
 }

--- a/v2/pkg/openapi/fixtures/v3.0.0/carts-api-oas_tt_10604.yaml
+++ b/v2/pkg/openapi/fixtures/v3.0.0/carts-api-oas_tt_10604.yaml
@@ -1,0 +1,71 @@
+openapi: "3.0.0"
+info:
+  title: Carts API
+  version: 1.0.0
+servers:
+  - url: http://localhost:3004/
+paths:
+  /carts:
+    get:
+      description: Returns list of all carts
+      operationId: getCarts
+      responses:
+        '200':
+          description: carts response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Cart'
+    post:
+      description: Creates new Cart
+      operationId: createCart
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Cart'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Cart'
+  /carts/{id}:
+    get:
+      description: Get single cart by its id
+      operationId: getCartById
+      parameters:
+        - name: id
+          in: path
+          description: ID of user to fetch
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: cart response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Cart'
+components:
+  schemas:
+    Cart:
+      type: object
+      properties:
+        id:
+          type: integer
+        products:
+          type: array
+          items:
+            type: object
+            properties:
+              product_id:
+                type: integer

--- a/v2/pkg/openapi/openapi_test.go
+++ b/v2/pkg/openapi/openapi_test.go
@@ -73,4 +73,8 @@ func TestOpenAPI_v3_0_0(t *testing.T) {
 	t.Run("unnamed-object.yaml", func(t *testing.T) {
 		testFixtureFile(t, "v3.0.0", "unnamed-object.yaml")
 	})
+
+	t.Run("carts-api-oas_tt_10604.yaml", func(t *testing.T) {
+		testFixtureFile(t, "v3.0.0", "carts-api-oas_tt_10604.yaml")
+	})
 }


### PR DESCRIPTION
This PR copies the latest OAS converter changes to the `v2` folder. See https://github.com/TykTechnologies/graphql-go-tools/pull/404