### PR TITLE
[TT-10697] Add placeholder Schema and Query to OpenAPI and graphql fixtures

### DIFF
--- a/pkg/openapi/fixtures/v3.0.0/enum-component-mutation.graphql
+++ b/pkg/openapi/fixtures/v3.0.0/enum-component-mutation.graphql
@@ -1,5 +1,12 @@
 schema {
+    query: QueryPlaceholder
     mutation: Mutation
+}
+
+"Placeholder object"
+type QueryPlaceholder {
+    "Placeholder field"
+    message: String
 }
 
 type Mutation {

--- a/pkg/openapi/fixtures/v3.0.0/enums-mutation.graphql
+++ b/pkg/openapi/fixtures/v3.0.0/enums-mutation.graphql
@@ -1,5 +1,12 @@
 schema {
+    query: QueryPlaceholder
     mutation: Mutation
+}
+
+"Placeholder object"
+type QueryPlaceholder {
+    "Placeholder field"
+    message: String
 }
 
 type Mutation {

--- a/pkg/openapi/openapi.go
+++ b/pkg/openapi/openapi.go
@@ -48,6 +48,24 @@ func ImportParsedOpenAPIv3Document(document *openapi3.T, report *operationreport
 			Name: "Query",
 		}
 		data.Schema.Types = append(data.Schema.Types, *queryType)
+	} else {
+		data.Schema.QueryType = &introspection.TypeName{
+			Name: "QueryPlaceholder",
+		}
+		stringScalarType := "String"
+		placeholderObject := introspection.FullType{
+			Kind:        introspection.OBJECT,
+			Name:        "QueryPlaceholder",
+			Description: "Placeholder object",
+			Fields: []introspection.Field{
+				{
+					Name:        "message",
+					Description: "Placeholder field",
+					Type:        introspection.TypeRef{Kind: introspection.SCALAR, Name: &stringScalarType},
+				},
+			},
+		}
+		data.Schema.Types = append(data.Schema.Types, placeholderObject)
 	}
 
 	mutationType, err := c.importMutationType()

--- a/v2/pkg/openapi/fixtures/v3.0.0/enum-component-mutation.graphql
+++ b/v2/pkg/openapi/fixtures/v3.0.0/enum-component-mutation.graphql
@@ -1,5 +1,12 @@
 schema {
+    query: QueryPlaceholder
     mutation: Mutation
+}
+
+"Placeholder object"
+type QueryPlaceholder {
+    "Placeholder field"
+    message: String
 }
 
 type Mutation {

--- a/v2/pkg/openapi/fixtures/v3.0.0/enums-mutation.graphql
+++ b/v2/pkg/openapi/fixtures/v3.0.0/enums-mutation.graphql
@@ -1,5 +1,12 @@
 schema {
+    query: QueryPlaceholder
     mutation: Mutation
+}
+
+"Placeholder object"
+type QueryPlaceholder {
+    "Placeholder field"
+    message: String
 }
 
 type Mutation {

--- a/v2/pkg/openapi/openapi.go
+++ b/v2/pkg/openapi/openapi.go
@@ -48,6 +48,24 @@ func ImportParsedOpenAPIv3Document(document *openapi3.T, report *operationreport
 			Name: "Query",
 		}
 		data.Schema.Types = append(data.Schema.Types, *queryType)
+	} else {
+		data.Schema.QueryType = &introspection.TypeName{
+			Name: "QueryPlaceholder",
+		}
+		stringScalarType := "String"
+		placeholderObject := introspection.FullType{
+			Kind:        introspection.OBJECT,
+			Name:        "QueryPlaceholder",
+			Description: "Placeholder object",
+			Fields: []introspection.Field{
+				{
+					Name:        "message",
+					Description: "Placeholder field",
+					Type:        introspection.TypeRef{Kind: introspection.SCALAR, Name: &stringScalarType},
+				},
+			},
+		}
+		data.Schema.Types = append(data.Schema.Types, placeholderObject)
 	}
 
 	mutationType, err := c.importMutationType()


### PR DESCRIPTION
This PR adds a placeholder Query type if there is no query definition in the source OpenAPI document. The behavior, including the `QueryPlaceholder` type name, is borrowed from IBM's openapi-to-graphql tool. 