### PR TITLE
[TT-11737] [PoC] custom Tyk directive @uppercase

### DIFF
--- a/pkg/customdirective/customdirective.go
+++ b/pkg/customdirective/customdirective.go
@@ -1,0 +1,7 @@
+package customdirective
+
+type CustomDirective interface {
+	Name() string
+	DataType() string
+	Execute([]byte) ([]byte, error)
+}


### PR DESCRIPTION
Proof of concept for [TT-11737](https://tyktech.atlassian.net/browse/TT-11737). 

* A custom directive has been added named `toUpper`. 
* `CustomDirective` interface has been added. Any struct that implements this interface can be used as a directive.
* This PoC only works for the proxy-only method. It's easy to extend it.
* The actual implementation lives in `pkg/engine/plan/plan.go` and `pkg/engine/resolve/resolve.go` files.
* The GraphQL data source takes a map of custom directives, it doesn't push the custom directives to the upstream. 
* The resolver executes the directive's business logic. 

Passing the custom directives to the inner layers of the library required some attention but the implementation itself is not too complicated. The directive implementation lives in Tyk GW and it's passed to the library via `graphql.NewProxyEngineConfigFactory` after initialization.