### PR TITLE
[TT-13608] Issues with custom scalar in query variable

### DIFF
--- a/pkg/astnormalization/input_coercion_for_list.go
+++ b/pkg/astnormalization/input_coercion_for_list.go
@@ -40,7 +40,7 @@ func (i *inputCoercionForListVisitor) EnterOperationDefinition(ref int) {
 
 func (i *inputCoercionForListVisitor) EnterVariableDefinition(ref int) {
 	variableNameString := i.operation.VariableDefinitionNameString(ref)
-	variableDefinition, exists := i.operation.VariableDefinitionByNameAndOperation(i.operationDefinitionRef, i.operation.VariableValueNameBytes(ref))
+	variableDefinition, exists := i.operation.VariableDefinitionByNameAndOperation(i.operationDefinitionRef, i.operation.VariableDefinitionNameBytes(ref))
 	if !exists {
 		return
 	}


### PR DESCRIPTION
PR for https://tyktech.atlassian.net/browse/TT-13608 

An analysis can be found here: https://tyktech.atlassian.net/browse/TT-13608?focusedCommentId=90515

Basically, input coercion for list visitor has been failing to infer the type of a node in the GQL operation and leaves the variable as-is instead of making a list from a object. 

This lead to raise `mismatched input value` error in `inputFieldDefaultInjectionVisitor` because the desired type was a `list` but the type in the `variables` JSON was an `object`. 

Inferring variable definition by its name not the value fixes the problem. 

I didn't copied the fix to `v2` folder because it already has the fix.