### PR TITLE
Fix/allow custom scalars extended

### DIFF
--- a/.github/workflows/v2.yml
+++ b/.github/workflows/v2.yml
@@ -55,6 +55,7 @@ jobs:
         with:
           working-directory: v2
           version: v2.1.6
+          only-new-issues: true
           args: --timeout=3m
   ci:
     name: CI Success

--- a/.github/workflows/v2.yml
+++ b/.github/workflows/v2.yml
@@ -51,10 +51,10 @@ jobs:
         with:
           go-version: 1.21
       - name: Run linters
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v8
         with:
           working-directory: v2
-          version: v1.55.2
+          version: v2.1.6
           args: --timeout=3m
   ci:
     name: CI Success

--- a/examples/kafka_pubsub/docker-compose-cluster.yml
+++ b/examples/kafka_pubsub/docker-compose-cluster.yml
@@ -2,7 +2,7 @@ version: "2"
 
 services:
   zookeeper:
-    image: docker.io/bitnami/zookeeper:3.8
+    image: docker.io/bitnamilegacy/zookeeper:3.8
     ports:
       - "2181:2181"
     volumes:
@@ -10,7 +10,7 @@ services:
     environment:
       - ALLOW_ANONYMOUS_LOGIN=yes
   kafka-0:
-    image: docker.io/bitnami/kafka:3.1
+    image: docker.io/bitnamilegacy/kafka:3.1
     ports:
       - "9082"
       - "9092:9092"
@@ -29,7 +29,7 @@ services:
     depends_on:
       - zookeeper
   kafka-1:
-    image: docker.io/bitnami/kafka:3.1
+    image: docker.io/bitnamilegacy/kafka:3.1
     ports:
       - "9082"
       - "9093:9092"
@@ -48,7 +48,7 @@ services:
     depends_on:
       - zookeeper
   kafka-2:
-    image: docker.io/bitnami/kafka:3.1
+    image: docker.io/bitnamilegacy/kafka:3.1
     ports:
       - "9082"
       - "9094:9092"
@@ -68,7 +68,7 @@ services:
       - zookeeper
 
   kafka-3:
-    image: docker.io/bitnami/kafka:3.1
+    image: docker.io/bitnamilegacy/kafka:3.1
     ports:
       - "9082"
       - "9095:9092"

--- a/examples/kafka_pubsub/docker-compose.yml
+++ b/examples/kafka_pubsub/docker-compose.yml
@@ -2,7 +2,7 @@ version: "2"
 
 services:
   zookeeper:
-    image: docker.io/bitnami/zookeeper:3.8
+    image: docker.io/bitnamilegacy/zookeeper:3.8
     ports:
       - "2181:2181"
     volumes:
@@ -10,7 +10,7 @@ services:
     environment:
       - ALLOW_ANONYMOUS_LOGIN=yes
   kafka:
-    image: docker.io/bitnami/kafka:3.1
+    image: docker.io/bitnamilegacy/kafka:3.1
     ports:
       - "9092:9092"
     volumes:
@@ -23,7 +23,7 @@ services:
       - zookeeper
 
   kafka-sasl:
-    image: docker.io/bitnami/kafka:3.1
+    image: docker.io/bitnamilegacy/kafka:3.1
     ports:
       - "9092:9092"
     volumes:

--- a/pkg/astvalidation/operation_rule_values.go
+++ b/pkg/astvalidation/operation_rule_values.go
@@ -311,9 +311,10 @@ func (v *valuesVisitor) valueSatisfiesScalar(value ast.Value, definitionTypeRef 
 	case bytes.Equal(scalarName, literal.FLOAT):
 		return v.valueSatisfiesScalarFloat(value, definitionTypeRef)
 	case bytes.Equal(scalarName, literal.STRING):
-		return v.valueSatisfiesScalarString(value, definitionTypeRef, true)
+		return v.valueSatisfiesScalarString(value, definitionTypeRef)
 	default:
-		return v.valueSatisfiesScalarString(value, definitionTypeRef, false)
+		// custom scalar values could be of any kind
+		return true
 	}
 }
 
