### PR TITLE
[TT-10697] Handle enum definition if the enum field is defined as a property

### DIFF
--- a/pkg/openapi/fixtures/v3.0.0/enum-properties.graphql
+++ b/pkg/openapi/fixtures/v3.0.0/enum-properties.graphql
@@ -1,0 +1,38 @@
+schema {
+    query: Query
+    mutation: Mutation
+}
+
+type Query {
+    "Get single user by their id"
+    getUserById(id: Int!): User
+    "Returns list of all Users"
+    getUsers: [User]
+}
+
+type Mutation {
+    "Creates new User"
+    createUser(userInput: UserInput!): User
+}
+
+enum CartType {
+    FULL
+    EMPTY
+    PARTIAL
+}
+
+type User {
+    cartType: CartType
+    cart_id: Int
+    email: String
+    id: Int!
+    username: String!
+}
+
+input UserInput {
+    cartType: CartType
+    cart_id: Int
+    email: String
+    id: Int!
+    username: String!
+}

--- a/pkg/openapi/fixtures/v3.0.0/enum-properties.yaml
+++ b/pkg/openapi/fixtures/v3.0.0/enum-properties.yaml
@@ -1,0 +1,79 @@
+openapi: "3.0.0"
+info:
+  title: Users API
+  version: 1.0.0
+servers:
+  - url: http://localhost:3004/
+paths:
+  /users:
+    get:
+      description: Returns list of all Users
+      operationId: getUsers
+      responses:
+        '200':
+          description: users response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/User'
+    post:
+      description: Creates new User
+      operationId: createUser
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/User'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/User'
+  /users/{id}:
+    get:
+      description: Get single user by their id
+      operationId: getUserById
+      parameters:
+        - name: id
+          in: path
+          description: ID of user to fetch
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: user response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+components:
+  schemas:
+    User:
+      type: object
+      required:
+        - id
+        - username
+      properties:
+        id:
+          type: integer
+        username:
+          type: string
+        email:
+          type: string
+        cart_id:
+          type: integer
+        cartType:
+          type: string
+          enum:
+            - full
+            - empty
+            - partial

--- a/pkg/openapi/openapi_test.go
+++ b/pkg/openapi/openapi_test.go
@@ -109,4 +109,8 @@ func TestOpenAPI_v3_0_0(t *testing.T) {
 	t.Run("enum-component-mutation.yaml", func(t *testing.T) {
 		testFixtureFile(t, "v3.0.0", "enum-component-mutation.yaml")
 	})
+
+	t.Run("enum-properties.yaml", func(t *testing.T) {
+		testFixtureFile(t, "v3.0.0", "enum-properties.yaml")
+	})
 }

--- a/v2/pkg/openapi/fixtures/v3.0.0/enum-properties.graphql
+++ b/v2/pkg/openapi/fixtures/v3.0.0/enum-properties.graphql
@@ -1,0 +1,38 @@
+schema {
+    query: Query
+    mutation: Mutation
+}
+
+type Query {
+    "Get single user by their id"
+    getUserById(id: Int!): User
+    "Returns list of all Users"
+    getUsers: [User]
+}
+
+type Mutation {
+    "Creates new User"
+    createUser(userInput: UserInput!): User
+}
+
+enum CartType {
+    FULL
+    EMPTY
+    PARTIAL
+}
+
+type User {
+    cartType: CartType
+    cart_id: Int
+    email: String
+    id: Int!
+    username: String!
+}
+
+input UserInput {
+    cartType: CartType
+    cart_id: Int
+    email: String
+    id: Int!
+    username: String!
+}

--- a/v2/pkg/openapi/fixtures/v3.0.0/enum-properties.yaml
+++ b/v2/pkg/openapi/fixtures/v3.0.0/enum-properties.yaml
@@ -1,0 +1,79 @@
+openapi: "3.0.0"
+info:
+  title: Users API
+  version: 1.0.0
+servers:
+  - url: http://localhost:3004/
+paths:
+  /users:
+    get:
+      description: Returns list of all Users
+      operationId: getUsers
+      responses:
+        '200':
+          description: users response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/User'
+    post:
+      description: Creates new User
+      operationId: createUser
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/User'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/User'
+  /users/{id}:
+    get:
+      description: Get single user by their id
+      operationId: getUserById
+      parameters:
+        - name: id
+          in: path
+          description: ID of user to fetch
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: user response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+components:
+  schemas:
+    User:
+      type: object
+      required:
+        - id
+        - username
+      properties:
+        id:
+          type: integer
+        username:
+          type: string
+        email:
+          type: string
+        cart_id:
+          type: integer
+        cartType:
+          type: string
+          enum:
+            - full
+            - empty
+            - partial

--- a/v2/pkg/openapi/openapi_test.go
+++ b/v2/pkg/openapi/openapi_test.go
@@ -109,4 +109,8 @@ func TestOpenAPI_v3_0_0(t *testing.T) {
 	t.Run("enum-component-mutation.yaml", func(t *testing.T) {
 		testFixtureFile(t, "v3.0.0", "enum-component-mutation.yaml")
 	})
+
+	t.Run("enum-properties.yaml", func(t *testing.T) {
+		testFixtureFile(t, "v3.0.0", "enum-properties.yaml")
+	})
 }


### PR DESCRIPTION
Fixes a bug if an enum field is defined as a component's property. See https://tyktech.atlassian.net/browse/TT-10697?focusedCommentId=48290 for the details.