### PR TITLE
[TT-11071] OAS converter fails when return type is JSON

### DIFF
--- a/pkg/openapi/mutation.go
+++ b/pkg/openapi/mutation.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/TykTechnologies/graphql-go-tools/pkg/introspection"
 	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/iancoleman/strcase"
 )
 
 // getInputValueFromParameter retrieves the input value from the given parameter and adds it to the field arguments.
@@ -133,12 +132,7 @@ func (c *converter) importMutationType() (*introspection.FullType, error) {
 					}
 				}
 
-				// Don't convert the type name to CamelCase if it is a predefined
-				// scalar such as JSON.
-				if _, ok := preDefinedScalarTypes[typeName]; !ok {
-					typeName = strcase.ToCamel(typeName)
-				}
-
+				typeName = toCamelIfNotPredefinedScalar(typeName)
 				typeRef, err := getTypeRef("object")
 				if err != nil {
 					return nil, err

--- a/pkg/openapi/mutation.go
+++ b/pkg/openapi/mutation.go
@@ -133,7 +133,12 @@ func (c *converter) importMutationType() (*introspection.FullType, error) {
 					}
 				}
 
-				typeName = strcase.ToCamel(typeName)
+				// Don't convert the type name to CamelCase if it is a predefined
+				// scalar such as JSON.
+				if _, ok := preDefinedScalarTypes[typeName]; !ok {
+					typeName = strcase.ToCamel(typeName)
+				}
+
 				typeRef, err := getTypeRef("object")
 				if err != nil {
 					return nil, err

--- a/pkg/openapi/openapi_test.go
+++ b/pkg/openapi/openapi_test.go
@@ -12,10 +12,10 @@ import (
 )
 
 func testFixtureFile(t *testing.T, version, name string) {
-	asyncapiDoc, err := os.ReadFile(fmt.Sprintf("./fixtures/%s/%s", version, name))
+	openapiDocument, err := os.ReadFile(fmt.Sprintf("./fixtures/%s/%s", version, name))
 	require.NoError(t, err)
 
-	doc, report := ImportOpenAPIDocumentString(string(asyncapiDoc))
+	doc, report := ImportOpenAPIDocumentString(string(openapiDocument))
 	if report.HasErrors() {
 		t.Fatal(report.Error())
 	}
@@ -33,7 +33,6 @@ func testFixtureFile(t *testing.T, version, name string) {
 	}
 
 	graphqlDoc, err := os.ReadFile(fmt.Sprintf("./fixtures/%s/%s.graphql", version, name))
-	fmt.Println(w.String())
 	require.NoError(t, err)
 	require.Equal(t, string(graphqlDoc), w.String())
 }

--- a/pkg/openapi/query.go
+++ b/pkg/openapi/query.go
@@ -62,7 +62,11 @@ func (c *converter) importQueryType() (*introspection.FullType, error) {
 					kind = "object"
 				}
 
-				typeName = strcase.ToCamel(typeName)
+				// Don't convert the type name to CamelCase if it is a predefined
+				// scalar such as JSON.
+				if _, ok := preDefinedScalarTypes[typeName]; !ok {
+					typeName = strcase.ToCamel(typeName)
+				}
 				typeRef, err := getTypeRef(kind)
 				if err != nil {
 					return nil, err

--- a/pkg/openapi/query.go
+++ b/pkg/openapi/query.go
@@ -62,11 +62,7 @@ func (c *converter) importQueryType() (*introspection.FullType, error) {
 					kind = "object"
 				}
 
-				// Don't convert the type name to CamelCase if it is a predefined
-				// scalar such as JSON.
-				if _, ok := preDefinedScalarTypes[typeName]; !ok {
-					typeName = strcase.ToCamel(typeName)
-				}
+				typeName = toCamelIfNotPredefinedScalar(typeName)
 				typeRef, err := getTypeRef(kind)
 				if err != nil {
 					return nil, err

--- a/pkg/openapi/utils.go
+++ b/pkg/openapi/utils.go
@@ -215,3 +215,12 @@ func getJSONSchemaFromRequestBody(operation *openapi3.Operation) *openapi3.Schem
 	}
 	return nil
 }
+
+func toCamelIfNotPredefinedScalar(typeName string) string {
+	// Don't convert the type name to CamelCase if it is a predefined
+	// scalar such as JSON.
+	if _, ok := preDefinedScalarTypes[typeName]; !ok {
+		return strcase.ToCamel(typeName)
+	}
+	return typeName
+}

--- a/v2/pkg/openapi/mutation.go
+++ b/v2/pkg/openapi/mutation.go
@@ -133,7 +133,11 @@ func (c *converter) importMutationType() (*introspection.FullType, error) {
 					}
 				}
 