@@ -388,7 +389,7 @@ func (v *valuesVisitor) valueSatisfiesScalarFloat(value ast.Value, definitionTyp
 	return false
 }
 
-func (v *valuesVisitor) valueSatisfiesScalarString(value ast.Value, definitionTypeRef int, builtInStringScalar bool) bool {
+func (v *valuesVisitor) valueSatisfiesScalarString(value ast.Value, definitionTypeRef int) bool {
 	if value.Kind == ast.ValueKindString {
 		return true
 	}
@@ -398,11 +399,7 @@ func (v *valuesVisitor) valueSatisfiesScalarString(value ast.Value, definitionTy
 		return false
 	}
 
-	if builtInStringScalar {
-		v.Report.AddExternalError(operationreport.ErrValueDoesntSatisfyString(printedValue, printedType, value.Position))
-	} else {
-		v.Report.AddExternalError(operationreport.ErrValueDoesntSatisfyType(printedValue, printedType, value.Position))
-	}
+	v.Report.AddExternalError(operationreport.ErrValueDoesntSatisfyString(printedValue, printedType, value.Position))
 
 	return false
 }

--- a/pkg/astvalidation/operation_validation_test.go
+++ b/pkg/astvalidation/operation_validation_test.go
@@ -2846,6 +2846,35 @@ func TestExecutionValidation(t *testing.T) {
 				})
 			})
 
