### PR TITLE
[TT-12313] UDG APIs - Array of strings in variables gets transformed to one big string by engine

### DIFF
--- a/pkg/engine/resolve/variable.go
+++ b/pkg/engine/resolve/variable.go
@@ -13,6 +13,8 @@ import (
 	"github.com/buger/jsonparser"
 )
 
+var doubleQuoteCharacter byte = 34
+
 type VariableKind int
 
 const (
@@ -637,8 +639,6 @@ func (v *Variables) AddVariable(variable Variable) (name string, exists bool) {
 type VariableSchema struct {
 }
 
-var doubleQuote byte = 34
-
 func extractStringWithQuotes(rootValueType JsonRootType, data []byte) ([]byte, jsonparser.ValueType) {
 	desiredType := jsonparser.Unknown
 	switch rootValueType.Kind {
@@ -652,7 +652,9 @@ func extractStringWithQuotes(rootValueType JsonRootType, data []byte) ([]byte, j
 	}
 
 	if desiredType == jsonparser.String {
-		if data[0] == doubleQuote && data[len(data)-1] == doubleQuote {
+		// Strip double quotes if data is a valid JSON string.
+		// See TT-12222 for more info.
+		if data[0] == doubleQuoteCharacter && data[len(data)-1] == doubleQuoteCharacter {
 			return data[1 : len(data)-1], desiredType
 		}
 	}

--- a/pkg/engine/resolve/variable.go
+++ b/pkg/engine/resolve/variable.go
@@ -4,10 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/buger/jsonparser"
 	"io"
 	"strconv"
-
-	"github.com/buger/jsonparser"
 
 	"github.com/TykTechnologies/graphql-go-tools/pkg/ast"
 	"github.com/TykTechnologies/graphql-go-tools/pkg/graphqljsonschema"
@@ -636,7 +635,7 @@ func extractStringWithQuotes(rootValueType JsonRootType, data []byte) ([]byte, j
 		}
 	}
 	if desiredType == jsonparser.String {
-		return data[1 : len(data)-1], desiredType
+		//return data[1 : len(data)-1], desiredType
 	}
 	return data, desiredType
 }

--- a/pkg/engine/resolve/variable.go
+++ b/pkg/engine/resolve/variable.go
@@ -652,7 +652,7 @@ func extractStringWithQuotes(rootValueType JsonRootType, data []byte) ([]byte, j
 	}
 
 	if desiredType == jsonparser.String {
-		// Strip double quotes if data is a valid JSON string.
+		// The JSON standard requires double quotes. We strip double quotes if data is a valid JSON string.
 		// See TT-12222 for more info.
 		if data[0] == doubleQuoteCharacter && data[len(data)-1] == doubleQuoteCharacter {
 			return data[1 : len(data)-1], desiredType

--- a/pkg/engine/resolve/variable.go
+++ b/pkg/engine/resolve/variable.go
@@ -125,6 +125,8 @@ func NewPlainVariableRendererWithValidationFromTypeRef(operation, definition *as
 		jsonSchema = graphqljsonschema.FromTypeRef(operation, definition, variableTypeRef)
 	}
 
+	fmt.Println(">>> NewPlainVariableRendererWithValidationFromTypeRef >>", variablePath, jsonSchema.Kind())
+
 	validator, err := graphqljsonschema.NewValidatorFromSchema(jsonSchema)
 	if err != nil {
 		return nil, err
@@ -166,7 +168,7 @@ func (p *PlainVariableRenderer) RenderVariable(ctx context.Context, data []byte,
 		}
 	}
 
-	data, _ = extractStringWithQuotes(p.rootValueType, data)
+	//data, _ = extractStringWithQuotes(p.rootValueType, data)
 
 	_, err := out.Write(data)
 	return err

--- a/pkg/postprocess/datasourceinput.go
+++ b/pkg/postprocess/datasourceinput.go
@@ -72,10 +72,11 @@ func (d *ProcessDataSource) traverseSingleFetch(fetch *resolve.SingleFetch) {
 	fetch.SetTemplateOutputToNullOnVariableNull = false
 }
 
-// correctGraphQLVariableTypes removes double quotes from the variable definition if the variable is not a string.
+// correctGraphQLVariableTypes removes double quotes from the variable definition if the variable type is not a string.
 // This function is only intended for variables in a GraphQL request body.
 func correctGraphQLVariableTypes(variables resolve.Variables, input string) string {
 	// See TT-12313 for details.
+	// The input should be a valid JSON. So it is normal to use double quotes for string values (variable markers).
 	_, _, _, err := jsonparser.Get([]byte(input), "body", "variables")
 	if errors.Is(err, jsonparser.KeyPathNotFoundError) {
 		// No variables, return the input as-is.

--- a/pkg/postprocess/datasourceinput.go
+++ b/pkg/postprocess/datasourceinput.go
@@ -70,7 +70,8 @@ func (d *ProcessDataSource) traverseSingleFetch(fetch *resolve.SingleFetch) {
 }
 
 func (d *ProcessDataSource) resolveInputTemplate(variables resolve.Variables, input string, template *resolve.InputTemplate) {
-
+	input = strings.ReplaceAll(input, "\"$", "$")
+	input = strings.ReplaceAll(input, "$\"", "$")
 	if input == "" {
 		return
 	}

--- a/pkg/postprocess/datasourceinput.go
+++ b/pkg/postprocess/datasourceinput.go
@@ -1,6 +1,7 @@
 package postprocess
 
 import (
+	"errors"
 	"fmt"
 	"github.com/buger/jsonparser"
 	"strconv"
@@ -71,6 +72,50 @@ func (d *ProcessDataSource) traverseSingleFetch(fetch *resolve.SingleFetch) {
 	fetch.SetTemplateOutputToNullOnVariableNull = false
 }
 
+// correctGraphQLVariableTypes removes double quotes from the variable definition if the variable is not a string.
+// This function is only intended for variables in a GraphQL request body.
+func correctGraphQLVariableTypes(variables resolve.Variables, input string) string {
+	// See TT-12313 for details.
+	_, _, _, err := jsonparser.Get([]byte(input), "body", "variables")
+	if errors.Is(err, jsonparser.KeyPathNotFoundError) {
+		// No variables, return the input as-is.
+		return input
+	}
+
+	segments := strings.Split(input, "$$")
+	isVariable := false
+	for _, seg := range segments {
+		switch {
+		case isVariable:
+			i, _ := strconv.Atoi(seg)
+			variableTemplateSegment := (variables)[i].TemplateSegment()
+			if variableTemplateSegment.Renderer == nil {
+				continue
+			}
+			// Get the variable type from its renderer. If the type isn't a string, remove double quotes
+			//
+			// Possible types:
+			// 	* NotExist
+			//	* String
+			//	* Number
+			//	* Object
+			//	* Array
+			//	* Boolean
+			//	* Null
+			//	* Unknown
+			if variableTemplateSegment.Renderer.GetRootValueType().Value != jsonparser.String {
+				newVariable := fmt.Sprintf("$$%s$$", seg)
+				oldVariable := fmt.Sprintf("\"%s\"", newVariable)
+				input = strings.Replace(input, oldVariable, newVariable, 1)
+			}
+			isVariable = false
+		default:
+			isVariable = true
+		}
+	}
+	return input
+}
+
 func (d *ProcessDataSource) resolveInputTemplate(variables resolve.Variables, input string, template *resolve.InputTemplate) {
 	if input == "" {
 		return
@@ -84,28 +129,8 @@ func (d *ProcessDataSource) resolveInputTemplate(variables resolve.Variables, in
 		return
 	}
 
+	input = correctGraphQLVariableTypes(variables, input)
 	segments := strings.Split(input, "$$")
-
-	{
-		isVariable := false
-		for _, seg := range segments {
-			switch {
-			case isVariable:
-				i, _ := strconv.Atoi(seg)
-				variableTemplateSegment := (variables)[i].TemplateSegment()
-				if variableTemplateSegment.Renderer.GetRootValueType().Value != jsonparser.String {
-					replacement := fmt.Sprintf("$$%s$$", seg)
-					oldVariable := fmt.Sprintf("\"%s\"", replacement)
-					input = strings.Replace(input, oldVariable, replacement, 1)
-				}
-				isVariable = false
-			default:
-				isVariable = true
-			}
-		}
-	}
-
-	segments = strings.Split(input, "$$")
 
 	isVariable := false
 	for _, seg := range segments {

--- a/pkg/postprocess/datasourceinput_test.go
+++ b/pkg/postprocess/datasourceinput_test.go
@@ -314,3 +314,268 @@ func TestDataSourceInput_Subscription_Process(t *testing.T) {
 
 	assert.Equal(t, expected, actual)
 }
+
+func TestDataSourceInput_Process_correctGraphQLVariableTypes(t *testing.T) {
+	// id is an integer, not a string. This tests checks the template after processing.
+	// See correctGraphQLVariableTypes function for the details.
+	pre := &plan.SynchronousResponsePlan{
+		Response: &resolve.GraphQLResponse{
+			Data: &resolve.Object{
+				Fetch: &resolve.SingleFetch{
+					BufferId:   0,
+					Input:      `{"method":"POST","url":"http://localhost:4001/$$0$$","body":{"query":"{me {id username}}"}}`,
+					DataSource: nil,
+					Variables: []resolve.Variable{
+						&resolve.ContextVariable{
+							Path:     []string{"id"},
+							Renderer: resolve.NewPlainVariableRenderer(),
+						},
+					},
+				},
+				Fields: []*resolve.Field{
+					{
+						HasBuffer: true,
+						BufferID:  0,
+						Name:      []byte("me"),
+						Value: &resolve.Object{
+							Fetch: &resolve.SingleFetch{
+								BufferId: 1,
+								Input:    `{"method":"POST","url":"http://localhost:4002","body":{"query":"query($representations: [_Any!]!){_entities(representations: $representations){... on User {reviews {body product {upc __typename}}}}}","variables":{"representations":[{"id":"$$0$$","__typename":"User"}]}}}`,
+								Variables: resolve.NewVariables(
+									&resolve.ObjectVariable{
+										Path:     []string{"id"},
+										Renderer: resolve.NewPlainVariableRenderer(),
+									},
+								),
+								DataSource: nil,
+								ProcessResponseConfig: resolve.ProcessResponseConfig{
+									ExtractGraphqlResponse:    true,
+									ExtractFederationEntities: true,
+								},
+								SetTemplateOutputToNullOnVariableNull: true,
+							},
+							Path:     []string{"me"},
+							Nullable: true,
+							Fields: []*resolve.Field{
+								{
+									Name: []byte("id"),
+									Value: &resolve.Integer{
+										Path: []string{"id"},
+									},
+								},
+								{
+									Name: []byte("username"),
+									Value: &resolve.String{
+										Path: []string{"username"},
+									},
+								},
+
+								{
+
+									HasBuffer: true,
+									BufferID:  1,
+									Name:      []byte("reviews"),
+									Value: &resolve.Array{
+										Path:     []string{"reviews"},
+										Nullable: true,
+										Item: &resolve.Object{
+											Nullable: true,
+											Fields: []*resolve.Field{
+												{
+													Name: []byte("body"),
+													Value: &resolve.String{
+														Path: []string{"body"},
+													},
+												},
+												{
+													Name: []byte("product"),
+													Value: &resolve.Object{
+														Path: []string{"product"},
+														Fetch: &resolve.SingleFetch{
+															BufferId:   2,
+															Input:      `{"method":"POST","url":"http://localhost:4003","body":{"query":"query($representations: [_Any!]!){_entities(representations: $representations){... on Product {name}}}","variables":{"representations":[{"upc":"$$0$$","__typename":"Product"}]}}}`,
+															DataSource: nil,
+															Variables: resolve.NewVariables(
+																&resolve.ObjectVariable{
+																	Path: []string{"upc"},
+																},
+															),
+															ProcessResponseConfig: resolve.ProcessResponseConfig{
+																ExtractGraphqlResponse:    true,
+																ExtractFederationEntities: true,
+															},
+															SetTemplateOutputToNullOnVariableNull: true,
+														},
+														Fields: []*resolve.Field{
+															{
+																HasBuffer: true,
+																BufferID:  2,
+																Name:      []byte("name"),
+																Value: &resolve.String{
+																	Path: []string{"name"},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	expected := &plan.SynchronousResponsePlan{
+		Response: &resolve.GraphQLResponse{
+			Data: &resolve.Object{
+				Fetch: &resolve.SingleFetch{
+					BufferId: 0,
+					InputTemplate: resolve.InputTemplate{
+						Segments: []resolve.TemplateSegment{
+							{
+								Data:        []byte(`{"method":"POST","url":"http://localhost:4001/`),
+								SegmentType: resolve.StaticSegmentType,
+							},
+							{
+								SegmentType:        resolve.VariableSegmentType,
+								VariableKind:       resolve.ContextVariableKind,
+								VariableSourcePath: []string{"id"},
+								Renderer:           resolve.NewPlainVariableRenderer(),
+							},
+							{
+								Data:        []byte(`","body":{"query":"{me {id username}}"}}`),
+								SegmentType: resolve.StaticSegmentType,
+							},
+						},
+					},
+					DataSource: nil,
+				},
+				Fields: []*resolve.Field{
+					{
+						HasBuffer: true,
+						BufferID:  0,
+						Name:      []byte("me"),
+						Value: &resolve.Object{
+							Fetch: &resolve.SingleFetch{
+								BufferId: 1,
+								InputTemplate: resolve.InputTemplate{
+									Segments: []resolve.TemplateSegment{
+										{
+											Data:        []byte(`{"method":"POST","url":"http://localhost:4002","body":{"query":"query($representations: [_Any!]!){_entities(representations: $representations){... on User {reviews {body product {upc __typename}}}}}","variables":{"representations":[{"id":`),
+											SegmentType: resolve.StaticSegmentType,
+										},
+										{
+											SegmentType:        resolve.VariableSegmentType,
+											VariableKind:       resolve.ObjectVariableKind,
+											VariableSourcePath: []string{"id"},
+											Renderer:           resolve.NewPlainVariableRenderer(),
+										},
+										{
+											Data:        []byte(`,"__typename":"User"}]}}}`),
+											SegmentType: resolve.StaticSegmentType,
+										},
+									},
+									SetTemplateOutputToNullOnVariableNull: true,
+								},
+								DataSource: nil,
+								ProcessResponseConfig: resolve.ProcessResponseConfig{
+									ExtractGraphqlResponse:    true,
+									ExtractFederationEntities: true,
+								},
+							},
+							Path:     []string{"me"},
+							Nullable: true,
+							Fields: []*resolve.Field{
+								{
+									Name: []byte("id"),
+									Value: &resolve.Integer{
+										Path: []string{"id"},
+									},
+								},
+								{
+									Name: []byte("username"),
+									Value: &resolve.String{
+										Path: []string{"username"},
+									},
+								},
+
+								{
+
+									HasBuffer: true,
+									BufferID:  1,
+									Name:      []byte("reviews"),
+									Value: &resolve.Array{
+										Path:     []string{"reviews"},
+										Nullable: true,
+										Item: &resolve.Object{
+											Nullable: true,
+											Fields: []*resolve.Field{
+												{
+													Name: []byte("body"),
+													Value: &resolve.String{
+														Path: []string{"body"},
+													},
+												},
+												{
+													Name: []byte("product"),
+													Value: &resolve.Object{
+														Path: []string{"product"},
+														Fetch: &resolve.SingleFetch{
+															BufferId: 2,
+															InputTemplate: resolve.InputTemplate{
+																Segments: []resolve.TemplateSegment{
+																	{
+																		Data:        []byte(`{"method":"POST","url":"http://localhost:4003","body":{"query":"query($representations: [_Any!]!){_entities(representations: $representations){... on Product {name}}}","variables":{"representations":[{"upc":"`),
+																		SegmentType: resolve.StaticSegmentType,
+																	},
+																	{
+																		SegmentType:        resolve.VariableSegmentType,
+																		VariableKind:       resolve.ObjectVariableKind,
+																		VariableSourcePath: []string{"upc"},
+																	},
+																	{
+																		Data:        []byte(`","__typename":"Product"}]}}}`),
+																		SegmentType: resolve.StaticSegmentType,
+																	},
+																},
+																SetTemplateOutputToNullOnVariableNull: true,
+															},
+															ProcessResponseConfig: resolve.ProcessResponseConfig{
+																ExtractGraphqlResponse:    true,
+																ExtractFederationEntities: true,
+															},
+														},
+														Fields: []*resolve.Field{
+															{
+																HasBuffer: true,
+																BufferID:  2,
+																Name:      []byte("name"),
+																Value: &resolve.String{
+																	Path: []string{"name"},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	processor := &ProcessDataSource{}
+	actual := processor.Process(pre)
+
+	assert.Equal(t, expected, actual)
+}


### PR DESCRIPTION
This PR fixes [TT-12313](https://tyktech.atlassian.net/browse/TT-12313) and [TT-12222](https://tyktech.atlassian.net/browse/TT-12222).

**TT-12313:**

Variables in an input template were evaluating as strings by default. It may produce invalid JSON as rendered input data. Now it protects the original data type. 

See the following:

A valid input template, variables in the `variables` object are strings because this is a valid JSON.

```json
{
    "body": {
        "variables": {
            "id": "$$0$$",
            "theme_ids": "$$1$$",
            "abc": "$$2$$"
        },
        "query": "query ProductById($id: Int, $theme_ids: [String], $abc: String) {\n    product(id: $id, theme_ids: $theme_ids, abc: $abc) {\n        id\n        name\n        info\n        price\n        theme_ids\n    }\n}"
    },
    "method": "POST",
    "url": "tyk://be7b5a95fd814a4f6b4a02e806e66664/",
    "header": {}
}
```

We need to remove double quote characters if the variable type is not string.

`GetRootValueType ` method added to `VariableRenderer` interface to inspect the type information during input template rendering.

**TT-12222:**

Tyk GW may send `null` as a string and graphql-go-tools tries to strip double quotes from a string during the input template rendering. It strips the first and last characters without any control. I added a control to prevent corrupting the string.

graphql-go-tools has some unit tests for null type in input templates but Tyk GW sends it as a string. But the fix still worths to apply. 


[TT-12313]: https://tyktech.atlassian.net/browse/TT-12313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TT-12222]: https://tyktech.atlassian.net/browse/TT-12222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