### PR TITLE
[TT-15426] fix: allow custom scalar values of any kind

### DIFF
--- a/pkg/astvalidation/operation_rule_values.go
+++ b/pkg/astvalidation/operation_rule_values.go
@@ -311,9 +311,10 @@ func (v *valuesVisitor) valueSatisfiesScalar(value ast.Value, definitionTypeRef 
 	case bytes.Equal(scalarName, literal.FLOAT):
 		return v.valueSatisfiesScalarFloat(value, definitionTypeRef)
 	case bytes.Equal(scalarName, literal.STRING):
-		return v.valueSatisfiesScalarString(value, definitionTypeRef, true)
+		return v.valueSatisfiesScalarString(value, definitionTypeRef)
 	default:
-		return v.valueSatisfiesScalarString(value, definitionTypeRef, false)
+		// custom scalar values could be of any kind
+		return true
 	}
 }
 
@@ -388,7 +389,7 @@ func (v *valuesVisitor) valueSatisfiesScalarFloat(value ast.Value, definitionTyp
 	return false
 }
 
-func (v *valuesVisitor) valueSatisfiesScalarString(value ast.Value, definitionTypeRef int, builtInStringScalar bool) bool {
+func (v *valuesVisitor) valueSatisfiesScalarString(value ast.Value, definitionTypeRef int) bool {
 	if value.Kind == ast.ValueKindString {
 		return true
 	}
@@ -398,11 +399,7 @@ func (v *valuesVisitor) valueSatisfiesScalarString(value ast.Value, definitionTy
 		return false
 	}
 
-	if builtInStringScalar {
-		v.Report.AddExternalError(operationreport.ErrValueDoesntSatisfyString(printedValue, printedType, value.Position))
-	} else {
-		v.Report.AddExternalError(operationreport.ErrValueDoesntSatisfyType(printedValue, printedType, value.Position))
-	}
+	v.Report.AddExternalError(operationreport.ErrValueDoesntSatisfyString(printedValue, printedType, value.Position))
 
 	return false
 }

--- a/pkg/astvalidation/operation_validation_test.go
+++ b/pkg/astvalidation/operation_validation_test.go
@@ -2846,6 +2846,35 @@ func TestExecutionValidation(t *testing.T) {
 				})
 			})
 
+			t.Run("valid custom scalar arguments", func(t *testing.T) {
+
+				const testSchema = `
+scalar BigInt
+
+schema {
+	query: Query
+}
+
+type Query {
+  add(a: BigInt!, b: BigInt!): BigInt!
+}
+
+`
+				t.Run("BigInt as arg given as integer", func(t *testing.T) {
+					runWithDefinition(t, testSchema, `{
+						add(a: 3000000000, b: 4000000000)
+					}`,
+						Values(), Valid)
+				})
+
+				t.Run("BigInt as arg given as string", func(t *testing.T) {
+					runWithDefinition(t, testSchema, `{
+						add(a: "3000000000", b: "4000000000")
+					}`,
+						Values(), Valid)
+				})
+			})
+
 			t.Run("145", func(t *testing.T) {
 				run(t, `
 							query goodComplexDefaultValue($search: ComplexInput = { name: "Fido" }) {

--- a/v2/pkg/astvalidation/operation_rule_values.go
+++ b/v2/pkg/astvalidation/operation_rule_values.go
@@ -311,9 +311,10 @@ func (v *valuesVisitor) valueSatisfiesScalar(value ast.Value, definitionTypeRef 
 	case bytes.Equal(scalarName, literal.FLOAT):
 		return v.valueSatisfiesScalarFloat(value, definitionTypeRef)
 	case bytes.Equal(scalarName, literal.STRING):
-		return v.valueSatisfiesScalarString(value, definitionTypeRef, true)
+		return v.valueSatisfiesScalarString(value, definitionTypeRef)
 	default:
-		return v.valueSatisfiesScalarString(value, definitionTypeRef, false)
+		// custom scalar values could be of any kind
+		return true
 	}
 }
 
@@ -388,7 +389,7 @@ func (v *valuesVisitor) valueSatisfiesScalarFloat(value ast.Value, definitionTyp
 	return false
 }
 
-func (v *valuesVisitor) valueSatisfiesScalarString(value ast.Value, definitionTypeRef int, builtInStringScalar bool) bool {
+func (v *valuesVisitor) valueSatisfiesScalarString(value ast.Value, definitionTypeRef int) bool {
 	if value.Kind == ast.ValueKindString {
 		return true
 	}
@@ -398,11 +399,7 @@ func (v *valuesVisitor) valueSatisfiesScalarString(value ast.Value, definitionTy
 		return false
 	}
 
-	if builtInStringScalar {
-		v.Report.AddExternalError(operationreport.ErrValueDoesntSatisfyString(printedValue, printedType, value.Position))
-	} else {
-		v.Report.AddExternalError(operationreport.ErrValueDoesntSatisfyType(printedValue, printedType, value.Position))
-	}
+	v.Report.AddExternalError(operationreport.ErrValueDoesntSatisfyString(printedValue, printedType, value.Position))
 
 	return false
 }

--- a/v2/pkg/astvalidation/operation_validation_test.go
+++ b/v2/pkg/astvalidation/operation_validation_test.go
@@ -2826,6 +2826,35 @@ func TestExecutionValidation(t *testing.T) {
 				})
 			})
 
+			t.Run("valid custom scalar arguments", func(t *testing.T) {
+
+				const testSchema = `
+scalar BigInt
+
+schema {
+	query: Query
+}
+
+type Query {
+  add(a: BigInt!, b: BigInt!): BigInt!
+}
+
+`
+				t.Run("BigInt as arg given as integer", func(t *testing.T) {
+					runWithDefinition(t, testSchema, `{
+						add(a: 3000000000, b: 4000000000)
+					}`,
+						Values(), Valid)
+				})
+
+				t.Run("BigInt as arg given as string", func(t *testing.T) {
+					runWithDefinition(t, testSchema, `{
+						add(a: "3000000000", b: "4000000000")
+					}`,
+						Values(), Valid)
+				})
+			})
+
 			t.Run("145", func(t *testing.T) {
 				run(t, `
 							query goodComplexDefaultValue($search: ComplexInput = { name: "Fido" }) {


### PR DESCRIPTION
Copied from https://github.com/wundergraph/graphql-go-tools/pull/1107

Custom scalar values should be able to be passed as any kind, not just strings. For example, a custom 64-bit integer value would be passed numerically.

Fixes https://github.com/wundergraph/graphql-go-tools/issues/1103

For cleanup, also removes the now extraneous builtInStringScalar parameter to valueSatisfiesScalarString, as it is only called on the built-in string scalar type.