+			t.Run("valid custom scalar arguments", func(t *testing.T) {
+
+				const testSchema = `
+scalar BigInt
+
+schema {
+	query: Query
+}
+
+type Query {
+  add(a: BigInt!, b: BigInt!): BigInt!
+}
+
+`
+				t.Run("BigInt as arg given as integer", func(t *testing.T) {
+					runWithDefinition(t, testSchema, `{
+						add(a: 3000000000, b: 4000000000)
+					}`,
+						Values(), Valid)
+				})
+
+				t.Run("BigInt as arg given as string", func(t *testing.T) {
+					runWithDefinition(t, testSchema, `{
+						add(a: "3000000000", b: "4000000000")
+					}`,
+						Values(), Valid)
+				})
+			})
+
 			t.Run("145", func(t *testing.T) {
 				run(t, `
 							query goodComplexDefaultValue($search: ComplexInput = { name: "Fido" }) {

--- a/pkg/engine/datasource/kafka_datasource/sarama_config_parameters_test.go
+++ b/pkg/engine/datasource/kafka_datasource/sarama_config_parameters_test.go
@@ -127,7 +127,7 @@ func (k *kafkaCluster) startKafka(t *testing.T, port int) *dockertest.Resource {
 	portID := getPortID(port)
 	resource, err := k.pool.RunWithOptions(&dockertest.RunOptions{
 		Name:       fmt.Sprintf("kafka-tyk-graphql-%d", port),
-		Repository: "bitnami/kafka",
+		Repository: "bitnamilegacy/kafka",
 		Tag:        "3.6.0",
 		NetworkID:  k.network.ID,
 		Hostname:   hostname,

--- a/pkg/engine/plan/plan.go
+++ b/pkg/engine/plan/plan.go
@@ -772,19 +772,29 @@ func (v *Visitor) resolveFieldValue(fieldRef, typeRef int, nullable bool, path [
 					Nullable: nullable,
 					Export:   fieldExport,
 				}
-			case "BigInt":
-				return &resolve.BigInt{
-					Path:     path,
-					Nullable: nullable,
-					Export:   fieldExport,
-				}
-			default:
+		case "BigInt":
+			return &resolve.BigInt{
+				Path:     path,
+				Nullable: nullable,
+				Export:   fieldExport,
+			}
+		case "JSON":
+			if unescapeResponseJson {
 				return &resolve.String{
 					Path:                 path,
 					Nullable:             nullable,
 					Export:               fieldExport,
 					UnescapeResponseJson: unescapeResponseJson,
 				}
+			}
+			fallthrough
+		default:
+			// Custom scalar - use Scalar node to pass through values as-is
+			return &resolve.Scalar{
+				Path:     path,
+				Nullable: nullable,
+				Export:   fieldExport,
+			}
 			}
 		case ast.NodeKindEnumTypeDefinition:
 			return &resolve.String{

--- a/pkg/engine/plan/plan.go
+++ b/pkg/engine/plan/plan.go
@@ -772,29 +772,27 @@ func (v *Visitor) resolveFieldValue(fieldRef, typeRef int, nullable bool, path [
 					Nullable: nullable,
 					Export:   fieldExport,
 				}
-		case "BigInt":
-			return &resolve.BigInt{
-				Path:     path,
-				Nullable: nullable,
-				Export:   fieldExport,
-			}
-		case "JSON":
-			if unescapeResponseJson {
+			case "BigInt":
+				return &resolve.BigInt{
+					Path:     path,
+					Nullable: nullable,
+					Export:   fieldExport,
+				}
+			case "JSON":
+				// JSON scalar always uses String node, with optional unescape
 				return &resolve.String{
 					Path:                 path,
 					Nullable:             nullable,
 					Export:               fieldExport,
 					UnescapeResponseJson: unescapeResponseJson,
 				}
-			}
-			fallthrough
-		default:
-			// Custom scalar - use Scalar node to pass through values as-is
-			return &resolve.Scalar{
-				Path:     path,
-				Nullable: nullable,
-				Export:   fieldExport,
-			}
+			default:
+				// Custom scalar - use Scalar node to pass through values as-is
+				return &resolve.Scalar{
+					Path:     path,
+					Nullable: nullable,
+					Export:   fieldExport,
+				}
 			}
 		case ast.NodeKindEnumTypeDefinition:
 			return &resolve.String{

--- a/pkg/engine/plan/plan_test.go
+++ b/pkg/engine/plan/plan_test.go
@@ -510,8 +510,9 @@ func TestPlanner_Plan(t *testing.T) {
 										Fields: []*resolve.Field{
 									{
 										Name: []byte("info"),
-										Value: &resolve.Scalar{
-											Path: []string{"info"},
+										Value: &resolve.String{
+											Path:                 []string{"info"},
+											UnescapeResponseJson: false,
 										},
 									},
 										},

--- a/pkg/engine/plan/plan_test.go
+++ b/pkg/engine/plan/plan_test.go
@@ -340,6 +340,46 @@ func TestPlanner_Plan(t *testing.T) {
 		))
 	})
 
+	t.Run("custom scalar long", func(t *testing.T) {
+		schema := `
+			scalar Long
+			
+			schema {
+				query: Query
+			}
+			
+			type Query {
+				getLong(id: Long!): Long!
+			}
+		`
+
+		t.Run("Long scalar field", test(
+			schema, `
+			{
+				getLong(id: 9223372036854775807)
+			}
+		`, "",
+			&SynchronousResponsePlan{
+				FlushInterval: 0,
+				Response: &resolve.GraphQLResponse{
+					Data: &resolve.Object{
+						Fields: []*resolve.Field{
+							{
+								Name: []byte("getLong"),
+								Value: &resolve.Scalar{
+									Path: []string{"getLong"},
+								},
+							},
+						},
+					},
+				},
+			},
+			Configuration{
+				DisableResolveFieldPositions: true,
+			},
+		))
+	})
+
 	t.Run("unescape response json", func(t *testing.T) {
 		schema := `
 			scalar JSON
@@ -468,13 +508,12 @@ func TestPlanner_Plan(t *testing.T) {
 									Value: &resolve.Object{
 										Path: []string{"hero"},
 										Fields: []*resolve.Field{
-											{
-												Name: []byte("info"),
-												Value: &resolve.String{
-													Path:                 []string{"info"},
-													UnescapeResponseJson: false,
-												},
-											},
+									{
+										Name: []byte("info"),
+										Value: &resolve.Scalar{
+											Path: []string{"info"},
+										},
+									},
 										},
 									},
 								},

--- a/pkg/engine/plan/plan_test.go
+++ b/pkg/engine/plan/plan_test.go
@@ -508,13 +508,13 @@ func TestPlanner_Plan(t *testing.T) {
 									Value: &resolve.Object{
 										Path: []string{"hero"},
 										Fields: []*resolve.Field{
-									{
-										Name: []byte("info"),
-										Value: &resolve.String{
-											Path:                 []string{"info"},
-											UnescapeResponseJson: false,
-										},
-									},
+											{
+												Name: []byte("info"),
+												Value: &resolve.String{
+													Path:                 []string{"info"},
+													UnescapeResponseJson: false,
+												},
+											},
 										},
 									},
 								},

--- a/pkg/engine/resolve/resolve.go
+++ b/pkg/engine/resolve/resolve.go
@@ -1651,7 +1651,7 @@ type Scalar struct {
 	Export   *FieldExport `json:"export,omitempty"`
 }
 
-func (_ *Scalar) NodeKind() NodeKind {
+func (*Scalar) NodeKind() NodeKind {
 	return NodeKindScalar
 }
 

--- a/pkg/engine/resolve/resolve.go
+++ b/pkg/engine/resolve/resolve.go
@@ -97,6 +97,7 @@ const (
 	NodeKindInteger
 	NodeKindFloat
 	NodeKindBigInt
+	NodeKindScalar
 	NodeKindCustom
 
 	FetchKindSingle FetchKind = iota + 1
@@ -431,6 +432,8 @@ func (r *Resolver) resolveNode(ctx *Context, node Node, data []byte, bufPair *Bu
 		return r.resolveFloat(ctx, n, data, bufPair)
 	case *BigInt:
 		return r.resolveBigInt(ctx, n, data, bufPair)
+	case *Scalar:
+		return r.resolveScalar(ctx, n, data, bufPair)
 	case *EmptyObject:
 		r.resolveEmptyObject(bufPair.Data)
 		return
@@ -991,6 +994,27 @@ func (r *Resolver) resolveCustom(ctx *Context, customValue *CustomNode, data []b
 		return fmt.Errorf("failed to resolve value type %s for path %s via custom resolver", dataType, string(ctx.path()))
 	}
 	customBuf.Data.WriteBytes(resolvedValue)
+	return nil
+}
+
+func (r *Resolver) resolveScalar(ctx *Context, scalarValue *Scalar, data []byte, scalarBuf *BufPair) error {
+	value, valueType, _, err := jsonparser.Get(data, scalarValue.Path...)
+	switch {
+	case err != nil, valueType == jsonparser.Null:
+		if !scalarValue.Nullable {
+			return errNonNullableFieldValueIsNull
+		}
+		r.resolveNull(scalarBuf.Data)
+		return nil
+	case valueType == jsonparser.String:
+		scalarBuf.Data.WriteBytes(quote)
+		scalarBuf.Data.WriteBytes(value)
+		scalarBuf.Data.WriteBytes(quote)
+	default:
+		// For custom scalars, pass through numbers, booleans, objects, and arrays as-is
+		scalarBuf.Data.WriteBytes(value)
+	}
+	r.exportField(ctx, scalarValue.Export, value)
 	return nil
 }
 
@@ -1619,6 +1643,16 @@ type BigInt struct {
 
 func (BigInt) NodeKind() NodeKind {
 	return NodeKindBigInt
+}
+
+type Scalar struct {
+	Path     []string
+	Nullable bool
+	Export   *FieldExport `json:"export,omitempty"`
+}
+
+func (_ *Scalar) NodeKind() NodeKind {
+	return NodeKindScalar
 }
 
 type Array struct {

--- a/pkg/engine/resolve/resolve_test.go
+++ b/pkg/engine/resolve/resolve_test.go
@@ -207,6 +207,44 @@ func TestResolver_ResolveNode(t *testing.T) {
 			},
 		}, Context{ctx: context.Background()}, `{"n":12345,"ns_small":"12346","ns_big":"1152921504606846976"}`
 	}))
+	t.Run("Custom Scalar (Long) with number value", testFn(false, false, func(t *testing.T, ctrl *gomock.Controller) (node Node, ctx Context, expectedOutput string) {
+		return &Object{
+			Fetch: &SingleFetch{
+				BufferId:   0,
+				DataSource: FakeDataSource(`{"getLongFromString": 9223372036854775807}`),
+			},
+			Fields: []*Field{
+				{
+					BufferID:  0,
+					HasBuffer: true,
+					Name:      []byte("getLongFromString"),
+					Value: &Scalar{
+						Path:     []string{"getLongFromString"},
+						Nullable: false,
+					},
+				},
+			},
+		}, Context{ctx: context.Background()}, `{"getLongFromString":9223372036854775807}`
+	}))
+	t.Run("Custom Scalar (Long) with string value", testFn(false, false, func(t *testing.T, ctrl *gomock.Controller) (node Node, ctx Context, expectedOutput string) {
+		return &Object{
+			Fetch: &SingleFetch{
+				BufferId:   0,
+				DataSource: FakeDataSource(`{"getLongFromString": "9223372036854775807"}`),
+			},
+			Fields: []*Field{
+				{
+					BufferID:  0,
+					HasBuffer: true,
+					Name:      []byte("getLongFromString"),
+					Value: &Scalar{
+						Path:     []string{"getLongFromString"},
+						Nullable: false,
+					},
+				},
+			},
+		}, Context{ctx: context.Background()}, `{"getLongFromString":"9223372036854775807"}`
+	}))
 	t.Run("object with null field", testFn(false, false, func(t *testing.T, ctrl *gomock.Controller) (node Node, ctx Context, expectedOutput string) {
 		return &Object{
 			Fields: []*Field{

--- a/v2/examples/kafka_pubsub/docker-compose-cluster.yml
+++ b/v2/examples/kafka_pubsub/docker-compose-cluster.yml
@@ -2,7 +2,7 @@ version: "2"
 
 services:
   zookeeper:
-    image: docker.io/bitnami/zookeeper:3.8
+    image: docker.io/bitnamilegacy/zookeeper:3.8
     ports:
       - "2181:2181"
     volumes:
@@ -10,7 +10,7 @@ services:
     environment:
       - ALLOW_ANONYMOUS_LOGIN=yes
   kafka-0:
-    image: docker.io/bitnami/kafka:3.1
+    image: docker.io/bitnamilegacy/kafka:3.1
     ports:
       - "9082"
       - "9092:9092"
@@ -29,7 +29,7 @@ services:
     depends_on:
       - zookeeper
   kafka-1:
-    image: docker.io/bitnami/kafka:3.1
+    image: docker.io/bitnamilegacy/kafka:3.1
     ports:
       - "9082"
       - "9093:9092"
@@ -48,7 +48,7 @@ services:
     depends_on:
       - zookeeper
   kafka-2:
-    image: docker.io/bitnami/kafka:3.1
+    image: docker.io/bitnamilegacy/kafka:3.1
     ports:
       - "9082"
       - "9094:9092"
@@ -68,7 +68,7 @@ services:
       - zookeeper
 
   kafka-3:
-    image: docker.io/bitnami/kafka:3.1
+    image: docker.io/bitnamilegacy/kafka:3.1
     ports:
       - "9082"
       - "9095:9092"

--- a/v2/examples/kafka_pubsub/docker-compose.yml
+++ b/v2/examples/kafka_pubsub/docker-compose.yml
@@ -2,7 +2,7 @@ version: "2"
 
 services:
   zookeeper:
-    image: docker.io/bitnami/zookeeper:3.8
+    image: docker.io/bitnamilegacy/zookeeper:3.8
     ports:
       - "2181:2181"
     volumes:
@@ -10,7 +10,7 @@ services:
     environment:
       - ALLOW_ANONYMOUS_LOGIN=yes
   kafka:
-    image: docker.io/bitnami/kafka:3.1
+    image: docker.io/bitnamilegacy/kafka:3.1
     ports:
       - "9092:9092"
     volumes:
@@ -23,7 +23,7 @@ services:
       - zookeeper
 
   kafka-sasl:
-    image: docker.io/bitnami/kafka:3.1
+    image: docker.io/bitnamilegacy/kafka:3.1
     ports:
       - "9092:9092"
     volumes:

--- a/v2/pkg/astvalidation/operation_rule_values.go
+++ b/v2/pkg/astvalidation/operation_rule_values.go
@@ -311,9 +311,10 @@ func (v *valuesVisitor) valueSatisfiesScalar(value ast.Value, definitionTypeRef 
 	case bytes.Equal(scalarName, literal.FLOAT):
 		return v.valueSatisfiesScalarFloat(value, definitionTypeRef)
 	case bytes.Equal(scalarName, literal.STRING):
-		return v.valueSatisfiesScalarString(value, definitionTypeRef, true)
+		return v.valueSatisfiesScalarString(value, definitionTypeRef)
 	default:
-		return v.valueSatisfiesScalarString(value, definitionTypeRef, false)
+		// custom scalar values could be of any kind
+		return true
 	}
 }
 
@@ -388,7 +389,7 @@ func (v *valuesVisitor) valueSatisfiesScalarFloat(value ast.Value, definitionTyp
 	return false
 }
 
-func (v *valuesVisitor) valueSatisfiesScalarString(value ast.Value, definitionTypeRef int, builtInStringScalar bool) bool {
+func (v *valuesVisitor) valueSatisfiesScalarString(value ast.Value, definitionTypeRef int) bool {
 	if value.Kind == ast.ValueKindString {
 		return true
 	}
@@ -398,11 +399,7 @@ func (v *valuesVisitor) valueSatisfiesScalarString(value ast.Value, definitionTy
 		return false
 	}
 
-	if builtInStringScalar {
-		v.Report.AddExternalError(operationreport.ErrValueDoesntSatisfyString(printedValue, printedType, value.Position))
-	} else {
-		v.Report.AddExternalError(operationreport.ErrValueDoesntSatisfyType(printedValue, printedType, value.Position))
-	}
+	v.Report.AddExternalError(operationreport.ErrValueDoesntSatisfyString(printedValue, printedType, value.Position))
 
 	return false
 }

--- a/v2/pkg/astvalidation/operation_validation_test.go
+++ b/v2/pkg/astvalidation/operation_validation_test.go
@@ -2826,6 +2826,35 @@ func TestExecutionValidation(t *testing.T) {
 				})
 			})
 
+			t.Run("valid custom scalar arguments", func(t *testing.T) {
+
+				const testSchema = `
+scalar BigInt
+
+schema {
+	query: Query
+}
+
+type Query {
+  add(a: BigInt!, b: BigInt!): BigInt!
+}
+
+`
+				t.Run("BigInt as arg given as integer", func(t *testing.T) {
+					runWithDefinition(t, testSchema, `{
+						add(a: 3000000000, b: 4000000000)
+					}`,
+						Values(), Valid)
+				})
+
+				t.Run("BigInt as arg given as string", func(t *testing.T) {
+					runWithDefinition(t, testSchema, `{
+						add(a: "3000000000", b: "4000000000")
+					}`,
+						Values(), Valid)
+				})
+			})
+
 			t.Run("145", func(t *testing.T) {
 				run(t, `
 							query goodComplexDefaultValue($search: ComplexInput = { name: "Fido" }) {

--- a/v2/pkg/engine/datasource/kafka_datasource/sarama_config_parameters_test.go
+++ b/v2/pkg/engine/datasource/kafka_datasource/sarama_config_parameters_test.go
@@ -127,7 +127,7 @@ func (k *kafkaCluster) startKafka(t *testing.T, port int) *dockertest.Resource {
 	portID := getPortID(port)
 	resource, err := k.pool.RunWithOptions(&dockertest.RunOptions{
 		Name:       fmt.Sprintf("kafka-tyk-graphql-%d", port),
-		Repository: "bitnami/kafka",
+		Repository: "bitnamilegacy/kafka",
 		Tag:        "3.6.0",
 		NetworkID:  k.network.ID,
 		Hostname:   hostname,


### PR DESCRIPTION
This PR fixes validation and resolution issues with custom scalars in GraphQL operations. Previously, custom scalars were incorrectly treated as built-in String scalars during validation, requiring
  string values and throwing validation errors for other types. The changes allow custom scalars to accept any value type (integers, strings, objects, etc.) during validation and introduce a new Scalar
  node type in the resolver that passes through values as-is without type coercion. The fix includes special handling for the JSON scalar (unescaped strings) and BigInt scalar (dedicated node type), while
   all other custom scalars use the generic pass-through behavior. Tests have been added to verify that custom scalar arguments can be provided as both integers and strings, ensuring flexibility in how
  custom scalars are used across the codebase.