-				typeName = strcase.ToCamel(typeName)
+				// Don't convert the type name to CamelCase if it is a predefined
+				// scalar such as JSON.
+				if _, ok := preDefinedScalarTypes[typeName]; !ok {
+					typeName = strcase.ToCamel(typeName)
+				}
 				typeRef, err := getTypeRef("object")
 				if err != nil {
 					return nil, err

--- a/v2/pkg/openapi/mutation.go
+++ b/v2/pkg/openapi/mutation.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/TykTechnologies/graphql-go-tools/v2/pkg/introspection"
 	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/iancoleman/strcase"
 )
 
 // getInputValueFromParameter retrieves the input value from the given parameter and adds it to the field arguments.
@@ -133,11 +132,7 @@ func (c *converter) importMutationType() (*introspection.FullType, error) {
 					}
 				}
 
-				// Don't convert the type name to CamelCase if it is a predefined
-				// scalar such as JSON.
-				if _, ok := preDefinedScalarTypes[typeName]; !ok {
-					typeName = strcase.ToCamel(typeName)
-				}
+				typeName = toCamelIfNotPredefinedScalar(typeName)
 				typeRef, err := getTypeRef("object")
 				if err != nil {
 					return nil, err

--- a/v2/pkg/openapi/openapi_test.go
+++ b/v2/pkg/openapi/openapi_test.go
@@ -12,10 +12,10 @@ import (
 )
 
 func testFixtureFile(t *testing.T, version, name string) {
-	asyncapiDoc, err := os.ReadFile(fmt.Sprintf("./fixtures/%s/%s", version, name))
+	openapiDocument, err := os.ReadFile(fmt.Sprintf("./fixtures/%s/%s", version, name))
 	require.NoError(t, err)
 
-	doc, report := ImportOpenAPIDocumentString(string(asyncapiDoc))
+	doc, report := ImportOpenAPIDocumentString(string(openapiDocument))
 	if report.HasErrors() {
 		t.Fatal(report.Error())
 	}
@@ -33,7 +33,6 @@ func testFixtureFile(t *testing.T, version, name string) {
 	}
 
 	graphqlDoc, err := os.ReadFile(fmt.Sprintf("./fixtures/%s/%s.graphql", version, name))
-	fmt.Println(w.String())
 	require.NoError(t, err)
 	require.Equal(t, string(graphqlDoc), w.String())
 }

--- a/v2/pkg/openapi/query.go
+++ b/v2/pkg/openapi/query.go
@@ -62,7 +62,11 @@ func (c *converter) importQueryType() (*introspection.FullType, error) {
 					kind = "object"
 				}
 
-				typeName = strcase.ToCamel(typeName)
+				// Don't convert the type name to CamelCase if it is a predefined
+				// scalar such as JSON.
+				if _, ok := preDefinedScalarTypes[typeName]; !ok {
+					typeName = strcase.ToCamel(typeName)
+				}
 				typeRef, err := getTypeRef(kind)
 				if err != nil {
 					return nil, err

--- a/v2/pkg/openapi/query.go
+++ b/v2/pkg/openapi/query.go
@@ -62,11 +62,7 @@ func (c *converter) importQueryType() (*introspection.FullType, error) {
 					kind = "object"
 				}
 
-				// Don't convert the type name to CamelCase if it is a predefined
-				// scalar such as JSON.
-				if _, ok := preDefinedScalarTypes[typeName]; !ok {
-					typeName = strcase.ToCamel(typeName)
-				}
+				typeName = toCamelIfNotPredefinedScalar(typeName)
 				typeRef, err := getTypeRef(kind)
 				if err != nil {
 					return nil, err

--- a/v2/pkg/openapi/utils.go
+++ b/v2/pkg/openapi/utils.go
@@ -215,3 +215,12 @@ func getJSONSchemaFromRequestBody(operation *openapi3.Operation) *openapi3.Schem
 	}
 	return nil
 }
+
+func toCamelIfNotPredefinedScalar(typeName string) string {
+	// Don't convert the type name to CamelCase if it is a predefined
+	// scalar such as JSON.
+	if _, ok := preDefinedScalarTypes[typeName]; !ok {
+		return strcase.ToCamel(typeName)
+	}
+	return typeName
+}


### PR DESCRIPTION
Tyk GW uses `github.com/iancoleman/strcase v0.3.0` but graphql-go-tools uses version `v0.2.0`. The OpenAPI translator uses the `strcase.ToCamel` method to process type names. This method in the newer version converts `JSON` to `Json`, while the older version doesn't do that. It simply returns the same string. 

This PR fixes this problem and checks the type name before further processing. We don't need to call `ToCamel` method if the type name is a predefined scalar type. 

We don't catch this error with our test suite because when graphql-go-tools is imported from Tyk GW, the newer version of the dependency is used. It may be a good idea to upgrade `github.com/iancoleman/strcase` to `v0.3.0` from `v0.2.0` for compatibility. I do not prefer to do that in this PR because different components of the library depend on it. It should be handled in a different story.
 