### PR TITLE
[TT-11249] OAS-to-GQL translator adds the same field many times

### DIFF
--- a/pkg/openapi/fixtures/v3.0.0/status-code-precedence.graphql
+++ b/pkg/openapi/fixtures/v3.0.0/status-code-precedence.graphql
@@ -1,0 +1,40 @@
+schema {
+    query: Query
+    mutation: Mutation
+}
+
+type Query {
+    "Returns a user based on a single ID, if the user does not have access to the pet"
+    findPetById(id: Int!): PetRange
+    """
+    Returns all pets from the system that the user has access to
+    Nam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia.
+
+    Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.
+    """
+    findPets(limit: Int, tags: [String]): [PetExplicit]
+}
+
+type Mutation {
+    "Creates a new pet in the store. Duplicates are allowed"
+    addPet(newPetInput: NewPetInput!): PetExplicit
+    "deletes a single pet based on the ID supplied"
+    deletePet(id: Int!): String
+}
+
+input NewPetInput {
+    name: String!
+    tag: String
+}
+
+type PetExplicit {
+    id: Int!
+    name: String!
+    tag: String
+}
+
+type PetRange {
+    id: Int!
+    name: String!
+    tag: String
+}

--- a/pkg/openapi/fixtures/v3.0.0/status-code-precedence.yaml
+++ b/pkg/openapi/fixtures/v3.0.0/status-code-precedence.yaml
@@ -1,0 +1,185 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  description: A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3.0 specification
+  termsOfService: http://swagger.io/terms/
+  contact:
+    name: Swagger API Team
+    email: apiteam@swagger.io
+    url: http://swagger.io
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+servers:
+  - url: http://petstore.swagger.io/api
+paths:
+  /pets:
+    get:
+      description: |
+        Returns all pets from the system that the user has access to
+        Nam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia.
+
+        Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.
+      operationId: findPets
+      parameters:
+        - name: tags
+          in: query
+          description: tags to filter by
+          required: false
+          style: form
+          schema:
+            type: array
+            items:
+              type: string
+        - name: limit
+          in: query
+          description: maximum number of results to return
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        2XX:
+          description: pet response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PetRange'
+        200:
+          description: pet response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PetExplicit'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    post:
+      description: Creates a new pet in the store. Duplicates are allowed
+      operationId: addPet
+      requestBody:
+        description: Pet to add to the store
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NewPet'
+      responses:
+        2XX:
+          description: pet response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PetRange'
+        200:
+          description: pet response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PetExplicit'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /pets/{id}:
+    get:
+      description: Returns a user based on a single ID, if the user does not have access to the pet
+      operationId: find pet by id
+      parameters:
+        - name: id
+          in: path
+          description: ID of pet to fetch
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        2XX:
+          description: pet response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PetRange'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    delete:
+      description: deletes a single pet based on the ID supplied
+      operationId: deletePet
+      parameters:
+        - name: id
+          in: path
+          description: ID of pet to delete
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        2XX:
+          description: pet deleted
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+components:
+  schemas:
+    PetRange:
+      allOf:
+        - $ref: '#/components/schemas/NewPet'
+        - type: object
+          required:
+            - id
+          properties:
+            id:
+              type: integer
+              format: int64
+
+    PetExplicit:
+      allOf:
+        - $ref: '#/components/schemas/NewPet'
+        - type: object
+          required:
+            - id
+          properties:
+            id:
+              type: integer
+              format: int64
+
+    NewPet:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+        tag:
+          type: string
+
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/pkg/openapi/fixtures/v3.0.0/status-code-valid-responses.graphql
+++ b/pkg/openapi/fixtures/v3.0.0/status-code-valid-responses.graphql
@@ -1,0 +1,40 @@
+schema {
+    query: Query
+    mutation: Mutation
+}
+
+type Query {
+    "Returns a user based on a single ID, if the user does not have access to the pet"
+    findPetById(id: Int!): [PetTwoHundredTwo]
+    """
+    Returns all pets from the system that the user has access to
+    Nam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia.
+
+    Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.
+    """
+    findPets(limit: Int, tags: [String]): [PetTwoHundred]
+}
+
+type Mutation {
+    "Creates a new pet in the store. Duplicates are allowed"
+    addPet(newPetInput: NewPetInput!): PetTwoHundred
+    "deletes a single pet based on the ID supplied"
+    deletePet(id: Int!): String
+}
+
+input NewPetInput {
+    name: String!
+    tag: String
+}
+
+type PetTwoHundred {
+    id: Int!
+    name: String!
+    tag: String
+}
+
+type PetTwoHundredTwo {
+    id: Int!
+    name: String!
+    tag: String
+}

