### PR TITLE
[TT-11069] Add support for status code ranges in OpenAPI

### DIFF
--- a/pkg/openapi/fixtures/v3.0.0/status-code-ranges.graphql
+++ b/pkg/openapi/fixtures/v3.0.0/status-code-ranges.graphql
@@ -1,0 +1,34 @@
+schema {
+    query: Query
+    mutation: Mutation
+}
+
+type Query {
+    "Returns a user based on a single ID, if the user does not have access to the pet"
+    findPetById(id: Int!): Pet
+    """
+    Returns all pets from the system that the user has access to
+    Nam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia.
+
+    Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.
+    """
+    findPets(limit: Int, tags: [String]): [Pet]
+}
+
+type Mutation {
+    "Creates a new pet in the store. Duplicates are allowed"
+    addPet(newPetInput: NewPetInput!): Pet
+    "deletes a single pet based on the ID supplied"
+    deletePet(id: Int!): String
+}
+
+input NewPetInput {
+    name: String!
+    tag: String
+}
+
+type Pet {
+    id: Int!
+    name: String!
+    tag: String
+}

--- a/pkg/openapi/fixtures/v3.0.0/status-code-ranges.yaml
+++ b/pkg/openapi/fixtures/v3.0.0/status-code-ranges.yaml
@@ -1,0 +1,158 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  description: A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3.0 specification
+  termsOfService: http://swagger.io/terms/
+  contact:
+    name: Swagger API Team
+    email: apiteam@swagger.io
+    url: http://swagger.io
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+servers:
+  - url: http://petstore.swagger.io/api
+paths:
+  /pets:
+    get:
+      description: |
+        Returns all pets from the system that the user has access to
+        Nam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia.
+
+        Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.
+      operationId: findPets
+      parameters:
+        - name: tags
+          in: query
+          description: tags to filter by
+          required: false
+          style: form
+          schema:
+            type: array
+            items:
+              type: string
+        - name: limit
+          in: query
+          description: maximum number of results to return
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        2XX:
+          description: pet response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    post:
+      description: Creates a new pet in the store. Duplicates are allowed
+      operationId: addPet
+      requestBody:
+        description: Pet to add to the store
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NewPet'
+      responses:
+        2XX:
+          description: pet response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /pets/{id}:
+    get:
+      description: Returns a user based on a single ID, if the user does not have access to the pet
+      operationId: find pet by id
+      parameters:
+        - name: id
+          in: path
+          description: ID of pet to fetch
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        2XX:
+          description: pet response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    delete:
+      description: deletes a single pet based on the ID supplied
+      operationId: deletePet
+      parameters:
+        - name: id
+          in: path
+          description: ID of pet to delete
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        2XX:
+          description: pet deleted
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+components:
+  schemas:
+    Pet:
+      allOf:
+        - $ref: '#/components/schemas/NewPet'
+        - type: object
+          required:
+            - id
+          properties:
+            id:
+              type: integer
+              format: int64
+
+    NewPet:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+        tag:
+          type: string
+
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/pkg/openapi/fulltype.go
+++ b/pkg/openapi/fulltype.go
@@ -3,12 +3,10 @@ package openapi
 import (
 	"errors"
 	"fmt"
-	"net/http"
-	"sort"
-	"strconv"
-
 	"github.com/TykTechnologies/graphql-go-tools/pkg/introspection"
 	"github.com/getkin/kin-openapi/openapi3"
+	"net/http"
+	"sort"
 )
 
 func (c *converter) checkAndProcessOneOfKeyword(schema *openapi3.SchemaRef) error {
@@ -213,7 +211,7 @@ func (c *converter) importFullTypes() ([]introspection.FullType, error) {
 				if statusCodeStr == "default" {
 					continue
 				}
-				status, err := strconv.Atoi(statusCodeStr)
+				status, err := convertStatusCode(statusCodeStr)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/openapi/mutation.go
+++ b/pkg/openapi/mutation.go
@@ -1,12 +1,10 @@
 package openapi
 
 import (
-	"net/http"
-	"sort"
-	"strconv"
-
 	"github.com/TykTechnologies/graphql-go-tools/pkg/introspection"
 	"github.com/getkin/kin-openapi/openapi3"
+	"net/http"
+	"sort"
 )
 
 // getInputValueFromParameter retrieves the input value from the given parameter and adds it to the field arguments.
@@ -36,7 +34,7 @@ func (c *converter) getInputValuesFromParameters(field *introspection.Field, par
 // If the response schema is an object, it returns a type name generated from the current path name. Otherwise, it returns "String".
 func (c *converter) tryMakeTypeNameFromOperation(status int, operation *openapi3.Operation) string {
 	// Try to make a new type name for unnamed objects.
-	responseRef := operation.Responses.Get(status)
+	responseRef := getResponseFromOperation(status, operation)
 	if responseRef != nil && responseRef.Value != nil {
 		mediaType := responseRef.Value.Content.Get("application/json")
 		if mediaType != nil && mediaType.Schema != nil && mediaType.Schema.Value != nil {
@@ -109,7 +107,7 @@ func (c *converter) importMutationType() (*introspection.FullType, error) {
 				if statusCodeStr == "default" {
 					continue
 				}
-				status, err := strconv.Atoi(statusCodeStr)
+				status, err := convertStatusCode(statusCodeStr)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/openapi/openapi.go
+++ b/pkg/openapi/openapi.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-
 	"github.com/TykTechnologies/graphql-go-tools/pkg/ast"
 	"github.com/TykTechnologies/graphql-go-tools/pkg/introspection"
 	"github.com/TykTechnologies/graphql-go-tools/pkg/operationreport"

--- a/pkg/openapi/openapi_test.go
+++ b/pkg/openapi/openapi_test.go
@@ -161,4 +161,8 @@ func TestOpenAPI_v3_0_0(t *testing.T) {
 	t.Run("anyOf-query-response-type.yaml", func(t *testing.T) {
 		testFixtureFile(t, "v3.0.0", "anyOf-query-response-type.yaml")
 	})
+
+	t.Run("status-code-ranges.yaml", func(t *testing.T) {
+		testFixtureFile(t, "v3.0.0", "status-code-ranges.yaml")
+	})
 }

--- a/pkg/openapi/query.go
+++ b/pkg/openapi/query.go
@@ -8,7 +8,6 @@ import (
 	"github.com/iancoleman/strcase"
 	"net/http"
 	"sort"
-	"strconv"
 )
 
 func (c *converter) importQueryType() (*introspection.FullType, error) {
@@ -29,7 +28,7 @@ func (c *converter) importQueryType() (*introspection.FullType, error) {
 				if statusCodeStr == "default" {
 					continue
 				}
-				status, err := strconv.Atoi(statusCodeStr)
+				status, err := convertStatusCode(statusCodeStr)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/openapi/utils_test.go
+++ b/pkg/openapi/utils_test.go
@@ -1,0 +1,83 @@
+package openapi
+
+import (
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestStatusCodeToRange(t *testing.T) {
+
+	t.Run("1XX", func(t *testing.T) {
+		for _, code := range []int{100, 120, 130} {
+			codeRange, err := statusCodeToRange(code)
+			assert.Nil(t, err)
+			assert.Equal(t, "1XX", codeRange)
+		}
+	})
+
+	t.Run("2XX", func(t *testing.T) {
+		for _, code := range []int{200, 220, 230} {
+			codeRange, err := statusCodeToRange(code)
+			assert.Nil(t, err)
+			assert.Equal(t, "2XX", codeRange)
+		}
+	})
+
+	t.Run("3XX", func(t *testing.T) {
+		for _, code := range []int{300, 320, 330} {
+			codeRange, err := statusCodeToRange(code)
+			assert.Nil(t, err)
+			assert.Equal(t, "3XX", codeRange)
+		}
+	})
+
+	t.Run("4XX", func(t *testing.T) {
+		for _, code := range []int{400, 420, 430} {
+			codeRange, err := statusCodeToRange(code)
+			assert.Nil(t, err)
+			assert.Equal(t, "4XX", codeRange)
+		}
+	})
+
+	t.Run("5XX", func(t *testing.T) {
+		for _, code := range []int{500, 520, 530} {
+			codeRange, err := statusCodeToRange(code)
+			assert.Nil(t, err)
+			assert.Equal(t, "5XX", codeRange)
+		}
+	})
+
+	t.Run("Invalid status code", func(t *testing.T) {
+		_, err := statusCodeToRange(620)
+		assert.ErrorContains(t, err, "unknown status code: 620")
+	})
+}
+
+func TestConvertStatusCode(t *testing.T) {
+	rangeToCode := map[string]int{
+		"1xx": 100,
+		"2xx": 200,
+		"3xx": 300,
+		"4xx": 400,
+		"5xx": 500,
+	}
+
+	for statusRange, expectedCode := range rangeToCode {
+		code, err := convertStatusCode(statusRange)
+		assert.Nil(t, err)
+		assert.Equal(t, expectedCode, code)
+	}
+}
+
+func TestGetResponseFromOperation(t *testing.T) {
+	operation := &openapi3.Operation{
+		Responses: openapi3.Responses{
+			"200": &openapi3.ResponseRef{Value: &openapi3.Response{}},
+			"3XX": &openapi3.ResponseRef{Value: &openapi3.Response{}},
+		},
+	}
+	assert.NotNil(t, getResponseFromOperation(200, operation))
+	assert.NotNil(t, getResponseFromOperation(300, operation))
+	assert.Nil(t, getResponseFromOperation(400, operation))
+}

--- a/v2/pkg/openapi/fixtures/v3.0.0/status-code-ranges.graphql
+++ b/v2/pkg/openapi/fixtures/v3.0.0/status-code-ranges.graphql
@@ -1,0 +1,34 @@
+schema {
+    query: Query
+    mutation: Mutation
+}
+
+type Query {
+    "Returns a user based on a single ID, if the user does not have access to the pet"
+    findPetById(id: Int!): Pet
+    """
+    Returns all pets from the system that the user has access to
+    Nam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia.
+
+    Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.
+    """
+    findPets(limit: Int, tags: [String]): [Pet]
+}
+
+type Mutation {
+    "Creates a new pet in the store. Duplicates are allowed"
+    addPet(newPetInput: NewPetInput!): Pet
+    "deletes a single pet based on the ID supplied"
+    deletePet(id: Int!): String
+}
+
+input NewPetInput {
+    name: String!
+    tag: String
+}
+
+type Pet {
+    id: Int!
+    name: String!
+    tag: String
+}

--- a/v2/pkg/openapi/fixtures/v3.0.0/status-code-ranges.yaml
+++ b/v2/pkg/openapi/fixtures/v3.0.0/status-code-ranges.yaml
@@ -1,0 +1,158 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  description: A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3.0 specification
+  termsOfService: http://swagger.io/terms/
+  contact:
+    name: Swagger API Team
+    email: apiteam@swagger.io
+    url: http://swagger.io
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+servers:
+  - url: http://petstore.swagger.io/api
+paths:
+  /pets:
+    get:
+      description: |
+        Returns all pets from the system that the user has access to
+        Nam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia.
+
+        Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.
+      operationId: findPets
+      parameters:
+        - name: tags
+          in: query
+          description: tags to filter by
+          required: false
+          style: form
+          schema:
+            type: array
+            items:
+              type: string
+        - name: limit
+          in: query
+          description: maximum number of results to return
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        2XX:
+          description: pet response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    post:
+      description: Creates a new pet in the store. Duplicates are allowed
+      operationId: addPet
+      requestBody:
+        description: Pet to add to the store
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NewPet'
+      responses:
+        2XX:
+          description: pet response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /pets/{id}:
+    get:
+      description: Returns a user based on a single ID, if the user does not have access to the pet
+      operationId: find pet by id
+      parameters:
+        - name: id
+          in: path
+          description: ID of pet to fetch
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        2XX:
+          description: pet response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    delete:
+      description: deletes a single pet based on the ID supplied
+      operationId: deletePet
+      parameters:
+        - name: id
+          in: path
+          description: ID of pet to delete
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        2XX:
+          description: pet deleted
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+components:
+  schemas:
+    Pet:
+      allOf:
+        - $ref: '#/components/schemas/NewPet'
+        - type: object
+          required:
+            - id
+          properties:
+            id:
+              type: integer
+              format: int64
+
+    NewPet:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+        tag:
+          type: string
+
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/v2/pkg/openapi/fulltype.go
+++ b/v2/pkg/openapi/fulltype.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"sort"
-	"strconv"
 
 	"github.com/TykTechnologies/graphql-go-tools/v2/pkg/introspection"
 	"github.com/getkin/kin-openapi/openapi3"
@@ -213,7 +212,7 @@ func (c *converter) importFullTypes() ([]introspection.FullType, error) {
 				if statusCodeStr == "default" {
 					continue
 				}
-				status, err := strconv.Atoi(statusCodeStr)
+				status, err := convertStatusCode(statusCodeStr)
 				if err != nil {
 					return nil, err
 				}

--- a/v2/pkg/openapi/mutation.go
+++ b/v2/pkg/openapi/mutation.go
@@ -3,7 +3,6 @@ package openapi
 import (
 	"net/http"
 	"sort"
-	"strconv"
 
 	"github.com/TykTechnologies/graphql-go-tools/v2/pkg/introspection"
 	"github.com/getkin/kin-openapi/openapi3"
@@ -36,7 +35,7 @@ func (c *converter) getInputValuesFromParameters(field *introspection.Field, par
 // If the response schema is an object, it returns a type name generated from the current path name. Otherwise, it returns "String".
 func (c *converter) tryMakeTypeNameFromOperation(status int, operation *openapi3.Operation) string {
 	// Try to make a new type name for unnamed objects.
-	responseRef := operation.Responses.Get(status)
+	responseRef := getResponseFromOperation(status, operation)
 	if responseRef != nil && responseRef.Value != nil {
 		mediaType := responseRef.Value.Content.Get("application/json")
 		if mediaType != nil && mediaType.Schema != nil && mediaType.Schema.Value != nil {
@@ -109,7 +108,7 @@ func (c *converter) importMutationType() (*introspection.FullType, error) {
 				if statusCodeStr == "default" {
 					continue
 				}
-				status, err := strconv.Atoi(statusCodeStr)
+				status, err := convertStatusCode(statusCodeStr)
 				if err != nil {
 					return nil, err
 				}

--- a/v2/pkg/openapi/openapi_test.go
+++ b/v2/pkg/openapi/openapi_test.go
@@ -161,4 +161,8 @@ func TestOpenAPI_v3_0_0(t *testing.T) {
 	t.Run("anyOf-query-response-type.yaml", func(t *testing.T) {
 		testFixtureFile(t, "v3.0.0", "anyOf-query-response-type.yaml")
 	})
+
+	t.Run("status-code-ranges.yaml", func(t *testing.T) {
+		testFixtureFile(t, "v3.0.0", "status-code-ranges.yaml")
+	})
 }

--- a/v2/pkg/openapi/query.go
+++ b/v2/pkg/openapi/query.go
@@ -3,12 +3,12 @@ package openapi
 import (
 	"errors"
 	"fmt"
+	"net/http"
+	"sort"
+
 	"github.com/TykTechnologies/graphql-go-tools/v2/pkg/introspection"
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/iancoleman/strcase"
-	"net/http"
-	"sort"
-	"strconv"
 )
 
 func (c *converter) importQueryType() (*introspection.FullType, error) {
@@ -29,7 +29,7 @@ func (c *converter) importQueryType() (*introspection.FullType, error) {
 				if statusCodeStr == "default" {
 					continue
 				}
-				status, err := strconv.Atoi(statusCodeStr)
+				status, err := convertStatusCode(statusCodeStr)
 				if err != nil {
 					return nil, err
 				}

--- a/v2/pkg/openapi/utils.go
+++ b/v2/pkg/openapi/utils.go
@@ -2,17 +2,31 @@ package openapi
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
+
 	"github.com/TykTechnologies/graphql-go-tools/v2/pkg/introspection"
 	"github.com/TykTechnologies/graphql-go-tools/v2/pkg/lexer/literal"
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/iancoleman/strcase"
-	"strings"
 )
 
 const JsonScalarType = "JSON"
 
 var preDefinedScalarTypes = map[string]string{
 	JsonScalarType: "The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).",
+}
+
+// From the OpenAPI spec: To define a range of response codes, you may use the
+// following range definitions: 1XX, 2XX, 3XX, 4XX, and 5XX.
+//
+// See https://swagger.io/docs/specification/describing-responses/
+var statusCodeRanges = map[string]int{
+	"1XX": 100,
+	"2XX": 200,
+	"3XX": 300,
+	"4XX": 400,
+	"5XX": 500,
 }
 
 // addScalarType adds a new scalar type to the converter's known full types list.
@@ -199,7 +213,7 @@ func getJSONSchemaFromResponseRef(response *openapi3.ResponseRef) *openapi3.Sche
 }
 
 func getJSONSchema(status int, operation *openapi3.Operation) *openapi3.SchemaRef {
-	response := operation.Responses.Get(status)
+	response := getResponseFromOperation(status, operation)
 	if response == nil {
 		return nil
 	}
@@ -223,4 +237,51 @@ func toCamelIfNotPredefinedScalar(typeName string) string {
 		return strcase.ToCamel(typeName)
 	}
 	return typeName
+}
+
+// statusCodeToRange returns a string representing the range of the given status code.
+// The function categorizes the status code into different ranges: 1XX, 2XX, 3XX, 4XX, 5XX.
+// If the status code is not within any of these ranges, an error is returned.
+func statusCodeToRange(status int) (string, error) {
+	if status >= 100 && status < 200 {
+		return "1XX", nil
+	} else if status >= 200 && status < 300 {
+		return "2XX", nil
+	} else if status >= 300 && status < 400 {
+		return "3XX", nil
+	} else if status >= 400 && status < 500 {
+		return "4XX", nil
+	} else if status >= 500 && status < 600 {
+		return "5XX", nil
+	} else {
+		return "", fmt.Errorf("unknown status code: %d", status)
+	}
+}
+
+func convertStatusCode(statusCode string) (int, error) {
+	// The spec advises to use ranges as '2XX' but the OpenAPI parser accepts
+	// '2xx' as a valid status code range.
+	statusCode = strings.ToUpper(statusCode)
+	if code, ok := statusCodeRanges[statusCode]; ok {
+		return code, nil
+	}
+	return strconv.Atoi(statusCode)
+}
+
+// getResponseFromOperation returns the response for the given status code from the operation's responses.
+// If a response with the given status code is not found, it tries to find the range for the status
+// code and returns the response for that range.
+func getResponseFromOperation(status int, operation *openapi3.Operation) *openapi3.ResponseRef {
+	response := operation.Responses.Get(status)
+	if response != nil {
+		return response
+	}
+	// Try to find the range this time.
+	statusCodeRange, err := statusCodeToRange(status)
+	if err != nil {
+		// Invalid status code. It's okay to return nil here. We couldn't find
+		// a response for the given status code.
+		return nil
+	}
+	return operation.Responses[statusCodeRange]
 }

--- a/v2/pkg/openapi/utils_test.go
+++ b/v2/pkg/openapi/utils_test.go
@@ -1,0 +1,84 @@
+package openapi
+
+import (
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStatusCodeToRange(t *testing.T) {
+
+	t.Run("1XX", func(t *testing.T) {
+		for _, code := range []int{100, 120, 130} {
+			codeRange, err := statusCodeToRange(code)
+			assert.Nil(t, err)
+			assert.Equal(t, "1XX", codeRange)
+		}
+	})
+
+	t.Run("2XX", func(t *testing.T) {
+		for _, code := range []int{200, 220, 230} {
+			codeRange, err := statusCodeToRange(code)
+			assert.Nil(t, err)
+			assert.Equal(t, "2XX", codeRange)
+		}
+	})
+
+	t.Run("3XX", func(t *testing.T) {
+		for _, code := range []int{300, 320, 330} {
+			codeRange, err := statusCodeToRange(code)
+			assert.Nil(t, err)
+			assert.Equal(t, "3XX", codeRange)
+		}
+	})
+
+	t.Run("4XX", func(t *testing.T) {
+		for _, code := range []int{400, 420, 430} {
+			codeRange, err := statusCodeToRange(code)
+			assert.Nil(t, err)
+			assert.Equal(t, "4XX", codeRange)
+		}
+	})
+
+	t.Run("5XX", func(t *testing.T) {
+		for _, code := range []int{500, 520, 530} {
+			codeRange, err := statusCodeToRange(code)
+			assert.Nil(t, err)
+			assert.Equal(t, "5XX", codeRange)
+		}
+	})
+
+	t.Run("Invalid status code", func(t *testing.T) {
+		_, err := statusCodeToRange(620)
+		assert.ErrorContains(t, err, "unknown status code: 620")
+	})
+}
+
+func TestConvertStatusCode(t *testing.T) {
+	rangeToCode := map[string]int{
+		"1xx": 100,
+		"2xx": 200,
+		"3xx": 300,
+		"4xx": 400,
+		"5xx": 500,
+	}
+
+	for statusRange, expectedCode := range rangeToCode {
+		code, err := convertStatusCode(statusRange)
+		assert.Nil(t, err)
+		assert.Equal(t, expectedCode, code)
+	}
+}
+
+func TestGetResponseFromOperation(t *testing.T) {
+	operation := &openapi3.Operation{
+		Responses: openapi3.Responses{
+			"200": &openapi3.ResponseRef{Value: &openapi3.Response{}},
+			"3XX": &openapi3.ResponseRef{Value: &openapi3.Response{}},
+		},
+	}
+	assert.NotNil(t, getResponseFromOperation(200, operation))
+	assert.NotNil(t, getResponseFromOperation(300, operation))
+	assert.Nil(t, getResponseFromOperation(400, operation))
+}


### PR DESCRIPTION
PR for https://tyktech.atlassian.net/browse/TT-11069

This update extends the handling of status codes in OpenAPI testing by including support for status code ranges. The implementation converts ranges to status codes in integer type and can also convert a status code to a range. 

The changes will be copied to the `v2` folder after approval.