### PR TITLE
[TT-11295] Gateway Panics when arguments are not defined in operation section

### DIFF
--- a/pkg/astvalidation/operation_rule_valid_arguments.go
+++ b/pkg/astvalidation/operation_rule_valid_arguments.go
@@ -71,6 +71,16 @@ func (v *validArgumentsVisitor) validateIfValueSatisfiesInputFieldDefinition(val
 		return
 	}
 
+	if operationTypeRef == ast.InvalidRef {
+		variableName, err := v.operation.PrintValueBytes(value, nil)
+		if v.HandleInternalErr(err) {
+			return
+		}
+		operationName := v.operation.Input.ByteSlice(v.operation.OperationDefinitions[v.Ancestors[0].Ref].Name)
+		v.StopWithExternalErr(operationreport.ErrVariableNotDefinedByOperation(string(variableName), value.Position, operationName))
+		return
+	}
+
 	printedValue, err := v.operation.PrintValueBytes(value, nil)
 	if v.HandleInternalErr(err) {
 		return

--- a/pkg/astvalidation/operation_validation_test.go
+++ b/pkg/astvalidation/operation_validation_test.go
@@ -3871,6 +3871,14 @@ func TestExecutionValidation(t *testing.T) {
 					))
 			})
 		})
+		t.Run("5.8.6 Variable not Defined by Operation", func(t *testing.T) {
+			run(t, `query intCannotGoIntoBoolean {
+									arguments {
+										booleanArgField(booleanArg: $intArg)
+									}
+								}`,
+				ValidArguments(), Invalid, withValidationErrors(`external: Variable "$intArg" is not defined by operation "intCannotGoIntoBoolean", locations: [{Line:3 Column:39}], path: [query,arguments,booleanArgField]`))
+		})
 	})
 }
 

--- a/pkg/operationreport/externalerror.go
+++ b/pkg/operationreport/externalerror.go
@@ -497,3 +497,9 @@ func ErrDuplicateFieldsMustBeIdentical(fieldName, parentName, typeOne, typeTwo s
 		"first subgraph: type '%s'\n second subgraph: type '%s'", fieldName, parentName, typeOne, typeTwo)
 	return err
 }
+
+func ErrVariableNotDefinedByOperation(variableName string, position position.Position, operationName ast.ByteSlice) (err ExternalError) {
+	err.Message = fmt.Sprintf(`Variable "%s" is not defined by operation "%s"`, variableName, operationName)
+	err.Locations = LocationsFromPosition(position)
+	return err
+}

--- a/v2/pkg/astvalidation/operation_rule_valid_arguments.go
+++ b/v2/pkg/astvalidation/operation_rule_valid_arguments.go
@@ -71,6 +71,16 @@ func (v *validArgumentsVisitor) validateIfValueSatisfiesInputFieldDefinition(val
 		return
 	}
 
+	if operationTypeRef == ast.InvalidRef {
+		variableName, err := v.operation.PrintValueBytes(value, nil)
+		if v.HandleInternalErr(err) {
+			return
+		}
+		operationName := v.operation.Input.ByteSlice(v.operation.OperationDefinitions[v.Ancestors[0].Ref].Name)
+		v.StopWithExternalErr(operationreport.ErrVariableNotDefinedByOperation(string(variableName), value.Position, operationName))
+		return
+	}
+
 	printedValue, err := v.operation.PrintValueBytes(value, nil)
 	if v.HandleInternalErr(err) {
 		return

--- a/v2/pkg/astvalidation/operation_validation_test.go
+++ b/v2/pkg/astvalidation/operation_validation_test.go
@@ -3874,6 +3874,15 @@ func TestExecutionValidation(t *testing.T) {
 						`Variable "$a" of type "Boolean" used in position expecting type "[String]"`,
 					))
 			})
+
+			t.Run("5.8.6 Variable not Defined by Operation", func(t *testing.T) {
+				run(t, `query intCannotGoIntoBoolean {
+									arguments {
+										booleanArgField(booleanArg: $intArg)
+									}
+								}`,
+					ValidArguments(), Invalid, withValidationErrors(`external: Variable "$intArg" is not defined by operation "intCannotGoIntoBoolean", locations: [{Line:3 Column:39}], path: [query,arguments,booleanArgField]`))
+			})
 		})
 	})
 }

--- a/v2/pkg/operationreport/externalerror.go
+++ b/v2/pkg/operationreport/externalerror.go
@@ -507,3 +507,9 @@ func ErrDuplicateFieldsMustBeIdentical(fieldName, parentName, typeOne, typeTwo s
 		"first subgraph: type '%s'\n second subgraph: type '%s'", fieldName, parentName, typeOne, typeTwo)
 	return err
 }
+
+func ErrVariableNotDefinedByOperation(variableName string, position position.Position, operationName ast.ByteSlice) (err ExternalError) {
+	err.Message = fmt.Sprintf(`Variable "%s" is not defined by operation "%s"`, variableName, operationName)
+	err.Locations = LocationsFromPosition(position)
+	return err
+}


### PR DESCRIPTION
This PR fixes TT-11295. The problem was not related to the Persist GQL feature. The library fails to validate a specifically crafted query in which variables are not defined in the operation. 

An example query: 

```graphql
query Analytics ($startMonth: String, $startYear: String!, $endDay: String!, $endMonth: String, $endYear: String!){
  analytics(
    EndDay: $endDay
    EndMonth: $endMonth
    EndYear: $endYear
    StartDay: $startDay
    StartMonth: $startMonth
    StartYear: $startYear
  ) {
    data {
      error
      hits
      success
      id {
        alias
        key
        additional_data {
          data {
            meta_data {
              department
            }
            tags
          }
        }
      }
    }
  }
}
```

`$startDay` is not defined in the operation `Analytics`. The library panics when you try to run this query. With this PR, it returns the following error:

```json:
{
  "message": "Variable \"$startDay\" is not defined by operation \"Analytics\"",
  "locations": [
    {
      "line": 6,
      "column": 15
    }
  ],
  "path": [
    "query",
    "analytics"
  ]
}
```