--- a/pkg/openapi/fixtures/v3.0.0/status-code-valid-responses.yaml
+++ b/pkg/openapi/fixtures/v3.0.0/status-code-valid-responses.yaml
@@ -1,0 +1,197 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  description: A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3.0 specification
+  termsOfService: http://swagger.io/terms/
+  contact:
+    name: Swagger API Team
+    email: apiteam@swagger.io
+    url: http://swagger.io
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+servers:
+  - url: http://petstore.swagger.io/api
+paths:
+  /pets:
+    get:
+      description: |
+        Returns all pets from the system that the user has access to
+        Nam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia.
+
+        Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.
+      operationId: findPets
+      parameters:
+        - name: tags
+          in: query
+          description: tags to filter by
+          required: false
+          style: form
+          schema:
+            type: array
+            items:
+              type: string
+        - name: limit
+          in: query
+          description: maximum number of results to return
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        200:
+          description: pet response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PetTwoHundred'
+        202:
+          description: pet response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PetTwoHundredTwo'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    post:
+      description: Creates a new pet in the store. Duplicates are allowed
+      operationId: addPet
+      requestBody:
+        description: Pet to add to the store
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NewPet'
+      responses:
+        200:
+          description: pet response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PetTwoHundred'
+        202:
+          description: pet response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PetTwoHundredTwo'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /pets/{id}:
+    get:
+      description: Returns a user based on a single ID, if the user does not have access to the pet
+      operationId: find pet by id
+      parameters:
+        - name: id
+          in: path
+          description: ID of pet to fetch
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        2XX:
+          description: pet response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PetTwoHundred'
+        202:
+          description: pet response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PetTwoHundredTwo'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    delete:
+      description: deletes a single pet based on the ID supplied
+      operationId: deletePet
+      parameters:
+        - name: id
+          in: path
+          description: ID of pet to delete
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        2XX:
+          description: pet deleted
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+components:
+  schemas:
+    PetTwoHundred:
+      allOf:
+        - $ref: '#/components/schemas/NewPet'
+        - type: object
+          required:
+            - id
+          properties:
+            id:
+              type: integer
+              format: int64
+
+    PetTwoHundredTwo:
+      allOf:
+        - $ref: '#/components/schemas/NewPet'
+        - type: object
+          required:
+            - id
+          properties:
+            id:
+              type: integer
+              format: int64
+
+    NewPet:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+        tag:
+          type: string
+
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/pkg/openapi/fulltype.go
+++ b/pkg/openapi/fulltype.go
@@ -207,11 +207,10 @@ func (c *converter) importFullTypes() ([]introspection.FullType, error) {
 				continue
 			}
 
-			_, responseRef, err := getValidResponse(operation.Responses)
+			_, schema, err := findSchemaRef(operation.Responses)
 			if err != nil {
 				return nil, err
 			}
-			schema := getJSONSchemaFromResponseRef(responseRef)
 			if schema == nil {
 				continue
 			}

--- a/pkg/openapi/fulltype.go
+++ b/pkg/openapi/fulltype.go
@@ -207,10 +207,12 @@ func (c *converter) importFullTypes() ([]introspection.FullType, error) {
 				continue
 			}
 
