### PR TITLE
[TT-10908] OAS Converter to handle allOf/anyOf/oneOf keywords

### DIFF
--- a/pkg/openapi/enum.go
+++ b/pkg/openapi/enum.go
@@ -17,13 +17,13 @@ func getEnumTypeRef() introspection.TypeRef {
 // Otherwise, a new enum type is created and stored in the knownEnums map and fullTypes slice.
 // It populates the enum values of the enum type based on the enum values in the schema.
 // Finally, it returns the created or retrieved enum type.
-func (c *converter) createOrGetEnumType(name string, schema *openapi3.SchemaRef) *introspection.FullType {
+func (c *converter) createOrGetEnumType(name string, schema *openapi3.SchemaRef) introspection.FullType {
 	name = strcase.ToCamel(name)
 	if enumType, ok := c.knownEnums[name]; ok {
 		return enumType
 	}
 
-	enumType := &introspection.FullType{
+	enumType := introspection.FullType{
 		Kind:        introspection.ENUM,
 		Name:        name,
 		Description: schema.Value.Description,
@@ -35,7 +35,7 @@ func (c *converter) createOrGetEnumType(name string, schema *openapi3.SchemaRef)
 		}
 		enumType.EnumValues = append(enumType.EnumValues, enumValue)
 	}
-	c.fullTypes = append(c.fullTypes, *enumType)
+	c.fullTypes = append(c.fullTypes, enumType)
 	c.knownEnums[name] = enumType
 	return enumType
 }

--- a/pkg/openapi/field.go
+++ b/pkg/openapi/field.go
@@ -71,12 +71,14 @@ func (c *converter) processSchemaProperties(fullType *introspection.FullType, sc
 		if err != nil {
 			return err
 		}
+		if len(schemaRef.Value.Enum) > 0 {
+			c.createOrGetEnumType(*typeRef.Name, schemaRef)
+		}
 		field := introspection.Field{
 			Name:        name,
 			Type:        *typeRef,
 			Description: schemaRef.Value.Description,
 		}
-
 		fullType.Fields = append(fullType.Fields, field)
 		sort.Slice(fullType.Fields, func(i, j int) bool {
 			return fullType.Fields[i].Name < fullType.Fields[j].Name

--- a/pkg/openapi/fixtures/v3.0.0/EmployeesApiBasic.graphql
+++ b/pkg/openapi/fixtures/v3.0.0/EmployeesApiBasic.graphql
@@ -10,7 +10,7 @@ type Query {
 
 type Mutation {
     "Uses the updateEmployee Db2 z/OS asset"
-    putEmployeesId(employeeBodyInput: EmployeeBodyInput, id: String!): EmployeeBody
+    putEmployees(employeeBodyInput: EmployeeBodyInput, id: String!): EmployeeBody
 }
 
 type EmployeeBody {

--- a/pkg/openapi/fixtures/v3.0.0/allOf-input-type-composition.graphql
+++ b/pkg/openapi/fixtures/v3.0.0/allOf-input-type-composition.graphql
@@ -1,0 +1,38 @@
+schema {
+    query: QueryPlaceholder
+    mutation: Mutation
+}
+
+"Placeholder object"
+type QueryPlaceholder {
+    "Placeholder field"
+    message: String
+}
+
+type Mutation {
+    postPets(pets: PetsInput): Dog
+}
+
+enum Breed {
+    DINGO
+    HUSKY
+    RETRIEVER
+    SHEPHERD
+}
+
+type Dog {
+    bark: Boolean
+    breed: Breed
+    pet_type: String!
+}
+
+input PetsInput {
+    address: String
+    age: Int
+    bark: Boolean
+    breed: Breed
+    color: String
+    name: String
+    pet_type: String!
+    surname: String
+}

--- a/pkg/openapi/fixtures/v3.0.0/allOf-input-type-composition.yaml
+++ b/pkg/openapi/fixtures/v3.0.0/allOf-input-type-composition.yaml
@@ -1,0 +1,66 @@
+openapi: "3.0.0"
+info:
+  title: Pets API
+  version: 1.0.0
+servers:
+  - url: http://localhost:3004/
+
+paths:
+  /pets:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/Dog'
+                - type: object
+                  properties:
+                    name:
+                      type: string
+                    surname:
+                      type: string
+                    age:
+                      type: integer
+                    address:
+                      type: string
+                - $ref: '#/components/schemas/Hamster'
+      responses:
+        '200':
+          description: Pets response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Dog'
+
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - pet_type
+      properties:
+        pet_type:
+          type: string
+      discriminator:
+        propertyName: pet_type
+    Dog:     # "Dog" is a value for the pet_type property (the discriminator value)
+      allOf: # Combines the main `Pet` schema with `Dog`-specific properties
+        - $ref: '#/components/schemas/Pet'
+        - type: object
+          # all other properties specific to a `Dog`
+          properties:
+            bark:
+              type: boolean
+            breed:
+              type: string
+              enum: [Dingo, Husky, Retriever, Shepherd]
+    Hamster:
+      allOf:
+        - $ref: '#/components/schemas/Pet'
+        - type: object
+          properties:
+            age:
+              type: integer
+            color:
+              type: string

--- a/pkg/openapi/fixtures/v3.0.0/allOf-input-type.graphql
+++ b/pkg/openapi/fixtures/v3.0.0/allOf-input-type.graphql
@@ -1,0 +1,34 @@
+schema {
+    query: QueryPlaceholder
+    mutation: Mutation
+}
+
+"Placeholder object"
+type QueryPlaceholder {
+    "Placeholder field"
+    message: String
+}
+
+type Mutation {
+    postPets(pets: PetsInput): Dog
+}
+
+enum Breed {
+    DINGO
+    HUSKY
+    RETRIEVER
+    SHEPHERD
+}
+
+type Dog {
+    bark: Boolean
+    breed: Breed
+}
+
+input PetsInput {
+    age: Int
+    bark: Boolean
+    breed: Breed
+    color: String
+    hunts: Boolean
+}

--- a/pkg/openapi/fixtures/v3.0.0/allOf-input-type.yaml
+++ b/pkg/openapi/fixtures/v3.0.0/allOf-input-type.yaml
@@ -1,0 +1,50 @@
+openapi: "3.0.0"
+info:
+  title: Pets API
+  version: 1.0.0
+servers:
+  - url: http://localhost:3004/
+
+paths:
+  /pets:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/Cat'
+                - $ref: '#/components/schemas/Dog'
+                - $ref: '#/components/schemas/Hamster'
+      responses:
+        '200':
+          description: Pets response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Dog'
+
+components:
+  schemas:
+    Dog:
+      type: object
+      properties:
+        bark:
+          type: boolean
+        breed:
+          type: string
+          enum: [Dingo, Husky, Retriever, Shepherd]
+    Cat:
+      type: object
+      properties:
+        hunts:
+          type: boolean
+        age:
+          type: integer
+    Hamster:
+      type: object
+      properties:
+        age:
+          type: integer
+        color:
+          type: string

--- a/pkg/openapi/fixtures/v3.0.0/allOf-query-composition.graphql
+++ b/pkg/openapi/fixtures/v3.0.0/allOf-query-composition.graphql
@@ -1,0 +1,25 @@
+schema {
+    query: Query
+}
+
+type Query {
+    pets: Pets
+}
+
+enum Breed {
+    DINGO
+    HUSKY
+    RETRIEVER
+    SHEPHERD
+}
+
+type Pets {
+    address: String
+    age: Int
+    bark: Boolean
+    breed: Breed
+    color: String
+    name: String
+    pet_type: String!
+    surname: String
+}

--- a/pkg/openapi/fixtures/v3.0.0/allOf-query-composition.yaml
+++ b/pkg/openapi/fixtures/v3.0.0/allOf-query-composition.yaml
@@ -1,0 +1,60 @@
+openapi: "3.0.0"
+info:
+  title: Pets API
+  version: 1.0.0
+servers:
+  - url: http://localhost:3004/
+
+paths:
+  /pets:
+    get:
+      responses:
+        '200':
+          description: Pets response
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Dog'
+                  - type: object
+                    properties:
+                      name:
+                        type: string
+                      surname:
+                        type: string
+                      age:
+                        type: integer
+                      address:
+                        type: string
+                  - $ref: '#/components/schemas/Hamster'
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - pet_type
+      properties:
+        pet_type:
+          type: string
+      discriminator:
+        propertyName: pet_type
+    Dog:     # "Dog" is a value for the pet_type property (the discriminator value)
+      allOf: # Combines the main `Pet` schema with `Dog`-specific properties
+        - $ref: '#/components/schemas/Pet'
+        - type: object
+          # all other properties specific to a `Dog`
+          properties:
+            bark:
+              type: boolean
+            breed:
+              type: string
+              enum: [Dingo, Husky, Retriever, Shepherd]
+    Hamster:
+      allOf:
+        - $ref: '#/components/schemas/Pet'
+        - type: object
+          properties:
+            age:
+              type: integer
+            color:
+              type: string

--- a/pkg/openapi/fixtures/v3.0.0/allOf-query-response-type.graphql
+++ b/pkg/openapi/fixtures/v3.0.0/allOf-query-response-type.graphql
@@ -1,0 +1,22 @@
+schema {
+    query: Query
+}
+
+type Query {
+    pets: Pets
+}
+
+enum Breed {
+    DINGO
+    HUSKY
+    RETRIEVER
+    SHEPHERD
+}
+
+type Pets {
+    age: Int
+    bark: Boolean
+    breed: Breed
+    color: String
+    hunts: Boolean
+}

--- a/pkg/openapi/fixtures/v3.0.0/allOf-query-response-type.yaml
+++ b/pkg/openapi/fixtures/v3.0.0/allOf-query-response-type.yaml
@@ -1,0 +1,45 @@
+openapi: "3.0.0"
+info:
+  title: Pets API
+  version: 1.0.0
+servers:
+  - url: http://localhost:3004/
+
+paths:
+  /pets:
+    get:
+      responses:
+        '200':
+          description: Pets response
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Cat'
+                  - $ref: '#/components/schemas/Dog'
+                  - $ref: '#/components/schemas/Hamster'
+
+components:
+  schemas:
+    Dog:
+      type: object
+      properties:
+        bark:
+          type: boolean
+        breed:
+          type: string
+          enum: [Dingo, Husky, Retriever, Shepherd]
+    Cat:
+      type: object
+      properties:
+        hunts:
+          type: boolean
+        age:
+          type: integer
+    Hamster:
+      type: object
+      properties:
+        age:
+          type: integer
+        color:
+          type: string

--- a/pkg/openapi/fixtures/v3.0.0/allOf-response-type-composition.graphql
+++ b/pkg/openapi/fixtures/v3.0.0/allOf-response-type-composition.graphql
@@ -1,0 +1,43 @@
+schema {
+    query: QueryPlaceholder
+    mutation: Mutation
+}
+
+"Placeholder object"
+type QueryPlaceholder {
+    "Placeholder field"
+    message: String
+}
+
+type Mutation {
+    postPets(pets: PetsInput): Pets
+}
+
+enum Breed {
+    DINGO
+    HUSKY
+    RETRIEVER
+    SHEPHERD
+}
+
+type Pets {
+    address: String
+    age: Int
+    bark: Boolean
+    breed: Breed
+    color: String
+    name: String
+    pet_type: String!
+    surname: String
+}
+
+input PetsInput {
+    address: String
+    age: Int
+    bark: Boolean
+    breed: Breed
+    color: String
+    name: String
+    pet_type: String!
+    surname: String
+}

--- a/pkg/openapi/fixtures/v3.0.0/allOf-response-type-composition.yaml
+++ b/pkg/openapi/fixtures/v3.0.0/allOf-response-type-composition.yaml
@@ -1,0 +1,77 @@
+openapi: "3.0.0"
+info:
+  title: Pets API
+  version: 1.0.0
+servers:
+  - url: http://localhost:3004/
+
+paths:
+  /pets:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/Dog'
+                - type: object
+                  properties:
+                    name:
+                      type: string
+                    surname:
+                      type: string
+                    age:
+                      type: integer
+                    address:
+                      type: string
+                - $ref: '#/components/schemas/Hamster'
+      responses:
+        '200':
+          description: Pets response
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Dog'
+                  - type: object
+                    properties:
+                      name:
+                        type: string
+                      surname:
+                        type: string
+                      age:
+                        type: integer
+                      address:
+                        type: string
+                  - $ref: '#/components/schemas/Hamster'
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - pet_type
+      properties:
+        pet_type:
+          type: string
+      discriminator:
+        propertyName: pet_type
+    Dog:     # "Dog" is a value for the pet_type property (the discriminator value)
+      allOf: # Combines the main `Pet` schema with `Dog`-specific properties
+        - $ref: '#/components/schemas/Pet'
+        - type: object
+          # all other properties specific to a `Dog`
+          properties:
+            bark:
+              type: boolean
+            breed:
+              type: string
+              enum: [Dingo, Husky, Retriever, Shepherd]
+    Hamster:
+      allOf:
+        - $ref: '#/components/schemas/Pet'
+        - type: object
+          properties:
+            age:
+              type: integer
+            color:
+              type: string

--- a/pkg/openapi/fixtures/v3.0.0/allOf-response-type.graphql
+++ b/pkg/openapi/fixtures/v3.0.0/allOf-response-type.graphql
@@ -1,0 +1,25 @@
+schema {
+    query: Query
+    mutation: Mutation
+}
+
+type Query {
+    pets: Pets
+}
+
+type Mutation {
+    postPets(catInput: CatInput): Pets
+}
+
+input CatInput {
+    age: Int
+    hunts: Boolean
+}
+
+type Pets {
+    age: Int
+    bark: Boolean
+    breed: Breed
+    color: String
+    hunts: Boolean
+}

--- a/pkg/openapi/fixtures/v3.0.0/allOf-response-type.graphql
+++ b/pkg/openapi/fixtures/v3.0.0/allOf-response-type.graphql
@@ -11,6 +11,13 @@ type Mutation {
     postPets(catInput: CatInput): Pets
 }
 
+enum Breed {
+    DINGO
+    HUSKY
+    RETRIEVER
+    SHEPHERD
+}
+
 input CatInput {
     age: Int
     hunts: Boolean

--- a/pkg/openapi/fixtures/v3.0.0/allOf-response-type.yaml
+++ b/pkg/openapi/fixtures/v3.0.0/allOf-response-type.yaml
@@ -1,0 +1,61 @@
+openapi: "3.0.0"
+info:
+  title: Pets API
+  version: 1.0.0
+servers:
+  - url: http://localhost:3004/
+
+paths:
+  /pets:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Cat'
+      responses:
+        '200':
+          description: Pets response
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Cat'
+                  - $ref: '#/components/schemas/Dog'
+                  - $ref: '#/components/schemas/Hamster'
+
+    get:
+      responses:
+        '200':
+          description: Pets response
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Cat'
+                  - $ref: '#/components/schemas/Dog'
+                  - $ref: '#/components/schemas/Hamster'
+components:
+  schemas:
+    Dog:
+      type: object
+      properties:
+        bark:
+          type: boolean
+        breed:
+          type: string
+          enum: [Dingo, Husky, Retriever, Shepherd]
+    Cat:
+      type: object
+      properties:
+        hunts:
+          type: boolean
+        age:
+          type: integer
+    Hamster:
+      type: object
+      properties:
+        age:
+          type: integer
+        color:
+          type: string

--- a/pkg/openapi/fixtures/v3.0.0/anyOf-input-type.graphql
+++ b/pkg/openapi/fixtures/v3.0.0/anyOf-input-type.graphql
@@ -1,0 +1,38 @@
+schema {
+    query: QueryPlaceholder
+    mutation: Mutation
+}
+
+"Placeholder object"
+type QueryPlaceholder {
+    "Placeholder field"
+    message: String
+}
+
+type Mutation {
+    postPets(pets: PetsInput): Dog
+}
+
+enum Breed {
+    DINGO
+    HUSKY
+    RETRIEVER
+    SHEPHERD
+}
+
+type Dog {
+    bark: Boolean
+    breed: Breed
+}
+
+enum PetType {
+    CAT
+    DOG
+}
+
+input PetsInput {
+    age: Int!
+    hunts: Boolean
+    nickname: String
+    pet_type: PetType
+}

--- a/pkg/openapi/fixtures/v3.0.0/anyOf-input-type.yaml
+++ b/pkg/openapi/fixtures/v3.0.0/anyOf-input-type.yaml
@@ -1,0 +1,54 @@
+openapi: "3.0.0"
+info:
+  title: Pets API
+  version: 1.0.0
+servers:
+  - url: http://localhost:3004/
+
+paths:
+  /pets:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              anyOf:
+                - $ref: '#/components/schemas/PetByAge'
+                - $ref: '#/components/schemas/PetByType'
+      responses:
+        '200':
+          description: Pets response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Dog'
+components:
+  schemas:
+    Dog:
+      type: object
+      properties:
+        bark:
+          type: boolean
+        breed:
+          type: string
+          enum: [ Dingo, Husky, Retriever, Shepherd ]
+    PetByAge:
+      type: object
+      properties:
+        age:
+          type: integer
+        nickname:
+          type: string
+      required:
+        - age
+
+    PetByType:
+      type: object
+      properties:
+        pet_type:
+          type: string
+          enum: [Cat, Dog]
+        hunts:
+          type: boolean
+      required:
+        - pet_type

--- a/pkg/openapi/fixtures/v3.0.0/anyOf-query-response-type.graphql
+++ b/pkg/openapi/fixtures/v3.0.0/anyOf-query-response-type.graphql
@@ -1,0 +1,19 @@
+schema {
+    query: Query
+}
+
+type Query {
+    petsFoobar(id: Int!): PetsFoobar
+}
+
+enum PetType {
+    CAT
+    DOG
+}
+
+type PetsFoobar {
+    age: Int!
+    hunts: Boolean
+    nickname: String
+    pet_type: PetType
+}

--- a/pkg/openapi/fixtures/v3.0.0/anyOf-query-response-type.yaml
+++ b/pkg/openapi/fixtures/v3.0.0/anyOf-query-response-type.yaml
@@ -1,0 +1,50 @@
+openapi: "3.0.0"
+info:
+  title: Pets API
+  version: 1.0.0
+servers:
+  - url: http://localhost:3004/
+
+paths:
+  /pets/{id}/foobar:
+    get:
+      parameters:
+        - name: id
+          in: path
+          description: ID of Pet to fetch
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: Pets response
+          content:
+            application/json:
+              schema:
+                anyOf:
+                  - $ref: '#/components/schemas/PetByAge'
+                  - $ref: '#/components/schemas/PetByType'
+
+components:
+  schemas:
+    PetByAge:
+      type: object
+      properties:
+        age:
+          type: integer
+        nickname:
+          type: string
+      required:
+        - age
+
+    PetByType:
+      type: object
+      properties:
+        pet_type:
+          type: string
+          enum: [Cat, Dog]
+        hunts:
+          type: boolean
+      required:
+        - pet_type

--- a/pkg/openapi/fixtures/v3.0.0/anyOf-response-type.graphql
+++ b/pkg/openapi/fixtures/v3.0.0/anyOf-response-type.graphql
@@ -1,0 +1,33 @@
+schema {
+    query: QueryPlaceholder
+    mutation: Mutation
+}
+
+"Placeholder object"
+type QueryPlaceholder {
+    "Placeholder field"
+    message: String
+}
+
+type Mutation {
+    postPets(pets: PetsInput): Pets
+}
+
+enum PetType {
+    CAT
+    DOG
+}
+
+type Pets {
+    age: Int!
+    hunts: Boolean
+    nickname: String
+    pet_type: PetType
+}
+
+input PetsInput {
+    age: Int!
+    hunts: Boolean
+    nickname: String
+    pet_type: PetType
+}

--- a/pkg/openapi/fixtures/v3.0.0/anyOf-response-type.yaml
+++ b/pkg/openapi/fixtures/v3.0.0/anyOf-response-type.yaml
@@ -1,0 +1,49 @@
+openapi: "3.0.0"
+info:
+  title: Pets API
+  version: 1.0.0
+servers:
+  - url: http://localhost:3004/
+
+paths:
+  /pets:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              anyOf:
+                - $ref: '#/components/schemas/PetByAge'
+                - $ref: '#/components/schemas/PetByType'
+      responses:
+        '200':
+          description: Pets response
+          content:
+            application/json:
+              schema:
+                anyOf:
+                  - $ref: '#/components/schemas/PetByAge'
+                  - $ref: '#/components/schemas/PetByType'
+
+components:
+  schemas:
+    PetByAge:
+      type: object
+      properties:
+        age:
+          type: integer
+        nickname:
+          type: string
+      required:
+        - age
+
+    PetByType:
+      type: object
+      properties:
+        pet_type:
+          type: string
+          enum: [Cat, Dog]
+        hunts:
+          type: boolean
+      required:
+        - pet_type

--- a/pkg/openapi/fixtures/v3.0.0/oneOf-input-type.graphql
+++ b/pkg/openapi/fixtures/v3.0.0/oneOf-input-type.graphql
@@ -1,0 +1,29 @@
+schema {
+    query: QueryPlaceholder
+    mutation: Mutation
+}
+
+"Placeholder object"
+type QueryPlaceholder {
+    "Placeholder field"
+    message: String
+}
+
+type Mutation {
+    postPets(petsInput: JSON): Dog
+}
+
+enum Breed {
+    DINGO
+    HUSKY
+    RETRIEVER
+    SHEPHERD
+}
+
+type Dog {
+    bark: Boolean
+    breed: Breed
+}
+
+"The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf)."
+scalar JSON

--- a/pkg/openapi/fixtures/v3.0.0/oneOf-input-type.yaml
+++ b/pkg/openapi/fixtures/v3.0.0/oneOf-input-type.yaml
@@ -1,0 +1,50 @@
+openapi: "3.0.0"
+info:
+  title: Pets API
+  version: 1.0.0
+servers:
+  - url: http://localhost:3004/
+
+paths:
+  /pets:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - $ref: '#/components/schemas/Cat'
+                - $ref: '#/components/schemas/Dog'
+                - $ref: '#/components/schemas/Hamster'
+      responses:
+        '200':
+          description: Pets response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Dog'
+
+components:
+  schemas:
+    Dog:
+      type: object
+      properties:
+        bark:
+          type: boolean
+        breed:
+          type: string
+          enum: [Dingo, Husky, Retriever, Shepherd]
+    Cat:
+      type: object
+      properties:
+        hunts:
+          type: boolean
+        age:
+          type: integer
+    Hamster:
+      type: object
+      properties:
+        age:
+          type: integer
+        color:
+          type: string

--- a/pkg/openapi/fixtures/v3.0.0/oneOf-response-type-composition.graphql
+++ b/pkg/openapi/fixtures/v3.0.0/oneOf-response-type-composition.graphql
@@ -1,0 +1,52 @@
+schema {
+    query: QueryPlaceholder
+    mutation: Mutation
+}
+
+"Placeholder object"
+type QueryPlaceholder {
+    "Placeholder field"
+    message: String
+}
+
+type Mutation {
+    postPets(petsInput: JSON): Pets
+}
+
+enum Breed {
+    DINGO
+    HUSKY
+    RETRIEVER
+    SHEPHERD
+}
+
+type Cat {
+    age: Int
+    hunts: Boolean
+}
+
+type Dog {
+    bark: Boolean
+    breed: Breed
+}
+
+type Hamster {
+    age: Int
+    color: String
+}
+
+"The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf)."
+scalar JSON
+
+union Pets = Cat | Dog | Hamster | PetsMember | PetsMember2
+
+type PetsMember {
+    address: String
+    age: Int
+    name: String
+    surname: String
+}
+
+type PetsMember2 {
+    username: String
+}

--- a/pkg/openapi/fixtures/v3.0.0/oneOf-response-type-composition.yaml
+++ b/pkg/openapi/fixtures/v3.0.0/oneOf-response-type-composition.yaml
@@ -1,0 +1,78 @@
+openapi: "3.0.0"
+info:
+  title: Pets API
+  version: 1.0.0
+servers:
+  - url: http://localhost:3004/
+
+paths:
+  /pets:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - $ref: '#/components/schemas/Cat'
+                - $ref: '#/components/schemas/Dog'
+                - $ref: '#/components/schemas/Hamster'
+                - type: object
+                  properties:
+                    name:
+                      type: string
+                    surname:
+                      type: string
+                    age:
+                      type: integer
+                    address:
+                      type: string
+      responses:
+        '200':
+          description: Pets response
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/Cat'
+                  - $ref: '#/components/schemas/Dog'
+                  - $ref: '#/components/schemas/Hamster'
+                  - type: object
+                    properties:
+                      name:
+                        type: string
+                      surname:
+                        type: string
+                      age:
+                        type: integer
+                      address:
+                        type: string
+                  - type: object
+                    properties:
+                      username:
+                        type: string
+
+
+components:
+  schemas:
+    Dog:
+      type: object
+      properties:
+        bark:
+          type: boolean
+        breed:
+          type: string
+          enum: [Dingo, Husky, Retriever, Shepherd]
+    Cat:
+      type: object
+      properties:
+        hunts:
+          type: boolean
+        age:
+          type: integer
+    Hamster:
+      type: object
+      properties:
+        age:
+          type: integer
+        color:
+          type: string

--- a/pkg/openapi/fixtures/v3.0.0/oneOf-response-type.graphql
+++ b/pkg/openapi/fixtures/v3.0.0/oneOf-response-type.graphql
@@ -1,0 +1,41 @@
+schema {
+    query: QueryPlaceholder
+    mutation: Mutation
+}
+
+"Placeholder object"
+type QueryPlaceholder {
+    "Placeholder field"
+    message: String
+}
+
+type Mutation {
+    postPets(petsInput: JSON): Pets
+}
+
+enum Breed {
+    DINGO
+    HUSKY
+    RETRIEVER
+    SHEPHERD
+}
+
+type Cat {
+    age: Int
+    hunts: Boolean
+}
+
+type Dog {
+    bark: Boolean
+    breed: Breed
+}
+
+type Hamster {
+    age: Int
+    color: String
+}
+
+"The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf)."
+scalar JSON
+
+union Pets = Cat | Dog | Hamster

--- a/pkg/openapi/fixtures/v3.0.0/oneOf-response-type.yaml
+++ b/pkg/openapi/fixtures/v3.0.0/oneOf-response-type.yaml
@@ -1,0 +1,53 @@
+openapi: "3.0.0"
+info:
+  title: Pets API
+  version: 1.0.0
+servers:
+  - url: http://localhost:3004/
+
+paths:
+  /pets:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - $ref: '#/components/schemas/Cat'
+                - $ref: '#/components/schemas/Dog'
+                - $ref: '#/components/schemas/Hamster'
+      responses:
+        '200':
+          description: Pets response
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/Cat'
+                  - $ref: '#/components/schemas/Dog'
+                  - $ref: '#/components/schemas/Hamster'
+
+components:
+  schemas:
+    Dog:
+      type: object
+      properties:
+        bark:
+          type: boolean
+        breed:
+          type: string
+          enum: [Dingo, Husky, Retriever, Shepherd]
+    Cat:
+      type: object
+      properties:
+        hunts:
+          type: boolean
+        age:
+          type: integer
+    Hamster:
+      type: object
+      properties:
+        age:
+          type: integer
+        color:
+          type: string

--- a/pkg/openapi/fulltype.go
+++ b/pkg/openapi/fulltype.go
@@ -111,7 +111,7 @@ func (c *converter) checkAndProcessAllOfKeyword(schema *openapi3.SchemaRef) erro
 			if _, ok := c.knownEnums[fullType.Name]; ok {
 				continue
 			} else {
-				c.knownEnums[fullType.Name] = &fullType
+				c.knownEnums[fullType.Name] = fullType
 				c.fullTypes = append(c.fullTypes, fullType)
 			}
 		}

--- a/pkg/openapi/fulltype.go
+++ b/pkg/openapi/fulltype.go
@@ -15,6 +15,20 @@ func (c *converter) checkAndProcessOneOfKeyword(schema *openapi3.SchemaRef) erro
 	if schema.Value.OneOf == nil {
 		return nil
 	}
+
+	// Set name to unnamed schemas.
+	var namedSchema = 1
+	for _, oneOfSchema := range schema.Value.OneOf {
+		if oneOfSchema.Ref == "" {
+			if namedSchema <= 1 {
+				oneOfSchema.Ref = fmt.Sprintf("%sMember", MakeTypeNameFromPathName(c.currentPathName))
+			} else {
+				oneOfSchema.Ref = fmt.Sprintf("%sMember%d", MakeTypeNameFromPathName(c.currentPathName), namedSchema)
+			}
+			namedSchema++
+		}
+	}
+
 	for _, oneOfSchema := range schema.Value.OneOf {
 		err := c.processSchema(oneOfSchema)
 		if err != nil {

--- a/pkg/openapi/fulltype.go
+++ b/pkg/openapi/fulltype.go
@@ -91,9 +91,12 @@ func (c *converter) checkAndProcessAllOfAnyOfCommon(ref string, items openapi3.S
 		return nil
 	}
 
+	// Create a new converter here to process AllOf and AnyOf keywords and merge the types.
+	// Then we move the merged type to the root converter.
 	cc := newConverter(c.openapi)
 	for i, item := range items {
 		if item.Ref == "" {
+			// Generate a name for the unnamed type. We just need the fields.
 			item.Ref = fmt.Sprintf("unnamed-type-item-%d", i)
 		}
 		if err = cc.processSchema(item); err != nil {

--- a/pkg/openapi/fulltype.go
+++ b/pkg/openapi/fulltype.go
@@ -40,10 +40,9 @@ func (c *converter) checkAndProcessOneOfKeyword(schema *openapi3.SchemaRef) erro
 		unionName := MakeTypeNameFromPathName(c.currentPathName)
 		if _, ok := c.knownUnions[unionName]; ok {
 			// Already have the union definition.
-			// TODO: Do we need to add more types to this UNION?
 			return nil
 		}
-		unionType := &introspection.FullType{
+		unionType := introspection.FullType{
 			Kind:          introspection.UNION,
 			Name:          unionName,
 			PossibleTypes: []introspection.TypeRef{},
@@ -62,7 +61,8 @@ func (c *converter) checkAndProcessOneOfKeyword(schema *openapi3.SchemaRef) erro
 				Name: &fullTypeName,
 			})
 		}
-		c.fullTypes = append(c.fullTypes, *unionType)
+		c.knownUnions[unionName] = unionType
+		c.fullTypes = append(c.fullTypes, unionType)
 	}
 	return nil
 }

--- a/pkg/openapi/input.go
+++ b/pkg/openapi/input.go
@@ -89,7 +89,7 @@ func (c *converter) makeInputObjectFromAllOf(schema *openapi3.SchemaRef) (string
 			if _, ok := c.knownEnums[fullType.Name]; ok {
 				continue
 			} else {
-				c.knownEnums[fullType.Name] = &fullType
+				c.knownEnums[fullType.Name] = fullType
 				c.fullTypes = append(c.fullTypes, fullType)
 			}
 		}

--- a/pkg/openapi/input.go
+++ b/pkg/openapi/input.go
@@ -57,6 +57,9 @@ func (c *converter) getInputValue(name string, schema *openapi3.SchemaRef) (*int
 		enumType := c.createOrGetEnumType(name, schema)
 		typeRef = getEnumTypeRef()
 		gqlType = enumType.Name
+	} else if schema.Value.OneOf != nil && len(schema.Value.OneOf) > 0 {
+		gqlType = name // JSON
+		typeRef = introspection.TypeRef{Kind: 0}
 	} else {
 		paramType := schema.Value.Type
 		if paramType == "array" {

--- a/pkg/openapi/input.go
+++ b/pkg/openapi/input.go
@@ -46,14 +46,13 @@ func (c *converter) processInputObject(schema *openapi3.SchemaRef) error {
 	return nil
 }
 
-// makeInputObjectFromAllOf converts a schema with multiple "allOf" properties into an input object.
-func (c *converter) makeInputObjectFromAllOf(schema *openapi3.SchemaRef) (string, error) {
+func (c *converter) makeInputObjectFromAllOfAnyOfCommon(items openapi3.SchemaRefs) (string, error) {
 	cc := newConverter(c.openapi)
-	for i, allOfSchema := range schema.Value.AllOf {
-		if allOfSchema.Ref == "" {
-			allOfSchema.Ref = fmt.Sprintf("unnamed-type-allof-%d", i)
+	for i, item := range items {
+		if item.Ref == "" {
+			item.Ref = fmt.Sprintf("unnamed-type-item-%d", i)
 		}
-		if err := cc.processSchema(allOfSchema); err != nil {
+		if err := cc.processSchema(item); err != nil {
 			return "", err
 		}
 	}
@@ -115,71 +114,13 @@ func (c *converter) makeInputObjectFromAllOf(schema *openapi3.SchemaRef) (string
 }
 
 // makeInputObjectFromAllOf converts a schema with multiple "allOf" properties into an input object.
+func (c *converter) makeInputObjectFromAllOf(schema *openapi3.SchemaRef) (string, error) {
+	return c.makeInputObjectFromAllOfAnyOfCommon(schema.Value.AllOf)
+}
+
+// makeInputObjectFromAllOf converts a schema with multiple "allOf" properties into an input object.
 func (c *converter) makeInputObjectFromAnyOf(schema *openapi3.SchemaRef) (string, error) {
-	cc := newConverter(c.openapi)
-	for i, anyOfSchema := range schema.Value.AnyOf {
-		if anyOfSchema.Ref == "" {
-			anyOfSchema.Ref = fmt.Sprintf("unnamed-type-anyof-%d", i)
-		}
-		if err := cc.processSchema(anyOfSchema); err != nil {
-			return "", err
-		}
-	}
-	mergedType := introspection.FullType{
-		Kind: introspection.INPUTOBJECT,
-		Name: MakeInputTypeName(MakeTypeNameFromPathName(c.currentPathName)),
-	}
-	knownFields := make(map[string]struct{})
-	knownInputFields := make(map[string]struct{})
-	for _, fullType := range cc.fullTypes {
-		if fullType.Kind == introspection.OBJECT {
-			for _, field := range fullType.Fields {
-				if _, ok := knownFields[field.Name]; !ok {
-					knownFields[field.Name] = struct{}{}
-					// Convert a Field to a InputValue
-					inputValue := introspection.InputValue{
-						Name:        field.Name,
-						Description: field.Description,
-						Type:        field.Type,
-					}
-					mergedType.InputFields = append(mergedType.InputFields, inputValue)
-				}
-			}
-			for _, inputField := range fullType.InputFields {
-				if _, ok := knownInputFields[inputField.Name]; !ok {
-					knownInputFields[inputField.Name] = struct{}{}
-					mergedType.InputFields = append(mergedType.InputFields, inputField)
-				}
-			}
-			mergedType.PossibleTypes = append(mergedType.PossibleTypes, fullType.PossibleTypes...)
-			mergedType.Interfaces = append(mergedType.Interfaces, fullType.Interfaces...)
-		} else if fullType.Kind == introspection.ENUM {
-			if _, ok := c.knownEnums[fullType.Name]; ok {
-				continue
-			} else {
-				c.knownEnums[fullType.Name] = fullType
-				c.fullTypes = append(c.fullTypes, fullType)
-			}
-		}
-	}
-
-	sort.Slice(mergedType.Fields, func(i, j int) bool {
-		return mergedType.Fields[i].Name < mergedType.Fields[j].Name
-	})
-	sort.Slice(mergedType.InputFields, func(i, j int) bool {
-		return mergedType.InputFields[i].Name < mergedType.InputFields[j].Name
-	})
-	sort.Slice(mergedType.EnumValues, func(i, j int) bool {
-		return mergedType.EnumValues[i].Name < mergedType.EnumValues[j].Name
-	})
-
-	c.fullTypes = append(c.fullTypes, mergedType)
-	sort.Slice(c.fullTypes, func(i, j int) bool {
-		return c.fullTypes[i].Name < c.fullTypes[j].Name
-	})
-	c.knownFullTypes[mergedType.Name] = &knownFullTypeDetails{}
-
-	return mergedType.Name, nil
+	return c.makeInputObjectFromAllOfAnyOfCommon(schema.Value.AnyOf)
 }
 
 func (c *converter) getInputValue(name string, schema *openapi3.SchemaRef) (*introspection.InputValue, error) {

--- a/pkg/openapi/input.go
+++ b/pkg/openapi/input.go
@@ -86,14 +86,6 @@ func (c *converter) makeInputObjectFromAllOfAnyOfCommon(items openapi3.SchemaRef
 					mergedType.InputFields = append(mergedType.InputFields, inputValue)
 				}
 			}
-			for _, inputField := range fullType.InputFields {
-				if _, ok := knownInputFields[inputField.Name]; !ok {
-					knownInputFields[inputField.Name] = struct{}{}
-					mergedType.InputFields = append(mergedType.InputFields, inputField)
-				}
-			}
-			mergedType.PossibleTypes = append(mergedType.PossibleTypes, fullType.PossibleTypes...)
-			mergedType.Interfaces = append(mergedType.Interfaces, fullType.Interfaces...)
 		} else if fullType.Kind == introspection.ENUM {
 			if _, ok := c.knownEnums[fullType.Name]; ok {
 				continue
@@ -101,25 +93,18 @@ func (c *converter) makeInputObjectFromAllOfAnyOfCommon(items openapi3.SchemaRef
 				c.knownEnums[fullType.Name] = fullType
 				c.fullTypes = append(c.fullTypes, fullType)
 			}
+		} else if fullType.Kind == introspection.INPUTOBJECT {
+			for _, inputField := range fullType.InputFields {
+				if _, ok := knownInputFields[inputField.Name]; !ok {
+					knownInputFields[inputField.Name] = struct{}{}
+					mergedType.InputFields = append(mergedType.InputFields, inputField)
+				}
+			}
 		}
+		mergedType.PossibleTypes = append(mergedType.PossibleTypes, fullType.PossibleTypes...)
+		mergedType.Interfaces = append(mergedType.Interfaces, fullType.Interfaces...)
 	}
-
-	sort.Slice(mergedType.Fields, func(i, j int) bool {
-		return mergedType.Fields[i].Name < mergedType.Fields[j].Name
-	})
-	sort.Slice(mergedType.InputFields, func(i, j int) bool {
-		return mergedType.InputFields[i].Name < mergedType.InputFields[j].Name
-	})
-	sort.Slice(mergedType.EnumValues, func(i, j int) bool {
-		return mergedType.EnumValues[i].Name < mergedType.EnumValues[j].Name
-	})
-
-	c.fullTypes = append(c.fullTypes, mergedType)
-	sort.Slice(c.fullTypes, func(i, j int) bool {
-		return c.fullTypes[i].Name < c.fullTypes[j].Name
-	})
-	c.knownFullTypes[mergedType.Name] = &knownFullTypeDetails{}
-
+	c.mergedTypePostProcessing(mergedType)
 	return mergedType.Name, nil
 }
 

--- a/pkg/openapi/mutation.go
+++ b/pkg/openapi/mutation.go
@@ -146,7 +146,7 @@ func (c *converter) importMutationType() (*introspection.FullType, error) {
 					Description: getOperationDescription(operation),
 				}
 				if field.Name == "" {
-					field.Name = MakeFieldNameFromEndpoint(method, pathName)
+					field.Name = MakeFieldNameFromEndpointForMutation(method, pathName)
 				}
 
 				if operation.RequestBody != nil {

--- a/pkg/openapi/mutation.go
+++ b/pkg/openapi/mutation.go
@@ -61,12 +61,19 @@ func (c *converter) getInputValueFromRequestBody(field *introspection.Field, sta
 	if schema == nil {
 		typeName = c.tryMakeTypeNameFromOperation(status, operation)
 	} else {
-		typeName, err = c.getReturnType(schema)
-		if err != nil {
-			return err
-		}
-		if len(schema.Value.Enum) > 0 {
-			c.createOrGetEnumType(typeName, schema)
+		if schema.Value.OneOf != nil && len(schema.Value.OneOf) > 0 {
+			// Problem: Input object types cannot be composed of union types.
+			// Mitigation: The data will be stored in an arbitrary JSON type.
+			typeName = JsonScalarType
+			c.addScalarType(JsonScalarType, preDefinedScalarTypes[JsonScalarType])
+		} else {
+			typeName, err = c.getReturnType(schema)
+			if err != nil {
+				return err
+			}
+			if len(schema.Value.Enum) > 0 {
+				c.createOrGetEnumType(typeName, schema)
+			}
 		}
 	}
 	inputValue, err := c.getInputValue(typeName, schema)
@@ -76,6 +83,11 @@ func (c *converter) getInputValueFromRequestBody(field *introspection.Field, sta
 	if operation.RequestBody.Value.Required {
 		inputValue.Type = convertToNonNull(&inputValue.Type)
 	}
+
+	if typeName == JsonScalarType {
+		inputValue.Name = MakeParameterName(MakeInputTypeName(MakeTypeNameFromPathName(c.currentPathName)))
+	}
+
 	field.Args = append(field.Args, *inputValue)
 	return nil
 }

--- a/pkg/openapi/openapi.go
+++ b/pkg/openapi/openapi.go
@@ -20,6 +20,7 @@ type converter struct {
 	openapi         *openapi3.T
 	knownFullTypes  map[string]*knownFullTypeDetails
 	knownEnums      map[string]*introspection.FullType
+	knownUnions     map[string]*introspection.FullType
 	fullTypes       []introspection.FullType
 	currentPathName string
 	currentPathItem *openapi3.PathItem
@@ -34,6 +35,7 @@ func ImportParsedOpenAPIv3Document(document *openapi3.T, report *operationreport
 		openapi:        document,
 		knownFullTypes: make(map[string]*knownFullTypeDetails),
 		knownEnums:     make(map[string]*introspection.FullType),
+		knownUnions:    make(map[string]*introspection.FullType),
 		fullTypes:      make([]introspection.FullType, 0),
 	}
 	data := introspection.Data{}

--- a/pkg/openapi/openapi.go
+++ b/pkg/openapi/openapi.go
@@ -30,14 +30,18 @@ type knownFullTypeDetails struct {
 	hasDescription bool
 }
 
-func ImportParsedOpenAPIv3Document(document *openapi3.T, report *operationreport.Report) *ast.Document {
-	c := &converter{
+func newConverter(document *openapi3.T) *converter {
+	return &converter{
 		openapi:        document,
 		knownFullTypes: make(map[string]*knownFullTypeDetails),
 		knownEnums:     make(map[string]*introspection.FullType),
 		knownUnions:    make(map[string]*introspection.FullType),
 		fullTypes:      make([]introspection.FullType, 0),
 	}
+}
+
+func ImportParsedOpenAPIv3Document(document *openapi3.T, report *operationreport.Report) *ast.Document {
+	c := newConverter(document)
 	data := introspection.Data{}
 
 	queryType, err := c.importQueryType()

--- a/pkg/openapi/openapi.go
+++ b/pkg/openapi/openapi.go
@@ -20,7 +20,7 @@ type converter struct {
 	openapi         *openapi3.T
 	knownFullTypes  map[string]*knownFullTypeDetails
 	knownEnums      map[string]introspection.FullType
-	knownUnions     map[string]*introspection.FullType
+	knownUnions     map[string]introspection.FullType
 	fullTypes       []introspection.FullType
 	currentPathName string
 	currentPathItem *openapi3.PathItem
@@ -35,7 +35,7 @@ func newConverter(document *openapi3.T) *converter {
 		openapi:        document,
 		knownFullTypes: make(map[string]*knownFullTypeDetails),
 		knownEnums:     make(map[string]introspection.FullType),
-		knownUnions:    make(map[string]*introspection.FullType),
+		knownUnions:    make(map[string]introspection.FullType),
 		fullTypes:      make([]introspection.FullType, 0),
 	}
 }

--- a/pkg/openapi/openapi.go
+++ b/pkg/openapi/openapi.go
@@ -19,7 +19,7 @@ var (
 type converter struct {
 	openapi         *openapi3.T
 	knownFullTypes  map[string]*knownFullTypeDetails
-	knownEnums      map[string]*introspection.FullType
+	knownEnums      map[string]introspection.FullType
 	knownUnions     map[string]*introspection.FullType
 	fullTypes       []introspection.FullType
 	currentPathName string
@@ -34,7 +34,7 @@ func newConverter(document *openapi3.T) *converter {
 	return &converter{
 		openapi:        document,
 		knownFullTypes: make(map[string]*knownFullTypeDetails),
-		knownEnums:     make(map[string]*introspection.FullType),
+		knownEnums:     make(map[string]introspection.FullType),
 		knownUnions:    make(map[string]*introspection.FullType),
 		fullTypes:      make([]introspection.FullType, 0),
 	}

--- a/pkg/openapi/openapi_test.go
+++ b/pkg/openapi/openapi_test.go
@@ -123,6 +123,10 @@ func TestOpenAPI_v3_0_0(t *testing.T) {
 		testFixtureFile(t, "v3.0.0", "oneOf-response-type.yaml")
 	})
 
+	t.Run("oneOf-response-type-composition.yaml", func(t *testing.T) {
+		testFixtureFile(t, "v3.0.0", "oneOf-response-type-composition.yaml")
+	})
+
 	t.Run("allOf-input-type.yaml", func(t *testing.T) {
 		testFixtureFile(t, "v3.0.0", "allOf-input-type.yaml")
 	})

--- a/pkg/openapi/openapi_test.go
+++ b/pkg/openapi/openapi_test.go
@@ -138,4 +138,12 @@ func TestOpenAPI_v3_0_0(t *testing.T) {
 	t.Run("allOf-response-type-composition.yaml", func(t *testing.T) {
 		testFixtureFile(t, "v3.0.0", "allOf-response-type-composition.yaml")
 	})
+
+	t.Run("allOf-query-composition.yaml", func(t *testing.T) {
+		testFixtureFile(t, "v3.0.0", "allOf-query-composition.yaml")
+	})
+
+	t.Run("allOf-query-response-type.yaml", func(t *testing.T) {
+		testFixtureFile(t, "v3.0.0", "allOf-query-response-type.yaml")
+	})
 }

--- a/pkg/openapi/openapi_test.go
+++ b/pkg/openapi/openapi_test.go
@@ -33,6 +33,7 @@ func testFixtureFile(t *testing.T, version, name string) {
 	}
 
 	graphqlDoc, err := os.ReadFile(fmt.Sprintf("./fixtures/%s/%s.graphql", version, name))
+	fmt.Println(w.String())
 	require.NoError(t, err)
 	require.Equal(t, string(graphqlDoc), w.String())
 }
@@ -116,5 +117,9 @@ func TestOpenAPI_v3_0_0(t *testing.T) {
 
 	t.Run("oneOf-input-type.yaml", func(t *testing.T) {
 		testFixtureFile(t, "v3.0.0", "oneOf-input-type.yaml")
+	})
+
+	t.Run("oneOf-response-type.yaml", func(t *testing.T) {
+		testFixtureFile(t, "v3.0.0", "oneOf-response-type.yaml")
 	})
 }

--- a/pkg/openapi/openapi_test.go
+++ b/pkg/openapi/openapi_test.go
@@ -134,4 +134,8 @@ func TestOpenAPI_v3_0_0(t *testing.T) {
 	t.Run("allOf-input-type-composition.yaml", func(t *testing.T) {
 		testFixtureFile(t, "v3.0.0", "allOf-input-type-composition.yaml")
 	})
+
+	t.Run("allOf-response-type-composition.yaml", func(t *testing.T) {
+		testFixtureFile(t, "v3.0.0", "allOf-response-type-composition.yaml")
+	})
 }

--- a/pkg/openapi/openapi_test.go
+++ b/pkg/openapi/openapi_test.go
@@ -113,4 +113,8 @@ func TestOpenAPI_v3_0_0(t *testing.T) {
 	t.Run("enum-properties.yaml", func(t *testing.T) {
 		testFixtureFile(t, "v3.0.0", "enum-properties.yaml")
 	})
+
+	t.Run("oneOf-input-type.yaml", func(t *testing.T) {
+		testFixtureFile(t, "v3.0.0", "oneOf-input-type.yaml")
+	})
 }

--- a/pkg/openapi/openapi_test.go
+++ b/pkg/openapi/openapi_test.go
@@ -126,4 +126,8 @@ func TestOpenAPI_v3_0_0(t *testing.T) {
 	t.Run("allOf-input-type.yaml", func(t *testing.T) {
 		testFixtureFile(t, "v3.0.0", "allOf-input-type.yaml")
 	})
+
+	t.Run("allOf-response-type.yaml", func(t *testing.T) {
+		testFixtureFile(t, "v3.0.0", "allOf-response-type.yaml")
+	})
 }

--- a/pkg/openapi/openapi_test.go
+++ b/pkg/openapi/openapi_test.go
@@ -130,4 +130,8 @@ func TestOpenAPI_v3_0_0(t *testing.T) {
 	t.Run("allOf-response-type.yaml", func(t *testing.T) {
 		testFixtureFile(t, "v3.0.0", "allOf-response-type.yaml")
 	})
+
+	t.Run("allOf-input-type-composition.yaml", func(t *testing.T) {
+		testFixtureFile(t, "v3.0.0", "allOf-input-type-composition.yaml")
+	})
 }

--- a/pkg/openapi/openapi_test.go
+++ b/pkg/openapi/openapi_test.go
@@ -150,4 +150,16 @@ func TestOpenAPI_v3_0_0(t *testing.T) {
 	t.Run("allOf-query-response-type.yaml", func(t *testing.T) {
 		testFixtureFile(t, "v3.0.0", "allOf-query-response-type.yaml")
 	})
+
+	t.Run("anyOf-input-type.yaml", func(t *testing.T) {
+		testFixtureFile(t, "v3.0.0", "anyOf-input-type.yaml")
+	})
+
+	t.Run("anyOf-response-type.yaml", func(t *testing.T) {
+		testFixtureFile(t, "v3.0.0", "anyOf-response-type.yaml")
+	})
+
+	t.Run("anyOf-query-response-type.yaml", func(t *testing.T) {
+		testFixtureFile(t, "v3.0.0", "anyOf-query-response-type.yaml")
+	})
 }

--- a/pkg/openapi/openapi_test.go
+++ b/pkg/openapi/openapi_test.go
@@ -122,4 +122,8 @@ func TestOpenAPI_v3_0_0(t *testing.T) {
 	t.Run("oneOf-response-type.yaml", func(t *testing.T) {
 		testFixtureFile(t, "v3.0.0", "oneOf-response-type.yaml")
 	})
+
+	t.Run("allOf-input-type.yaml", func(t *testing.T) {
+		testFixtureFile(t, "v3.0.0", "allOf-input-type.yaml")
+	})
 }

--- a/pkg/openapi/query.go
+++ b/pkg/openapi/query.go
@@ -3,14 +3,12 @@ package openapi
 import (
 	"errors"
 	"fmt"
-	"net/http"
-	"sort"
-	"strconv"
-	"strings"
-
 	"github.com/TykTechnologies/graphql-go-tools/pkg/introspection"
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/iancoleman/strcase"
+	"net/http"
+	"sort"
+	"strconv"
 )
 
 func (c *converter) importQueryType() (*introspection.FullType, error) {
@@ -79,7 +77,7 @@ func (c *converter) importQueryType() (*introspection.FullType, error) {
 					return nil, err
 				}
 				if queryField.Name == "" {
-					queryField.Name = strings.Trim(pathName, "/")
+					queryField.Name = MakeFieldNameFromEndpoint(pathName)
 				}
 				queryType.Fields = append(queryType.Fields, *queryField)
 			}

--- a/pkg/openapi/typename.go
+++ b/pkg/openapi/typename.go
@@ -58,6 +58,10 @@ func (c *converter) getReturnType(schemaRef *openapi3.SchemaRef) (string, error)
 	if schemaRef.Value.OneOf != nil && len(schemaRef.Value.OneOf) > 0 {
 		return MakeTypeNameFromPathName(c.currentPathName), nil
 	}
+
+	if schemaRef.Value.AllOf != nil && len(schemaRef.Value.AllOf) > 0 {
+		return MakeTypeNameFromPathName(c.currentPathName), nil
+	}
 	return "", err
 }
 

--- a/pkg/openapi/typename.go
+++ b/pkg/openapi/typename.go
@@ -2,7 +2,6 @@ package openapi
 
 import (
 	"errors"
-
 	"github.com/getkin/kin-openapi/openapi3"
 )
 
@@ -31,7 +30,7 @@ func (c *converter) tryExtractTypeName(schemaRef *openapi3.SchemaRef) (graphqlTy
 	return
 }
 
-func (c *converter) getReturnType(schemaRef *openapi3.SchemaRef) (graphqlTypeName string, err error) {
+func (c *converter) getTypeNameFromSchema(schemaRef *openapi3.SchemaRef) (graphqlTypeName string, err error) {
 	if schemaRef.Value.Type != "object" && schemaRef.Value.Type != "array" {
 		if schemaRef.Ref != "" {
 			return extractFullTypeNameFromRef(schemaRef.Ref)
@@ -48,6 +47,18 @@ func (c *converter) getReturnType(schemaRef *openapi3.SchemaRef) (graphqlTypeNam
 		return c.tryExtractTypeName(schemaRef)
 	}
 	return graphqlTypeName, err
+}
+
+func (c *converter) getReturnType(schemaRef *openapi3.SchemaRef) (string, error) {
+	typeName, err := c.getTypeNameFromSchema(schemaRef)
+	if err == nil {
+		return typeName, nil
+	}
+
+	if schemaRef.Value.OneOf != nil && len(schemaRef.Value.OneOf) > 0 {
+		return MakeTypeNameFromPathName(c.currentPathName), nil
+	}
+	return "", err
 }
 
 // getGraphQLTypeName returns the GraphQL type name corresponding to the given OpenAPI schema reference.

--- a/pkg/openapi/typename.go
+++ b/pkg/openapi/typename.go
@@ -12,7 +12,7 @@ func (c *converter) tryExtractTypeName(schemaRef *openapi3.SchemaRef) (graphqlTy
 	if schemaRef.Value.Type == "object" {
 		// If the schema value doesn't have any properties, the object will be stored in an arbitrary JSON type.
 		if len(schemaRef.Value.Properties) == 0 {
-			graphqlTypeName = "JSON"
+			graphqlTypeName = JsonScalarType
 			c.addScalarType(graphqlTypeName, preDefinedScalarTypes[graphqlTypeName])
 		} else {
 			// Unnamed object

--- a/pkg/openapi/typename.go
+++ b/pkg/openapi/typename.go
@@ -62,6 +62,10 @@ func (c *converter) getReturnType(schemaRef *openapi3.SchemaRef) (string, error)
 	if schemaRef.Value.AllOf != nil && len(schemaRef.Value.AllOf) > 0 {
 		return MakeTypeNameFromPathName(c.currentPathName), nil
 	}
+
+	if schemaRef.Value.AnyOf != nil && len(schemaRef.Value.AnyOf) > 0 {
+		return MakeTypeNameFromPathName(c.currentPathName), nil
+	}
 	return "", err
 }
 

--- a/pkg/openapi/utils.go
+++ b/pkg/openapi/utils.go
@@ -10,8 +10,10 @@ import (
 	"github.com/iancoleman/strcase"
 )
 
+const JsonScalarType = "JSON"
+
 var preDefinedScalarTypes = map[string]string{
-	"JSON": "The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).",
+	JsonScalarType: "The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).",
 }
 
 // addScalarType adds a new scalar type to the converter's known full types list.

--- a/pkg/openapi/utils.go
+++ b/pkg/openapi/utils.go
@@ -2,12 +2,11 @@ package openapi
 
 import (
 	"fmt"
-	"strings"
-
 	"github.com/TykTechnologies/graphql-go-tools/pkg/introspection"
 	"github.com/TykTechnologies/graphql-go-tools/pkg/lexer/literal"
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/iancoleman/strcase"
+	"strings"
 )
 
 const JsonScalarType = "JSON"
@@ -44,9 +43,30 @@ func makeListItemFromTypeName(typeName string) string {
 	return fmt.Sprintf("%sListItem", strcase.ToCamel(typeName))
 }
 
-func MakeTypeNameFromPathName(name string) string {
+// cleanupEndpoint takes a string `name` and splits it by the forward slash ('/').
+// It creates an empty slice `result` to store the cleaned-up words.
+// For each word in the `parsed` slice, it checks if the word has length zero or starts with '{'.
+// If either of these conditions is true, it skips to the next word.
+// Otherwise, it appends the word to the `result` slice.
+// Finally, it returns the `result` slice containing the cleaned-up words.
+func cleanupEndpoint(name string) []string {
 	parsed := strings.Split(name, "/")
-	return strcase.ToCamel(parsed[len(parsed)-1])
+	var result []string
+	for _, word := range parsed {
+		if len(word) == 0 {
+			continue
+		}
+		if strings.HasPrefix(word, "{") {
+			continue
+		}
+		result = append(result, word)
+	}
+	return result
+}
+
+func MakeTypeNameFromPathName(name string) string {
+	result := cleanupEndpoint(name)
+	return strcase.ToCamel(strings.Join(result, " "))
 }
 
 func MakeInputTypeName(name string) string {
@@ -58,12 +78,15 @@ func MakeFieldNameFromOperationID(operationID string) string {
 	return strcase.ToLowerCamel(operationID)
 }
 
-func MakeFieldNameFromEndpoint(method, endpoint string) string {
-	endpoint = strings.Replace(endpoint, "/", " ", -1)
-	endpoint = strings.Replace(endpoint, "{", " ", -1)
-	endpoint = strings.Replace(endpoint, "}", " ", -1)
-	endpoint = strings.TrimSpace(endpoint)
-	return strcase.ToLowerCamel(fmt.Sprintf("%s %s", strings.ToLower(method), endpoint))
+func MakeFieldNameFromEndpointForMutation(method, endpoint string) string {
+	result := []string{strings.ToLower(method)}
+	result = append(result, cleanupEndpoint(endpoint)...)
+	return strcase.ToLowerCamel(strings.Join(result, " "))
+}
+
+func MakeFieldNameFromEndpoint(endpoint string) string {
+	result := cleanupEndpoint(endpoint)
+	return strcase.ToLowerCamel(strings.Join(result, " "))
 }
 
 func MakeParameterName(name string) string {

--- a/v2/pkg/openapi/enum.go
+++ b/v2/pkg/openapi/enum.go
@@ -17,13 +17,13 @@ func getEnumTypeRef() introspection.TypeRef {
 // Otherwise, a new enum type is created and stored in the knownEnums map and fullTypes slice.
 // It populates the enum values of the enum type based on the enum values in the schema.
 // Finally, it returns the created or retrieved enum type.
-func (c *converter) createOrGetEnumType(name string, schema *openapi3.SchemaRef) *introspection.FullType {
+func (c *converter) createOrGetEnumType(name string, schema *openapi3.SchemaRef) introspection.FullType {
 	name = strcase.ToCamel(name)
 	if enumType, ok := c.knownEnums[name]; ok {
 		return enumType
 	}
 
-	enumType := &introspection.FullType{
+	enumType := introspection.FullType{
 		Kind:        introspection.ENUM,
 		Name:        name,
 		Description: schema.Value.Description,
@@ -35,7 +35,7 @@ func (c *converter) createOrGetEnumType(name string, schema *openapi3.SchemaRef)
 		}
 		enumType.EnumValues = append(enumType.EnumValues, enumValue)
 	}
-	c.fullTypes = append(c.fullTypes, *enumType)
+	c.fullTypes = append(c.fullTypes, enumType)
 	c.knownEnums[name] = enumType
 	return enumType
 }

--- a/v2/pkg/openapi/field.go
+++ b/v2/pkg/openapi/field.go
@@ -71,12 +71,14 @@ func (c *converter) processSchemaProperties(fullType *introspection.FullType, sc
 		if err != nil {
 			return err
 		}
+		if len(schemaRef.Value.Enum) > 0 {
+			c.createOrGetEnumType(*typeRef.Name, schemaRef)
+		}
 		field := introspection.Field{
 			Name:        name,
 			Type:        *typeRef,
 			Description: schemaRef.Value.Description,
 		}
-
 		fullType.Fields = append(fullType.Fields, field)
 		sort.Slice(fullType.Fields, func(i, j int) bool {
 			return fullType.Fields[i].Name < fullType.Fields[j].Name

--- a/v2/pkg/openapi/fixtures/v3.0.0/EmployeesApiBasic.graphql
+++ b/v2/pkg/openapi/fixtures/v3.0.0/EmployeesApiBasic.graphql
@@ -10,7 +10,7 @@ type Query {
 
 type Mutation {
     "Uses the updateEmployee Db2 z/OS asset"
-    putEmployeesId(employeeBodyInput: EmployeeBodyInput, id: String!): EmployeeBody
+    putEmployees(employeeBodyInput: EmployeeBodyInput, id: String!): EmployeeBody
 }
 
 type EmployeeBody {

--- a/v2/pkg/openapi/fixtures/v3.0.0/allOf-input-type-composition.graphql
+++ b/v2/pkg/openapi/fixtures/v3.0.0/allOf-input-type-composition.graphql
@@ -1,0 +1,38 @@
+schema {
+    query: QueryPlaceholder
+    mutation: Mutation
+}
+
+"Placeholder object"
+type QueryPlaceholder {
+    "Placeholder field"
+    message: String
+}
+
+type Mutation {
+    postPets(pets: PetsInput): Dog
+}
+
+enum Breed {
+    DINGO
+    HUSKY
+    RETRIEVER
+    SHEPHERD
+}
+
+type Dog {
+    bark: Boolean
+    breed: Breed
+    pet_type: String!
+}
+
+input PetsInput {
+    address: String
+    age: Int
+    bark: Boolean
+    breed: Breed
+    color: String
+    name: String
+    pet_type: String!
+    surname: String
+}

--- a/v2/pkg/openapi/fixtures/v3.0.0/allOf-input-type-composition.yaml
+++ b/v2/pkg/openapi/fixtures/v3.0.0/allOf-input-type-composition.yaml
@@ -1,0 +1,66 @@
+openapi: "3.0.0"
+info:
+  title: Pets API
+  version: 1.0.0
+servers:
+  - url: http://localhost:3004/
+
+paths:
+  /pets:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/Dog'
+                - type: object
+                  properties:
+                    name:
+                      type: string
+                    surname:
+                      type: string
+                    age:
+                      type: integer
+                    address:
+                      type: string
+                - $ref: '#/components/schemas/Hamster'
+      responses:
+        '200':
+          description: Pets response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Dog'
+
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - pet_type
+      properties:
+        pet_type:
+          type: string
+      discriminator:
+        propertyName: pet_type
+    Dog:     # "Dog" is a value for the pet_type property (the discriminator value)
+      allOf: # Combines the main `Pet` schema with `Dog`-specific properties
+        - $ref: '#/components/schemas/Pet'
+        - type: object
+          # all other properties specific to a `Dog`
+          properties:
+            bark:
+              type: boolean
+            breed:
+              type: string
+              enum: [Dingo, Husky, Retriever, Shepherd]
+    Hamster:
+      allOf:
+        - $ref: '#/components/schemas/Pet'
+        - type: object
+          properties:
+            age:
+              type: integer
+            color:
+              type: string

--- a/v2/pkg/openapi/fixtures/v3.0.0/allOf-input-type.graphql
+++ b/v2/pkg/openapi/fixtures/v3.0.0/allOf-input-type.graphql
@@ -1,0 +1,34 @@
+schema {
+    query: QueryPlaceholder
+    mutation: Mutation
+}
+
+"Placeholder object"
+type QueryPlaceholder {
+    "Placeholder field"
+    message: String
+}
+
+type Mutation {
+    postPets(pets: PetsInput): Dog
+}
+
+enum Breed {
+    DINGO
+    HUSKY
+    RETRIEVER
+    SHEPHERD
+}
+
+type Dog {
+    bark: Boolean
+    breed: Breed
+}
+
+input PetsInput {
+    age: Int
+    bark: Boolean
+    breed: Breed
+    color: String
+    hunts: Boolean
+}

--- a/v2/pkg/openapi/fixtures/v3.0.0/allOf-input-type.yaml
+++ b/v2/pkg/openapi/fixtures/v3.0.0/allOf-input-type.yaml
@@ -1,0 +1,50 @@
+openapi: "3.0.0"
+info:
+  title: Pets API
+  version: 1.0.0
+servers:
+  - url: http://localhost:3004/
+
+paths:
+  /pets:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/Cat'
+                - $ref: '#/components/schemas/Dog'
+                - $ref: '#/components/schemas/Hamster'
+      responses:
+        '200':
+          description: Pets response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Dog'
+
+components:
+  schemas:
+    Dog:
+      type: object
+      properties:
+        bark:
+          type: boolean
+        breed:
+          type: string
+          enum: [Dingo, Husky, Retriever, Shepherd]
+    Cat:
+      type: object
+      properties:
+        hunts:
+          type: boolean
+        age:
+          type: integer
+    Hamster:
+      type: object
+      properties:
+        age:
+          type: integer
+        color:
+          type: string

--- a/v2/pkg/openapi/fixtures/v3.0.0/allOf-query-composition.graphql
+++ b/v2/pkg/openapi/fixtures/v3.0.0/allOf-query-composition.graphql
@@ -1,0 +1,25 @@
+schema {
+    query: Query
+}
+
+type Query {
+    pets: Pets
+}
+
+enum Breed {
+    DINGO
+    HUSKY
+    RETRIEVER
+    SHEPHERD
+}
+
+type Pets {
+    address: String
+    age: Int
+    bark: Boolean
+    breed: Breed
+    color: String
+    name: String
+    pet_type: String!
+    surname: String
+}

--- a/v2/pkg/openapi/fixtures/v3.0.0/allOf-query-composition.yaml
+++ b/v2/pkg/openapi/fixtures/v3.0.0/allOf-query-composition.yaml
@@ -1,0 +1,60 @@
+openapi: "3.0.0"
+info:
+  title: Pets API
+  version: 1.0.0
+servers:
+  - url: http://localhost:3004/
+
+paths:
+  /pets:
+    get:
+      responses:
+        '200':
+          description: Pets response
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Dog'
+                  - type: object
+                    properties:
+                      name:
+                        type: string
+                      surname:
+                        type: string
+                      age:
+                        type: integer
+                      address:
+                        type: string
+                  - $ref: '#/components/schemas/Hamster'
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - pet_type
+      properties:
+        pet_type:
+          type: string
+      discriminator:
+        propertyName: pet_type
+    Dog:     # "Dog" is a value for the pet_type property (the discriminator value)
+      allOf: # Combines the main `Pet` schema with `Dog`-specific properties
+        - $ref: '#/components/schemas/Pet'
+        - type: object
+          # all other properties specific to a `Dog`
+          properties:
+            bark:
+              type: boolean
+            breed:
+              type: string
+              enum: [Dingo, Husky, Retriever, Shepherd]
+    Hamster:
+      allOf:
+        - $ref: '#/components/schemas/Pet'
+        - type: object
+          properties:
+            age:
+              type: integer
+            color:
+              type: string

--- a/v2/pkg/openapi/fixtures/v3.0.0/allOf-query-response-type.graphql
+++ b/v2/pkg/openapi/fixtures/v3.0.0/allOf-query-response-type.graphql
@@ -1,0 +1,22 @@
+schema {
+    query: Query
+}
+
+type Query {
+    pets: Pets
+}
+
+enum Breed {
+    DINGO
+    HUSKY
+    RETRIEVER
+    SHEPHERD
+}
+
+type Pets {
+    age: Int
+    bark: Boolean
+    breed: Breed
+    color: String
+    hunts: Boolean
+}

--- a/v2/pkg/openapi/fixtures/v3.0.0/allOf-query-response-type.yaml
+++ b/v2/pkg/openapi/fixtures/v3.0.0/allOf-query-response-type.yaml
@@ -1,0 +1,45 @@
+openapi: "3.0.0"
+info:
+  title: Pets API
+  version: 1.0.0
+servers:
+  - url: http://localhost:3004/
+
+paths:
+  /pets:
+    get:
+      responses:
+        '200':
+          description: Pets response
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Cat'
+                  - $ref: '#/components/schemas/Dog'
+                  - $ref: '#/components/schemas/Hamster'
+
+components:
+  schemas:
+    Dog:
+      type: object
+      properties:
+        bark:
+          type: boolean
+        breed:
+          type: string
+          enum: [Dingo, Husky, Retriever, Shepherd]
+    Cat:
+      type: object
+      properties:
+        hunts:
+          type: boolean
+        age:
+          type: integer
+    Hamster:
+      type: object
+      properties:
+        age:
+          type: integer
+        color:
+          type: string

--- a/v2/pkg/openapi/fixtures/v3.0.0/allOf-response-type-composition.graphql
+++ b/v2/pkg/openapi/fixtures/v3.0.0/allOf-response-type-composition.graphql
@@ -1,0 +1,43 @@
+schema {
+    query: QueryPlaceholder
+    mutation: Mutation
+}
+
+"Placeholder object"
+type QueryPlaceholder {
+    "Placeholder field"
+    message: String
+}
+
+type Mutation {
+    postPets(pets: PetsInput): Pets
+}
+
+enum Breed {
+    DINGO
+    HUSKY
+    RETRIEVER
+    SHEPHERD
+}
+
+type Pets {
+    address: String
+    age: Int
+    bark: Boolean
+    breed: Breed
+    color: String
+    name: String
+    pet_type: String!
+    surname: String
+}
+
+input PetsInput {
+    address: String
+    age: Int
+    bark: Boolean
+    breed: Breed
+    color: String
+    name: String
+    pet_type: String!
+    surname: String
+}

--- a/v2/pkg/openapi/fixtures/v3.0.0/allOf-response-type-composition.yaml
+++ b/v2/pkg/openapi/fixtures/v3.0.0/allOf-response-type-composition.yaml
@@ -1,0 +1,77 @@
+openapi: "3.0.0"
+info:
+  title: Pets API
+  version: 1.0.0
+servers:
+  - url: http://localhost:3004/
+
+paths:
+  /pets:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/Dog'
+                - type: object
+                  properties:
+                    name:
+                      type: string
+                    surname:
+                      type: string
+                    age:
+                      type: integer
+                    address:
+                      type: string
+                - $ref: '#/components/schemas/Hamster'
+      responses:
+        '200':
+          description: Pets response
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Dog'
+                  - type: object
+                    properties:
+                      name:
+                        type: string
+                      surname:
+                        type: string
+                      age:
+                        type: integer
+                      address:
+                        type: string
+                  - $ref: '#/components/schemas/Hamster'
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - pet_type
+      properties:
+        pet_type:
+          type: string
+      discriminator:
+        propertyName: pet_type
+    Dog:     # "Dog" is a value for the pet_type property (the discriminator value)
+      allOf: # Combines the main `Pet` schema with `Dog`-specific properties
+        - $ref: '#/components/schemas/Pet'
+        - type: object
+          # all other properties specific to a `Dog`
+          properties:
+            bark:
+              type: boolean
+            breed:
+              type: string
+              enum: [Dingo, Husky, Retriever, Shepherd]
+    Hamster:
+      allOf:
+        - $ref: '#/components/schemas/Pet'
+        - type: object
+          properties:
+            age:
+              type: integer
+            color:
+              type: string

--- a/v2/pkg/openapi/fixtures/v3.0.0/allOf-response-type.graphql
+++ b/v2/pkg/openapi/fixtures/v3.0.0/allOf-response-type.graphql
@@ -1,0 +1,32 @@
+schema {
+    query: Query
+    mutation: Mutation
+}
+
+type Query {
+    pets: Pets
+}
+
+type Mutation {
+    postPets(catInput: CatInput): Pets
+}
+
+enum Breed {
+    DINGO
+    HUSKY
+    RETRIEVER
+    SHEPHERD
+}
+
+input CatInput {
+    age: Int
+    hunts: Boolean
+}
+
+type Pets {
+    age: Int
+    bark: Boolean
+    breed: Breed
+    color: String
+    hunts: Boolean
+}

--- a/v2/pkg/openapi/fixtures/v3.0.0/allOf-response-type.yaml
+++ b/v2/pkg/openapi/fixtures/v3.0.0/allOf-response-type.yaml
@@ -1,0 +1,61 @@
+openapi: "3.0.0"
+info:
+  title: Pets API
+  version: 1.0.0
+servers:
+  - url: http://localhost:3004/
+
+paths:
+  /pets:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Cat'
+      responses:
+        '200':
+          description: Pets response
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Cat'
+                  - $ref: '#/components/schemas/Dog'
+                  - $ref: '#/components/schemas/Hamster'
+
+    get:
+      responses:
+        '200':
+          description: Pets response
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Cat'
+                  - $ref: '#/components/schemas/Dog'
+                  - $ref: '#/components/schemas/Hamster'
+components:
+  schemas:
+    Dog:
+      type: object
+      properties:
+        bark:
+          type: boolean
+        breed:
+          type: string
+          enum: [Dingo, Husky, Retriever, Shepherd]
+    Cat:
+      type: object
+      properties:
+        hunts:
+          type: boolean
+        age:
+          type: integer
+    Hamster:
+      type: object
+      properties:
+        age:
+          type: integer
+        color:
+          type: string

--- a/v2/pkg/openapi/fixtures/v3.0.0/anyOf-input-type.graphql
+++ b/v2/pkg/openapi/fixtures/v3.0.0/anyOf-input-type.graphql
@@ -1,0 +1,38 @@
+schema {
+    query: QueryPlaceholder
+    mutation: Mutation
+}
+
+"Placeholder object"
+type QueryPlaceholder {
+    "Placeholder field"
+    message: String
+}
+
+type Mutation {
+    postPets(pets: PetsInput): Dog
+}
+
+enum Breed {
+    DINGO
+    HUSKY
+    RETRIEVER
+    SHEPHERD
+}
+
+type Dog {
+    bark: Boolean
+    breed: Breed
+}
+
+enum PetType {
+    CAT
+    DOG
+}
+
+input PetsInput {
+    age: Int!
+    hunts: Boolean
+    nickname: String
+    pet_type: PetType
+}

--- a/v2/pkg/openapi/fixtures/v3.0.0/anyOf-input-type.yaml
+++ b/v2/pkg/openapi/fixtures/v3.0.0/anyOf-input-type.yaml
@@ -1,0 +1,54 @@
+openapi: "3.0.0"
+info:
+  title: Pets API
+  version: 1.0.0
+servers:
+  - url: http://localhost:3004/
+
+paths:
+  /pets:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              anyOf:
+                - $ref: '#/components/schemas/PetByAge'
+                - $ref: '#/components/schemas/PetByType'
+      responses:
+        '200':
+          description: Pets response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Dog'
+components:
+  schemas:
+    Dog:
+      type: object
+      properties:
+        bark:
+          type: boolean
+        breed:
+          type: string
+          enum: [ Dingo, Husky, Retriever, Shepherd ]
+    PetByAge:
+      type: object
+      properties:
+        age:
+          type: integer
+        nickname:
+          type: string
+      required:
+        - age
+
+    PetByType:
+      type: object
+      properties:
+        pet_type:
+          type: string
+          enum: [Cat, Dog]
+        hunts:
+          type: boolean
+      required:
+        - pet_type

--- a/v2/pkg/openapi/fixtures/v3.0.0/anyOf-query-response-type.graphql
+++ b/v2/pkg/openapi/fixtures/v3.0.0/anyOf-query-response-type.graphql
@@ -1,0 +1,19 @@
+schema {
+    query: Query
+}
+
+type Query {
+    petsFoobar(id: Int!): PetsFoobar
+}
+
+enum PetType {
+    CAT
+    DOG
+}
+
+type PetsFoobar {
+    age: Int!
+    hunts: Boolean
+    nickname: String
+    pet_type: PetType
+}

--- a/v2/pkg/openapi/fixtures/v3.0.0/anyOf-query-response-type.yaml
+++ b/v2/pkg/openapi/fixtures/v3.0.0/anyOf-query-response-type.yaml
@@ -1,0 +1,50 @@
+openapi: "3.0.0"
+info:
+  title: Pets API
+  version: 1.0.0
+servers:
+  - url: http://localhost:3004/
+
+paths:
+  /pets/{id}/foobar:
+    get:
+      parameters:
+        - name: id
+          in: path
+          description: ID of Pet to fetch
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: Pets response
+          content:
+            application/json:
+              schema:
+                anyOf:
+                  - $ref: '#/components/schemas/PetByAge'
+                  - $ref: '#/components/schemas/PetByType'
+
+components:
+  schemas:
+    PetByAge:
+      type: object
+      properties:
+        age:
+          type: integer
+        nickname:
+          type: string
+      required:
+        - age
+
+    PetByType:
+      type: object
+      properties:
+        pet_type:
+          type: string
+          enum: [Cat, Dog]
+        hunts:
+          type: boolean
+      required:
+        - pet_type

--- a/v2/pkg/openapi/fixtures/v3.0.0/anyOf-response-type.graphql
+++ b/v2/pkg/openapi/fixtures/v3.0.0/anyOf-response-type.graphql
@@ -1,0 +1,33 @@
+schema {
+    query: QueryPlaceholder
+    mutation: Mutation
+}
+
+"Placeholder object"
+type QueryPlaceholder {
+    "Placeholder field"
+    message: String
+}
+
+type Mutation {
+    postPets(pets: PetsInput): Pets
+}
+
+enum PetType {
+    CAT
+    DOG
+}
+
+type Pets {
+    age: Int!
+    hunts: Boolean
+    nickname: String
+    pet_type: PetType
+}
+
+input PetsInput {
+    age: Int!
+    hunts: Boolean
+    nickname: String
+    pet_type: PetType
+}

--- a/v2/pkg/openapi/fixtures/v3.0.0/anyOf-response-type.yaml
+++ b/v2/pkg/openapi/fixtures/v3.0.0/anyOf-response-type.yaml
@@ -1,0 +1,49 @@
+openapi: "3.0.0"
+info:
+  title: Pets API
+  version: 1.0.0
+servers:
+  - url: http://localhost:3004/
+
+paths:
+  /pets:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              anyOf:
+                - $ref: '#/components/schemas/PetByAge'
+                - $ref: '#/components/schemas/PetByType'
+      responses:
+        '200':
+          description: Pets response
+          content:
+            application/json:
+              schema:
+                anyOf:
+                  - $ref: '#/components/schemas/PetByAge'
+                  - $ref: '#/components/schemas/PetByType'
+
+components:
+  schemas:
+    PetByAge:
+      type: object
+      properties:
+        age:
+          type: integer
+        nickname:
+          type: string
+      required:
+        - age
+
+    PetByType:
+      type: object
+      properties:
+        pet_type:
+          type: string
+          enum: [Cat, Dog]
+        hunts:
+          type: boolean
+      required:
+        - pet_type

--- a/v2/pkg/openapi/fixtures/v3.0.0/oneOf-input-type.graphql
+++ b/v2/pkg/openapi/fixtures/v3.0.0/oneOf-input-type.graphql
@@ -1,0 +1,29 @@
+schema {
+    query: QueryPlaceholder
+    mutation: Mutation
+}
+
+"Placeholder object"
+type QueryPlaceholder {
+    "Placeholder field"
+    message: String
+}
+
+type Mutation {
+    postPets(petsInput: JSON): Dog
+}
+
+enum Breed {
+    DINGO
+    HUSKY
+    RETRIEVER
+    SHEPHERD
+}
+
+type Dog {
+    bark: Boolean
+    breed: Breed
+}
+
+"The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf)."
+scalar JSON

--- a/v2/pkg/openapi/fixtures/v3.0.0/oneOf-input-type.yaml
+++ b/v2/pkg/openapi/fixtures/v3.0.0/oneOf-input-type.yaml
@@ -1,0 +1,50 @@
+openapi: "3.0.0"
+info:
+  title: Pets API
+  version: 1.0.0
+servers:
+  - url: http://localhost:3004/
+
+paths:
+  /pets:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - $ref: '#/components/schemas/Cat'
+                - $ref: '#/components/schemas/Dog'
+                - $ref: '#/components/schemas/Hamster'
+      responses:
+        '200':
+          description: Pets response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Dog'
+
+components:
+  schemas:
+    Dog:
+      type: object
+      properties:
+        bark:
+          type: boolean
+        breed:
+          type: string
+          enum: [Dingo, Husky, Retriever, Shepherd]
+    Cat:
+      type: object
+      properties:
+        hunts:
+          type: boolean
+        age:
+          type: integer
+    Hamster:
+      type: object
+      properties:
+        age:
+          type: integer
+        color:
+          type: string

--- a/v2/pkg/openapi/fixtures/v3.0.0/oneOf-response-type-composition.graphql
+++ b/v2/pkg/openapi/fixtures/v3.0.0/oneOf-response-type-composition.graphql
@@ -1,0 +1,52 @@
+schema {
+    query: QueryPlaceholder
+    mutation: Mutation
+}
+
+"Placeholder object"
+type QueryPlaceholder {
+    "Placeholder field"
+    message: String
+}
+
+type Mutation {
+    postPets(petsInput: JSON): Pets
+}
+
+enum Breed {
+    DINGO
+    HUSKY
+    RETRIEVER
+    SHEPHERD
+}
+
+type Cat {
+    age: Int
+    hunts: Boolean
+}
+
+type Dog {
+    bark: Boolean
+    breed: Breed
+}
+
+type Hamster {
+    age: Int
+    color: String
+}
+
+"The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf)."
+scalar JSON
+
+union Pets = Cat | Dog | Hamster | PetsMember | PetsMember2
+
+type PetsMember {
+    address: String
+    age: Int
+    name: String
+    surname: String
+}
+
+type PetsMember2 {
+    username: String
+}

--- a/v2/pkg/openapi/fixtures/v3.0.0/oneOf-response-type-composition.yaml
+++ b/v2/pkg/openapi/fixtures/v3.0.0/oneOf-response-type-composition.yaml
@@ -1,0 +1,78 @@
+openapi: "3.0.0"
+info:
+  title: Pets API
+  version: 1.0.0
+servers:
+  - url: http://localhost:3004/
+
+paths:
+  /pets:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - $ref: '#/components/schemas/Cat'
+                - $ref: '#/components/schemas/Dog'
+                - $ref: '#/components/schemas/Hamster'
+                - type: object
+                  properties:
+                    name:
+                      type: string
+                    surname:
+                      type: string
+                    age:
+                      type: integer
+                    address:
+                      type: string
+      responses:
+        '200':
+          description: Pets response
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/Cat'
+                  - $ref: '#/components/schemas/Dog'
+                  - $ref: '#/components/schemas/Hamster'
+                  - type: object
+                    properties:
+                      name:
+                        type: string
+                      surname:
+                        type: string
+                      age:
+                        type: integer
+                      address:
+                        type: string
+                  - type: object
+                    properties:
+                      username:
+                        type: string
+
+
+components:
+  schemas:
+    Dog:
+      type: object
+      properties:
+        bark:
+          type: boolean
+        breed:
+          type: string
+          enum: [Dingo, Husky, Retriever, Shepherd]
+    Cat:
+      type: object
+      properties:
+        hunts:
+          type: boolean
+        age:
+          type: integer
+    Hamster:
+      type: object
+      properties:
+        age:
+          type: integer
+        color:
+          type: string

--- a/v2/pkg/openapi/fixtures/v3.0.0/oneOf-response-type.graphql
+++ b/v2/pkg/openapi/fixtures/v3.0.0/oneOf-response-type.graphql
@@ -1,0 +1,41 @@
+schema {
+    query: QueryPlaceholder
+    mutation: Mutation
+}
+
+"Placeholder object"
+type QueryPlaceholder {
+    "Placeholder field"
+    message: String
+}
+
+type Mutation {
+    postPets(petsInput: JSON): Pets
+}
+
+enum Breed {
+    DINGO
+    HUSKY
+    RETRIEVER
+    SHEPHERD
+}
+
+type Cat {
+    age: Int
+    hunts: Boolean
+}
+
+type Dog {
+    bark: Boolean
+    breed: Breed
+}
+
+type Hamster {
+    age: Int
+    color: String
+}
+
+"The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf)."
+scalar JSON
+
+union Pets = Cat | Dog | Hamster

--- a/v2/pkg/openapi/fixtures/v3.0.0/oneOf-response-type.yaml
+++ b/v2/pkg/openapi/fixtures/v3.0.0/oneOf-response-type.yaml
@@ -1,0 +1,53 @@
+openapi: "3.0.0"
+info:
+  title: Pets API
+  version: 1.0.0
+servers:
+  - url: http://localhost:3004/
+
+paths:
+  /pets:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - $ref: '#/components/schemas/Cat'
+                - $ref: '#/components/schemas/Dog'
+                - $ref: '#/components/schemas/Hamster'
+      responses:
+        '200':
+          description: Pets response
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/Cat'
+                  - $ref: '#/components/schemas/Dog'
+                  - $ref: '#/components/schemas/Hamster'
+
+components:
+  schemas:
+    Dog:
+      type: object
+      properties:
+        bark:
+          type: boolean
+        breed:
+          type: string
+          enum: [Dingo, Husky, Retriever, Shepherd]
+    Cat:
+      type: object
+      properties:
+        hunts:
+          type: boolean
+        age:
+          type: integer
+    Hamster:
+      type: object
+      properties:
+        age:
+          type: integer
+        color:
+          type: string

--- a/v2/pkg/openapi/fulltype.go
+++ b/v2/pkg/openapi/fulltype.go
@@ -1,6 +1,8 @@
 package openapi
 
 import (
+	"errors"
+	"fmt"
 	"net/http"
 	"sort"
 	"strconv"
@@ -8,6 +10,166 @@ import (
 	"github.com/TykTechnologies/graphql-go-tools/v2/pkg/introspection"
 	"github.com/getkin/kin-openapi/openapi3"
 )
+
+func (c *converter) checkAndProcessOneOfKeyword(schema *openapi3.SchemaRef) error {
+	if schema.Value.OneOf == nil {
+		return nil
+	}
+
+	// Set name to unnamed schemas.
+	var namedSchema = 1
+	for _, oneOfSchema := range schema.Value.OneOf {
+		if oneOfSchema.Ref == "" {
+			if namedSchema <= 1 {
+				oneOfSchema.Ref = fmt.Sprintf("%sMember", MakeTypeNameFromPathName(c.currentPathName))
+			} else {
+				oneOfSchema.Ref = fmt.Sprintf("%sMember%d", MakeTypeNameFromPathName(c.currentPathName), namedSchema)
+			}
+			namedSchema++
+		}
+	}
+
+	for _, oneOfSchema := range schema.Value.OneOf {
+		err := c.processSchema(oneOfSchema)
+		if err != nil {
+			return err
+		}
+	}
+	// Create a UNION type here
+	if len(schema.Value.OneOf) > 0 {
+		unionName := MakeTypeNameFromPathName(c.currentPathName)
+		if _, ok := c.knownUnions[unionName]; ok {
+			// Already have the union definition.
+			return nil
+		}
+		unionType := introspection.FullType{
+			Kind:          introspection.UNION,
+			Name:          unionName,
+			PossibleTypes: []introspection.TypeRef{},
+		}
+		for _, oneOfSchema := range schema.Value.OneOf {
+			fullTypeName, err := extractFullTypeNameFromRef(oneOfSchema.Ref)
+			if errors.Is(err, errTypeNameExtractionImpossible) {
+				fullTypeName = MakeTypeNameFromPathName(c.currentPathName)
+				err = nil
+			}
+			if err != nil {
+				return err
+			}
+			unionType.PossibleTypes = append(unionType.PossibleTypes, introspection.TypeRef{
+				Kind: introspection.OBJECT,
+				Name: &fullTypeName,
+			})
+		}
+		c.knownUnions[unionName] = unionType
+		c.fullTypes = append(c.fullTypes, unionType)
+	}
+	return nil
+}
+
+func (c *converter) mergedTypePostProcessing(mergedType introspection.FullType) {
+	sort.Slice(mergedType.Fields, func(i, j int) bool {
+		return mergedType.Fields[i].Name < mergedType.Fields[j].Name
+	})
+	sort.Slice(mergedType.InputFields, func(i, j int) bool {
+		return mergedType.InputFields[i].Name < mergedType.InputFields[j].Name
+	})
+	sort.Slice(mergedType.EnumValues, func(i, j int) bool {
+		return mergedType.EnumValues[i].Name < mergedType.EnumValues[j].Name
+	})
+
+	c.fullTypes = append(c.fullTypes, mergedType)
+	sort.Slice(c.fullTypes, func(i, j int) bool {
+		return c.fullTypes[i].Name < c.fullTypes[j].Name
+	})
+	c.knownFullTypes[mergedType.Name] = &knownFullTypeDetails{}
+}
+
+func (c *converter) checkAndProcessAllOfAnyOfCommon(ref string, items openapi3.SchemaRefs) error {
+	var (
+		err      error
+		typeName string
+	)
+
+	// schema.Ref
+	if ref != "" {
+		typeName, err = extractFullTypeNameFromRef(ref)
+		if errors.Is(err, errTypeNameExtractionImpossible) {
+			typeName = MakeTypeNameFromPathName(c.currentPathName)
+			err = nil
+		}
+		if err != nil {
+			return err
+		}
+	} else {
+		typeName = MakeTypeNameFromPathName(c.currentPathName)
+	}
+	if _, ok := c.knownFullTypes[typeName]; ok {
+		// Already created, passing it.
+		return nil
+	}
+
+	// Create a new converter here to process AllOf and AnyOf keywords and merge the types.
+	// Then we move the merged type to the root converter.
+	cc := newConverter(c.openapi)
+	for i, item := range items {
+		if item.Ref == "" {
+			// Generate a name for the unnamed type. We just need the fields.
+			item.Ref = fmt.Sprintf("unnamed-type-item-%d", i)
+		}
+		if err = cc.processSchema(item); err != nil {
+			return err
+		}
+	}
+	mergedType := introspection.FullType{
+		Kind: introspection.OBJECT,
+		Name: typeName,
+	}
+	knownFields := make(map[string]struct{})
+	for _, fullType := range cc.fullTypes {
+		if fullType.Kind == introspection.OBJECT {
+			for _, field := range fullType.Fields {
+				if _, ok := knownFields[field.Name]; !ok {
+					knownFields[field.Name] = struct{}{}
+					mergedType.Fields = append(mergedType.Fields, field)
+				}
+			}
+		} else if fullType.Kind == introspection.ENUM {
+			if _, ok := c.knownEnums[fullType.Name]; ok {
+				continue
+			} else {
+				c.knownEnums[fullType.Name] = fullType
+				c.fullTypes = append(c.fullTypes, fullType)
+			}
+		}
+		mergedType.PossibleTypes = append(mergedType.PossibleTypes, fullType.PossibleTypes...)
+		mergedType.Interfaces = append(mergedType.Interfaces, fullType.Interfaces...)
+	}
+	c.mergedTypePostProcessing(mergedType)
+	return nil
+}
+
+// checkAndProcessAllOfKeyword checks for the "allOf" keyword in the schema and processes it if it exists.
+// It merges the fields, enum values, input fields, possible types, and interfaces of the allOf schemas into one merged type.
+// The merged type is then added to the list of full types and stored in the knownFullTypes map.
+func (c *converter) checkAndProcessAllOfKeyword(schema *openapi3.SchemaRef) error {
+	if schema.Value.AllOf == nil {
+		return nil
+	}
+	return c.checkAndProcessAllOfAnyOfCommon(schema.Ref, schema.Value.AllOf)
+}
+
+// checkAndProcessAnyOfKeyword checks for the "anyOf" keyword in the schema and processes it if it exists.
+// It calls the checkAndProcessAllOfAnyOfCommon method with the schema reference and the anyOf schemas.
+// This method is used to handle schemas that have multiple possible types as defined by the anyOf keyword.
+// It merges the fields, enum values, input fields, possible types, and interfaces of the anyOf schemas into one merged type.
+// The merged type is then added to the list of full types and stored in the knownFullTypes map.
+func (c *converter) checkAndProcessAnyOfKeyword(schema *openapi3.SchemaRef) error {
+	if schema.Value.AnyOf == nil {
+		return nil
+	}
+	return c.checkAndProcessAllOfAnyOfCommon(schema.Ref, schema.Value.AnyOf)
+}
 
 func (c *converter) processSchema(schema *openapi3.SchemaRef) error {
 	if schema.Value.Type == "array" {
@@ -18,6 +180,21 @@ func (c *converter) processSchema(schema *openapi3.SchemaRef) error {
 		return c.processArray(schema)
 	} else if schema.Value.Type == "object" {
 		return c.processObject(schema)
+	}
+
+	err := c.checkAndProcessOneOfKeyword(schema)
+	if err != nil {
+		return err
+	}
+
+	err = c.checkAndProcessAllOfKeyword(schema)
+	if err != nil {
+		return err
+	}
+
+	err = c.checkAndProcessAnyOfKeyword(schema)
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/v2/pkg/openapi/input.go
+++ b/v2/pkg/openapi/input.go
@@ -46,6 +46,78 @@ func (c *converter) processInputObject(schema *openapi3.SchemaRef) error {
 	return nil
 }
 
+func (c *converter) makeInputObjectFromAllOfAnyOfCommon(items openapi3.SchemaRefs) (string, error) {
+	// Create a new converter here to process AllOf and AnyOf keywords and merge the types.
+	// Then we move the merged type to the root converter.
+	cc := newConverter(c.openapi)
+	for i, item := range items {
+		if item.Ref == "" {
+			// Generate a name for the unnamed type. We just need the fields.
+			item.Ref = fmt.Sprintf("unnamed-type-item-%d", i)
+		}
+		if err := cc.processSchema(item); err != nil {
+			return "", err
+		}
+	}
+
+	typeName := MakeInputTypeName(MakeTypeNameFromPathName(c.currentPathName))
+	if _, ok := c.knownFullTypes[typeName]; ok {
+		// Already created, passing it.
+		return typeName, nil
+	}
+
+	mergedType := introspection.FullType{
+		Kind: introspection.INPUTOBJECT,
+		Name: typeName,
+	}
+	knownFields := make(map[string]struct{})
+	knownInputFields := make(map[string]struct{})
+	for _, fullType := range cc.fullTypes {
+		if fullType.Kind == introspection.OBJECT {
+			for _, field := range fullType.Fields {
+				if _, ok := knownFields[field.Name]; !ok {
+					knownFields[field.Name] = struct{}{}
+					// Convert a Field to a InputValue
+					inputValue := introspection.InputValue{
+						Name:        field.Name,
+						Description: field.Description,
+						Type:        field.Type,
+					}
+					mergedType.InputFields = append(mergedType.InputFields, inputValue)
+				}
+			}
+		} else if fullType.Kind == introspection.ENUM {
+			if _, ok := c.knownEnums[fullType.Name]; ok {
+				continue
+			} else {
+				c.knownEnums[fullType.Name] = fullType
+				c.fullTypes = append(c.fullTypes, fullType)
+			}
+		} else if fullType.Kind == introspection.INPUTOBJECT {
+			for _, inputField := range fullType.InputFields {
+				if _, ok := knownInputFields[inputField.Name]; !ok {
+					knownInputFields[inputField.Name] = struct{}{}
+					mergedType.InputFields = append(mergedType.InputFields, inputField)
+				}
+			}
+		}
+		mergedType.PossibleTypes = append(mergedType.PossibleTypes, fullType.PossibleTypes...)
+		mergedType.Interfaces = append(mergedType.Interfaces, fullType.Interfaces...)
+	}
+	c.mergedTypePostProcessing(mergedType)
+	return mergedType.Name, nil
+}
+
+// makeInputObjectFromAllOf converts a schema with multiple "allOf" properties into an input object.
+func (c *converter) makeInputObjectFromAllOf(schema *openapi3.SchemaRef) (string, error) {
+	return c.makeInputObjectFromAllOfAnyOfCommon(schema.Value.AllOf)
+}
+
+// makeInputObjectFromAllOf converts a schema with multiple "allOf" properties into an input object.
+func (c *converter) makeInputObjectFromAnyOf(schema *openapi3.SchemaRef) (string, error) {
+	return c.makeInputObjectFromAllOfAnyOfCommon(schema.Value.AnyOf)
+}
+
 func (c *converter) getInputValue(name string, schema *openapi3.SchemaRef) (*introspection.InputValue, error) {
 	var (
 		err     error
@@ -57,6 +129,21 @@ func (c *converter) getInputValue(name string, schema *openapi3.SchemaRef) (*int
 		enumType := c.createOrGetEnumType(name, schema)
 		typeRef = getEnumTypeRef()
 		gqlType = enumType.Name
+	} else if schema.Value.OneOf != nil && len(schema.Value.OneOf) > 0 {
+		gqlType = name // JSON
+		typeRef = introspection.TypeRef{Kind: 0}
+	} else if schema.Value.AllOf != nil && len(schema.Value.AllOf) > 0 {
+		gqlType, err = c.makeInputObjectFromAllOf(schema)
+		if err != nil {
+			return nil, err
+		}
+		typeRef = introspection.TypeRef{Kind: 7}
+	} else if schema.Value.AnyOf != nil && len(schema.Value.AnyOf) > 0 {
+		gqlType, err = c.makeInputObjectFromAnyOf(schema)
+		if err != nil {
+			return nil, err
+		}
+		typeRef = introspection.TypeRef{Kind: 7}
 	} else {
 		paramType := schema.Value.Type
 		if paramType == "array" {

--- a/v2/pkg/openapi/openapi.go
+++ b/v2/pkg/openapi/openapi.go
@@ -19,7 +19,8 @@ var (
 type converter struct {
 	openapi         *openapi3.T
 	knownFullTypes  map[string]*knownFullTypeDetails
-	knownEnums      map[string]*introspection.FullType
+	knownEnums      map[string]introspection.FullType
+	knownUnions     map[string]introspection.FullType
 	fullTypes       []introspection.FullType
 	currentPathName string
 	currentPathItem *openapi3.PathItem
@@ -29,13 +30,18 @@ type knownFullTypeDetails struct {
 	hasDescription bool
 }
 
-func ImportParsedOpenAPIv3Document(document *openapi3.T, report *operationreport.Report) *ast.Document {
-	c := &converter{
+func newConverter(document *openapi3.T) *converter {
+	return &converter{
 		openapi:        document,
 		knownFullTypes: make(map[string]*knownFullTypeDetails),
-		knownEnums:     make(map[string]*introspection.FullType),
+		knownEnums:     make(map[string]introspection.FullType),
+		knownUnions:    make(map[string]introspection.FullType),
 		fullTypes:      make([]introspection.FullType, 0),
 	}
+}
+
+func ImportParsedOpenAPIv3Document(document *openapi3.T, report *operationreport.Report) *ast.Document {
+	c := newConverter(document)
 	data := introspection.Data{}
 
 	queryType, err := c.importQueryType()

--- a/v2/pkg/openapi/openapi_test.go
+++ b/v2/pkg/openapi/openapi_test.go
@@ -33,6 +33,7 @@ func testFixtureFile(t *testing.T, version, name string) {
 	}
 
 	graphqlDoc, err := os.ReadFile(fmt.Sprintf("./fixtures/%s/%s.graphql", version, name))
+	fmt.Println(w.String())
 	require.NoError(t, err)
 	require.Equal(t, string(graphqlDoc), w.String())
 }
@@ -112,5 +113,53 @@ func TestOpenAPI_v3_0_0(t *testing.T) {
 
 	t.Run("enum-properties.yaml", func(t *testing.T) {
 		testFixtureFile(t, "v3.0.0", "enum-properties.yaml")
+	})
+
+	t.Run("oneOf-input-type.yaml", func(t *testing.T) {
+		testFixtureFile(t, "v3.0.0", "oneOf-input-type.yaml")
+	})
+
+	t.Run("oneOf-response-type.yaml", func(t *testing.T) {
+		testFixtureFile(t, "v3.0.0", "oneOf-response-type.yaml")
+	})
+
+	t.Run("oneOf-response-type-composition.yaml", func(t *testing.T) {
+		testFixtureFile(t, "v3.0.0", "oneOf-response-type-composition.yaml")
+	})
+
+	t.Run("allOf-input-type.yaml", func(t *testing.T) {
+		testFixtureFile(t, "v3.0.0", "allOf-input-type.yaml")
+	})
+
+	t.Run("allOf-response-type.yaml", func(t *testing.T) {
+		testFixtureFile(t, "v3.0.0", "allOf-response-type.yaml")
+	})
+
+	t.Run("allOf-input-type-composition.yaml", func(t *testing.T) {
+		testFixtureFile(t, "v3.0.0", "allOf-input-type-composition.yaml")
+	})
+
+	t.Run("allOf-response-type-composition.yaml", func(t *testing.T) {
+		testFixtureFile(t, "v3.0.0", "allOf-response-type-composition.yaml")
+	})
+
+	t.Run("allOf-query-composition.yaml", func(t *testing.T) {
+		testFixtureFile(t, "v3.0.0", "allOf-query-composition.yaml")
+	})
+
+	t.Run("allOf-query-response-type.yaml", func(t *testing.T) {
+		testFixtureFile(t, "v3.0.0", "allOf-query-response-type.yaml")
+	})
+
+	t.Run("anyOf-input-type.yaml", func(t *testing.T) {
+		testFixtureFile(t, "v3.0.0", "anyOf-input-type.yaml")
+	})
+
+	t.Run("anyOf-response-type.yaml", func(t *testing.T) {
+		testFixtureFile(t, "v3.0.0", "anyOf-response-type.yaml")
+	})
+
+	t.Run("anyOf-query-response-type.yaml", func(t *testing.T) {
+		testFixtureFile(t, "v3.0.0", "anyOf-query-response-type.yaml")
 	})
 }

--- a/v2/pkg/openapi/query.go
+++ b/v2/pkg/openapi/query.go
@@ -3,14 +3,12 @@ package openapi
 import (
 	"errors"
 	"fmt"
-	"net/http"
-	"sort"
-	"strconv"
-	"strings"
-
 	"github.com/TykTechnologies/graphql-go-tools/v2/pkg/introspection"
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/iancoleman/strcase"
+	"net/http"
+	"sort"
+	"strconv"
 )
 
 func (c *converter) importQueryType() (*introspection.FullType, error) {
@@ -79,7 +77,7 @@ func (c *converter) importQueryType() (*introspection.FullType, error) {
 					return nil, err
 				}
 				if queryField.Name == "" {
-					queryField.Name = strings.Trim(pathName, "/")
+					queryField.Name = MakeFieldNameFromEndpoint(pathName)
 				}
 				queryType.Fields = append(queryType.Fields, *queryField)
 			}


### PR DESCRIPTION
OAS converter now handles `allOf`, `anyOf`, and `oneOf` keywords. Documentation can be found here: https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not/

- Related test fixtures start with `allOf`, `anyOf`, and `oneOf` prefixes.
- IBM/openapi-to-graphql tool has been used to check the implementation.
- A bug in field name generation has also been fixed. We can now convert this to a field name: `/pets/{id}/foobar` -> `petsFoobar(id: Int!): PetsFoobar`. See `anyOf-query-response-type.yaml` file.

I'll copy the changes to the `v2` folder after approval. 