### PR TITLE
add is validated attribute and method to request

### DIFF
--- a/pkg/graphql/request.go
+++ b/pkg/graphql/request.go
@@ -40,6 +40,7 @@ type Request struct {
 	document     ast.Document
 	isParsed     bool
 	isNormalized bool
+	isValidated  bool
 	request      resolve.Request
 
 	validForSchema map[uint64]ValidationResult
@@ -107,6 +108,10 @@ func (r Request) Print(writer io.Writer) (n int, err error) {
 
 func (r *Request) IsNormalized() bool {
 	return r.isNormalized
+}
+
+func (r *Request) IsValidated() bool {
+	return r.isValidated
 }
 
 func (r *Request) parseQueryOnce() (report operationreport.Report) {

--- a/pkg/graphql/request_test.go
+++ b/pkg/graphql/request_test.go
@@ -76,26 +76,6 @@ func TestRequest_Print(t *testing.T) {
 	assert.Equal(t, query, bytesBuf.String())
 }
 
-func TestRequest_IsNormalized(t *testing.T) {
-	request := Request{
-		isNormalized: true,
-	}
-
-	result := request.IsNormalized()
-
-	assert.True(t, result, "Expect IsNormalized to be true")
-}
-
-func TestRequest_IsValidated(t *testing.T) {
-	request := Request{
-		isValidated: true,
-	}
-
-	result := request.IsValidated()
-
-	assert.True(t, result, "Expect IsValidated to be true")
-}
-
 func TestRequest_CalculateComplexity(t *testing.T) {
 	t.Run("should return error when schema is nil", func(t *testing.T) {
 		request := Request{}

--- a/pkg/graphql/request_test.go
+++ b/pkg/graphql/request_test.go
@@ -76,6 +76,26 @@ func TestRequest_Print(t *testing.T) {
 	assert.Equal(t, query, bytesBuf.String())
 }
 
+func TestRequest_IsNormalized(t *testing.T) {
+	request := Request{
+		isNormalized: true,
+	}
+
+	result := request.IsNormalized()
+
+	assert.True(t, result, "Expect IsNormalized to be true")
+}
+
+func TestRequest_IsValidated(t *testing.T) {
+	request := Request{
+		isValidated: true,
+	}
+
+	result := request.IsValidated()
+
+	assert.True(t, result, "Expect IsValidated to be true")
+}
+
 func TestRequest_CalculateComplexity(t *testing.T) {
 	t.Run("should return error when schema is nil", func(t *testing.T) {
 		request := Request{}

--- a/pkg/graphql/validation.go
+++ b/pkg/graphql/validation.go
@@ -41,6 +41,7 @@ func (r *Request) ValidateForSchema(schema *Schema) (result ValidationResult, er
 	if err != nil {
 		return result, err
 	}
+	r.isValidated = true
 	r.validForSchema[schemaHash] = result
 	return result, err
 }

--- a/pkg/graphql/validation_test.go
+++ b/pkg/graphql/validation_test.go
@@ -24,6 +24,7 @@ func TestRequest_ValidateForSchema(t *testing.T) {
 		assert.Error(t, err)
 		assert.Equal(t, ErrNilSchema, err)
 		assert.Equal(t, ValidationResult{Valid: false, Errors: nil}, result)
+		assert.False(t, request.isValidated)
 	})
 
 	t.Run("should return gql errors no valid operation is in the the request", func(t *testing.T) {
@@ -68,6 +69,7 @@ func TestRequest_ValidateForSchema(t *testing.T) {
 		assert.NoError(t, err)
 		assert.True(t, result.Valid)
 		assert.Nil(t, result.Errors)
+		assert.True(t, request.isValidated)
 	})
 
 	t.Run("should return valid result for introspection query after normalization", func(t *testing.T) {
@@ -93,6 +95,7 @@ func TestRequest_ValidateForSchema(t *testing.T) {
 		assert.NoError(t, err)
 		assert.True(t, result.Valid)
 		assert.Nil(t, result.Errors)
+		assert.True(t, request.isValidated)
 	})
 }
 


### PR DESCRIPTION
This PR

 modifies the Request.go file to:
    add isValidated boolean attribute to the request struct
    add the IsValidated method to return the value of isValidated
    
modifies the validation.go file to: 
set isValidated to true



This is being done to simplify removing normalization and validation from the graphql engine in the gateway.