-			for statusCodeStr := range operation.Responses {
-				if statusCodeStr == "default" {
-					continue
-				}
+			responses, err := sanitizeResponses(operation.Responses)
+			if err != nil {
+				return nil, fmt.Errorf("error while sanitizing responses for %s: %w", pathName, err)
+			}
+
+			for statusCodeStr := range responses {
 				status, err := convertStatusCode(statusCodeStr)
 				if err != nil {
 					return nil, err

--- a/pkg/openapi/fulltype.go
+++ b/pkg/openapi/fulltype.go
@@ -207,29 +207,17 @@ func (c *converter) importFullTypes() ([]introspection.FullType, error) {
 				continue
 			}
 
-			responses, err := sanitizeResponses(operation.Responses)
+			_, responseRef, err := getValidResponse(operation.Responses)
 			if err != nil {
-				return nil, fmt.Errorf("error while sanitizing responses for %s: %w", pathName, err)
+				return nil, err
 			}
-
-			for statusCodeStr := range responses {
-				status, err := convertStatusCode(statusCodeStr)
-				if err != nil {
-					return nil, err
-				}
-				if !isValidResponse(status) {
-					continue
-				}
-
-				schema := getJSONSchema(status, operation)
-				if schema == nil {
-					continue
-				}
-
-				err = c.processSchema(schema)
-				if err != nil {
-					return nil, err
-				}
+			schema := getJSONSchemaFromResponseRef(responseRef)
+			if schema == nil {
+				continue
+			}
+			err = c.processSchema(schema)
+			if err != nil {
+				return nil, err
 			}
 		}
 	}

--- a/pkg/openapi/mutation.go
+++ b/pkg/openapi/mutation.go
@@ -104,11 +104,10 @@ func (c *converter) importMutationType() (*introspection.FullType, error) {
 				continue
 			}
 
-			statusCode, responseRef, err := getValidResponse(operation.Responses)
+			statusCode, schema, err := findSchemaRef(operation.Responses)
 			if err != nil {
 				return nil, err
 			}
-			schema := getJSONSchemaFromResponseRef(responseRef)
 
 			var typeName string
 			if schema == nil {

--- a/pkg/openapi/mutation.go
+++ b/pkg/openapi/mutation.go
@@ -1,6 +1,7 @@
 package openapi
 
 import (
+	"fmt"
 	"github.com/TykTechnologies/graphql-go-tools/pkg/introspection"
 	"github.com/getkin/kin-openapi/openapi3"
 	"net/http"
@@ -103,10 +104,13 @@ func (c *converter) importMutationType() (*introspection.FullType, error) {
 			if operation == nil {
 				continue
 			}
-			for statusCodeStr := range operation.Responses {
-				if statusCodeStr == "default" {
-					continue
-				}
+
+			responses, err := sanitizeResponses(operation.Responses)
+			if err != nil {
+				return nil, fmt.Errorf("error while sanitizing responses for %s: %w", pathName, err)
+			}
+
+			for statusCodeStr := range responses {
 				status, err := convertStatusCode(statusCodeStr)
 				if err != nil {
 					return nil, err

--- a/pkg/openapi/openapi_test.go
+++ b/pkg/openapi/openapi_test.go
@@ -34,7 +34,6 @@ func testFixtureFile(t *testing.T, version, name string) {
 
 	graphqlDoc, err := os.ReadFile(fmt.Sprintf("./fixtures/%s/%s.graphql", version, name))
 	require.NoError(t, err)
-	fmt.Println(w.String())
 	require.Equal(t, string(graphqlDoc), w.String())
 }
 
@@ -169,5 +168,9 @@ func TestOpenAPI_v3_0_0(t *testing.T) {
 
 	t.Run("status-code-precedence.yaml", func(t *testing.T) {
 		testFixtureFile(t, "v3.0.0", "status-code-precedence.yaml")
+	})
+
+	t.Run("status-code-valid-responses.yaml", func(t *testing.T) {
+		testFixtureFile(t, "v3.0.0", "status-code-valid-responses.yaml")
 	})
 }

--- a/pkg/openapi/openapi_test.go
+++ b/pkg/openapi/openapi_test.go
@@ -34,6 +34,7 @@ func testFixtureFile(t *testing.T, version, name string) {
 
 	graphqlDoc, err := os.ReadFile(fmt.Sprintf("./fixtures/%s/%s.graphql", version, name))
 	require.NoError(t, err)
+	fmt.Println(w.String())
 	require.Equal(t, string(graphqlDoc), w.String())
 }
 
@@ -164,5 +165,9 @@ func TestOpenAPI_v3_0_0(t *testing.T) {
 
 	t.Run("status-code-ranges.yaml", func(t *testing.T) {
 		testFixtureFile(t, "v3.0.0", "status-code-ranges.yaml")
+	})
+
+	t.Run("status-code-precedence.yaml", func(t *testing.T) {
+		testFixtureFile(t, "v3.0.0", "status-code-precedence.yaml")
 	})
 }

--- a/pkg/openapi/query.go
+++ b/pkg/openapi/query.go
@@ -3,11 +3,12 @@ package openapi
 import (
 	"errors"
 	"fmt"
+	"net/http"
+	"sort"
+
 	"github.com/TykTechnologies/graphql-go-tools/pkg/introspection"
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/iancoleman/strcase"
-	"net/http"
-	"sort"
 )
 
 func (c *converter) importQueryType() (*introspection.FullType, error) {
@@ -25,64 +26,53 @@ func (c *converter) importQueryType() (*introspection.FullType, error) {
 				continue
 			}
 
-			responses, err := sanitizeResponses(operation.Responses)
+			statusCode, responseRef, err := getValidResponse(operation.Responses)
 			if err != nil {
-				return nil, fmt.Errorf("error while sanitizing responses for %s: %w", pathName, err)
+				return nil, err
+			}
+			schema := getJSONSchemaFromResponseRef(responseRef)
+
+			var (
+				kind     string
+				typeName string
+			)
+			if schema == nil {
+				typeName = c.tryMakeTypeNameFromOperation(statusCode, operation)
+			} else {
+				kind = schema.Value.Type
+				typeName, err = c.getReturnType(schema)
+				if err != nil {
+					return nil, err
+				}
+				if len(schema.Value.Enum) > 0 {
+					c.createOrGetEnumType(typeName, schema)
+				}
 			}
 
-			for statusCodeStr := range responses {
-				status, err := convertStatusCode(statusCodeStr)
-				if err != nil {
-					return nil, err
-				}
-
-				if !isValidResponse(status) {
-					continue
-				}
-
-				schema := getJSONSchema(status, operation)
-
-				var (
-					kind     string
-					typeName string
-				)
-				if schema == nil {
-					typeName = c.tryMakeTypeNameFromOperation(status, operation)
-				} else {
-					kind = schema.Value.Type
-					typeName, err = c.getReturnType(schema)
-					if err != nil {
-						return nil, err
-					}
-					if len(schema.Value.Enum) > 0 {
-						c.createOrGetEnumType(typeName, schema)
-					}
-				}
-
-				if kind == "" {
-					// We assume that it is an object type.
-					kind = "object"
-				}
-
-				typeName = toCamelIfNotPredefinedScalar(typeName)
-				typeRef, err := getTypeRef(kind)
-				if err != nil {
-					return nil, err
-				}
-				if kind == "array" {
-					// Array of some type
-					typeRef.OfType = &introspection.TypeRef{Kind: 3, Name: &typeName}
-				}
-				typeRef.Name = &typeName
-				queryField, err := c.importQueryTypeFields(&typeRef, operation)
-				if err != nil {
-					return nil, err
-				}
-				if queryField.Name == "" {
-					queryField.Name = MakeFieldNameFromEndpoint(pathName)
-				}
-				queryType.Fields = append(queryType.Fields, *queryField)
+			if kind == "" {
+				// We assume that it is an object type.
+				kind = "object"
 			}
+
+			typeName = toCamelIfNotPredefinedScalar(typeName)
+			typeRef, err := getTypeRef(kind)
+			if err != nil {
+				return nil, err
+			}
+			if kind == "array" {
+				// Array of some type
+				typeRef.OfType = &introspection.TypeRef{Kind: 3, Name: &typeName}
+			}
+			typeRef.Name = &typeName
+			queryField, err := c.importQueryTypeFields(&typeRef, operation)
+			if err != nil {
+				return nil, err
+			}
+			if queryField.Name == "" {
+				queryField.Name = MakeFieldNameFromEndpoint(pathName)
+			}
+			queryType.Fields = append(queryType.Fields, *queryField)
+			//}
 		}
 	}
 	sort.Slice(queryType.Fields, func(i, j int) bool {

--- a/pkg/openapi/query.go
+++ b/pkg/openapi/query.go
@@ -24,10 +24,13 @@ func (c *converter) importQueryType() (*introspection.FullType, error) {
 			if operation == nil {
 				continue
 			}
-			for statusCodeStr := range operation.Responses {
-				if statusCodeStr == "default" {
-					continue
-				}
+
+			responses, err := sanitizeResponses(operation.Responses)
+			if err != nil {
+				return nil, fmt.Errorf("error while sanitizing responses for %s: %w", pathName, err)
+			}
+
+			for statusCodeStr := range responses {
 				status, err := convertStatusCode(statusCodeStr)
 				if err != nil {
 					return nil, err

--- a/pkg/openapi/query.go
+++ b/pkg/openapi/query.go
@@ -26,11 +26,10 @@ func (c *converter) importQueryType() (*introspection.FullType, error) {
 				continue
 			}
 
-			statusCode, responseRef, err := getValidResponse(operation.Responses)
+			statusCode, schema, err := findSchemaRef(operation.Responses)
 			if err != nil {
 				return nil, err
 			}
-			schema := getJSONSchemaFromResponseRef(responseRef)
 
 			var (
 				kind     string

--- a/pkg/openapi/utils.go
+++ b/pkg/openapi/utils.go
@@ -302,15 +302,12 @@ func isStatusCodeRange(statusCode string) bool {
 // sanitizeResponses cleans up responses. If a response range is defined using an
 // explicit code, the explicit code definition takes precedence over the range definition for that code.
 func sanitizeResponses(responses openapi3.Responses) (openapi3.Responses, error) {
-	/*
-			OpenAPI specification:
-
-			To define a range of response codes, you may use the following range definitions:
-			1XX, 2XX, 3XX, 4XX, and 5XX.
-
-			If a response range is defined using an explicit code, the explicit code definition
-		    takes precedence over the range definition for that code.
-	*/
+	// OpenAPI specification:
+	//
+	// To define a range of response codes, you may use the following range definitions:
+	// 1XX, 2XX, 3XX, 4XX, and 5XX.
+	// If a response range is defined using an explicit code, the explicit code definition
+	//takes precedence over the range definition for that code.
 
 	result := make(openapi3.Responses)
 	occupiedStatusCodeRange := make(map[string]struct{})

--- a/pkg/openapi/utils.go
+++ b/pkg/openapi/utils.go
@@ -216,12 +216,12 @@ func getJSONSchemaFromResponseRef(response *openapi3.ResponseRef) *openapi3.Sche
 	return schema
 }
 
-func getJSONSchema(status int, operation *openapi3.Operation) *openapi3.SchemaRef {
-	response := getResponseFromOperation(status, operation)
-	if response == nil {
-		return nil
+func findSchemaRef(responses openapi3.Responses) (int, *openapi3.SchemaRef, error) {
+	statusCode, responseRef, err := getValidResponse(responses)
+	if err != nil {
+		return 0, nil, err
 	}
-	return getJSONSchemaFromResponseRef(response)
+	return statusCode, getJSONSchemaFromResponseRef(responseRef), nil
 }
 
 func getJSONSchemaFromRequestBody(operation *openapi3.Operation) *openapi3.SchemaRef {

--- a/pkg/openapi/utils_test.go
+++ b/pkg/openapi/utils_test.go
@@ -1,9 +1,11 @@
 package openapi
 
 import (
+	"net/http"
+	"testing"
+
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestStatusCodeToRange(t *testing.T) {
@@ -80,4 +82,42 @@ func TestGetResponseFromOperation(t *testing.T) {
 	assert.NotNil(t, getResponseFromOperation(200, operation))
 	assert.NotNil(t, getResponseFromOperation(300, operation))
 	assert.Nil(t, getResponseFromOperation(400, operation))
+}
+
+func Test_sanitizeResponses(t *testing.T) {
+	twoHundredResponseRef := &openapi3.ResponseRef{Value: &openapi3.Response{}}
+	twoHundredRangeResponseRef := &openapi3.ResponseRef{Value: &openapi3.Response{}}
+	threeHundredRangeResponseRef := &openapi3.ResponseRef{Value: &openapi3.Response{}}
+
+	responses := openapi3.Responses{
+		"200": twoHundredResponseRef,
+		"2XX": twoHundredRangeResponseRef,
+		"3XX": threeHundredRangeResponseRef,
+	}
+	result, err := sanitizeResponses(responses)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(result))
+	assert.Equal(t, twoHundredResponseRef, result["200"])
+	assert.Equal(t, threeHundredRangeResponseRef, result["3XX"])
+}
+
+func Test_getValidResponse(t *testing.T) {
+	twoHundredResponseRef := &openapi3.ResponseRef{Value: &openapi3.Response{}}
+	twoHundredTwoResponseRef := &openapi3.ResponseRef{Value: &openapi3.Response{}}
+	twoHundredRangeResponseRef := &openapi3.ResponseRef{Value: &openapi3.Response{}}
+	threeHundredRangeResponseRef := &openapi3.ResponseRef{Value: &openapi3.Response{}}
+
+	responses := openapi3.Responses{
+		"200": twoHundredResponseRef,
+		"202": twoHundredTwoResponseRef,
+		"2XX": twoHundredRangeResponseRef,
+		"3XX": threeHundredRangeResponseRef,
+	}
+
+	// OpenAPI-to-GraphQL translator mimics IBM/openapi-to-graphql tool. This tool accepts HTTP code 200-299 or 2XX
+	// as valid responses. Other status codes are simply ignored. Currently, we follow the same convention.
+	statusCode, responseRef, err := getValidResponse(responses)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, statusCode)
+	assert.Equal(t, twoHundredResponseRef, responseRef)
 }


### PR DESCRIPTION
This PR fixes bad handling of responses if an HTTP status code range and explicit code definition are used at the same time. The OpenAPI specification is clear about this:

> To define a range of response codes, you may use the following range definitions: 1XX, 2XX, 3XX, 4XX, and 5XX. If a response range is defined using an explicit code, the explicit code definition takes precedence over the range definition for that code.

Now, the OpenAPI-to-GraphQL translator picks the explicit code definition over the range definition. 

Suppose the OpenAPI document contains multiple possible successful response objects (HTTP code 200-299 or 2XX). Only one can be chosen. It selects the first response object with the successful status code (200-299). The response object with the HTTP code 200 will be selected if defined. This behavior is borrowed from IBM/openapi-to-graphql tool.

This PR also removes redundant and useless code in response handling. 

The changes will be copied to the `v2` folder after approval.