### PR TITLE
[TT-17165] fix(v2): use-after-free in async subscription context lifetime

### DIFF
--- a/v2/pkg/graphql/execution_engine_v2_custom.go
+++ b/v2/pkg/graphql/execution_engine_v2_custom.go
@@ -103,6 +103,23 @@ func (c *CustomExecutionEngineV2Executor) putExecutionCtx(ctx *internalExecution
 	c.internalExecutionContextPool.Put(ctx)
 }
 
+// putExecutionCtxAfterAsyncSubscription releases the wrapper back to the pool
+// without calling Free() on the in-flight resolve.Context that has been handed
+// off to the asynchronous subscription resolver loop. The resolver retains a
+// reference to that context for the lifetime of the subscription; freeing it
+// here would race with the resolver goroutine and corrupt live subscription
+// state (see TestCustomExecutionEngineV2Executor_AsyncSubscription_NoUseAfterFree).
+//
+// To keep the pooled wrapper safe for reuse we swap its resolveContext pointer
+// for a fresh one so that the next caller does not inherit stale per-request
+// fields (Variables, Stats, RenameTypeNames, ...). The original context is now
+// owned exclusively by the resolver and will be GC'd when the subscription
+// terminates.
+func (c *CustomExecutionEngineV2Executor) putExecutionCtxAfterAsyncSubscription(ctx *internalExecutionContext) {
+	ctx.resolveContext = resolve.NewContext(context.Background())
+	c.internalExecutionContextPool.Put(ctx)
+}
+
 func (c *CustomExecutionEngineV2Executor) Execute(ctx context.Context, operation *Request, writer resolve.SubscriptionResponseWriter, options ...ExecutionOptionsV2) error {
 	if !c.ExecutionStages.AllRequiredStagesProvided() {
 		return ErrRequiredStagesMissing
@@ -130,7 +147,20 @@ func (c *CustomExecutionEngineV2Executor) Execute(ctx context.Context, operation
 	}
 
 	execContext := c.getExecutionCtx()
-	defer c.putExecutionCtx(execContext)
+	// asyncSubscription is set when planResult is a *plan.SubscriptionResponsePlan
+	// because the only resolver path for that plan kind (see ExecutionEngineV2.Resolve)
+	// is AsyncResolveGraphQLSubscription, which hands the resolve.Context off to a
+	// background goroutine. In that case the deferred release MUST NOT Free() the
+	// context — that would race with the resolver loop's xcontext.Detach call and
+	// crash subscriptions. See putExecutionCtxAfterAsyncSubscription for details.
+	var asyncSubscription bool
+	defer func() {
+		if asyncSubscription {
+			c.putExecutionCtxAfterAsyncSubscription(execContext)
+			return
+		}
+		c.putExecutionCtx(execContext)
+	}()
 	execContext.prepare(ctx, operation.Variables, operation.request)
 	c.ExecutionStages.RequiredStages.ResolverStage.Setup(ctx, execContext.postProcessor, execContext.resolveContext, operation, options...)
 
@@ -140,6 +170,10 @@ func (c *CustomExecutionEngineV2Executor) Execute(ctx context.Context, operation
 		return err
 	} else if report.HasErrors() {
 		return report
+	}
+
+	if _, ok := planResult.(*plan.SubscriptionResponsePlan); ok {
+		asyncSubscription = true
 	}
 
 	err = c.ExecutionStages.RequiredStages.ResolverStage.Resolve(execContext.resolveContext, planResult, writer)

--- a/v2/pkg/graphql/execution_engine_v2_custom_subscription_test.go
+++ b/v2/pkg/graphql/execution_engine_v2_custom_subscription_test.go
@@ -1,0 +1,276 @@
+package graphql
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cespare/xxhash/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/TykTechnologies/graphql-go-tools/v2/pkg/engine/plan"
+	"github.com/TykTechnologies/graphql-go-tools/v2/pkg/engine/postprocess"
+	"github.com/TykTechnologies/graphql-go-tools/v2/pkg/engine/resolve"
+	"github.com/TykTechnologies/graphql-go-tools/v2/pkg/operationreport"
+)
+
+// TestCustomExecutionEngineV2Executor_AsyncSubscription_NoUseAfterFree exercises the
+// async subscription path of the custom executor. The executor used to free the
+// resolve.Context in a deferred call inside Execute, while AsyncResolveGraphQLSubscription
+// had already enqueued that same *resolve.Context onto the resolver's event loop.
+// The async loop later dereferenced the freed context and crashed inside
+// xcontext.Detach -> context.WithCancel.
+//
+// The repro:
+//   - Build a CustomExecutionEngineV2Executor.
+//   - Resolver stage returns a SubscriptionResponsePlan and resolves through the real
+//     resolver via AsyncResolveGraphQLSubscription, just like ExecutionEngineV2 does.
+//   - A fake stream emits 3 events then completes.
+//   - Without the fix this test panics inside the resolver goroutine; with the fix
+//     all three events arrive in order and the writer sees a Complete().
+func TestCustomExecutionEngineV2Executor_AsyncSubscription_NoUseAfterFree(t *testing.T) {
+	defaultTimeout := 10 * time.Second
+
+	rCtx, rCancel := context.WithCancel(context.Background())
+	defer rCancel()
+
+	resolver := resolve.New(rCtx, resolve.ResolverOptions{
+		MaxConcurrency: 16,
+	})
+
+	// Simple subscription plan with a fake stream that emits {"data":{"counter":N}} until N==2.
+	stream := newFakeSubscriptionStream(func(counter int) (string, bool) {
+		return fmt.Sprintf(`{"data":{"counter":%d}}`, counter), counter == 2
+	})
+
+	subscriptionPlan := &plan.SubscriptionResponsePlan{
+		Response: &resolve.GraphQLSubscription{
+			Trigger: resolve.GraphQLSubscriptionTrigger{
+				Source: stream,
+				InputTemplate: resolve.InputTemplate{
+					Segments: []resolve.TemplateSegment{
+						{
+							SegmentType: resolve.StaticSegmentType,
+							Data:        []byte(`{"method":"POST","url":"http://localhost:4000","body":{"query":"subscription { counter }"}}`),
+						},
+					},
+				},
+				PostProcessing: resolve.PostProcessingConfiguration{
+					SelectResponseDataPath:   []string{"data"},
+					SelectResponseErrorsPath: []string{"errors"},
+				},
+			},
+			Response: &resolve.GraphQLResponse{
+				Data: &resolve.Object{
+					Fields: []*resolve.Field{
+						{
+							Name: []byte("counter"),
+							Value: &resolve.Integer{
+								Path: []string{"counter"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	stage := &subscriptionResolverStage{
+		resolver: resolver,
+		plan:     subscriptionPlan,
+	}
+
+	executor, err := NewCustomExecutionEngineV2ExecutorByStages(CustomExecutionEngineV2Stages{
+		RequiredStages: CustomExecutionEngineV2RequiredStages{
+			ResolverStage: stage,
+		},
+	})
+	require.NoError(t, err)
+
+	recorder := newSubscriptionRecorder()
+
+	// The Tyk gateway calls Execute with a per-request context. Use a context with
+	// a cancel func so the test cleans up if anything stalls.
+	execCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Run Execute on a goroutine and detect panics.
+	done := make(chan struct{})
+	var panicValue interface{}
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				panicValue = r
+			}
+			close(done)
+		}()
+		execErr := executor.Execute(execCtx, &Request{}, recorder)
+		assert.NoError(t, execErr)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(defaultTimeout):
+		t.Fatal("Execute did not return within timeout")
+	}
+	require.Nil(t, panicValue, "Execute panicked: %v", panicValue)
+
+	// The subscription writes happen on the resolver's goroutine. The resolver loop
+	// may panic *after* Execute returns when it tries to call xcontext.Detach on
+	// the freed context. Wait for all 3 messages and Complete; if either fails to
+	// arrive within the timeout the bug is reproduced.
+	recorder.AwaitMessageCount(t, 3, defaultTimeout)
+	recorder.AwaitComplete(t, defaultTimeout)
+
+	messages := recorder.Messages()
+	assert.ElementsMatch(t, []string{
+		`{"data":{"counter":0}}`,
+		`{"data":{"counter":1}}`,
+		`{"data":{"counter":2}}`,
+	}, messages)
+}
+
+// subscriptionResolverStage mimics ExecutionEngineV2.Resolve for a subscription plan.
+// It deliberately uses AsyncResolveGraphQLSubscription so the test exercises the
+// exact use-after-free path the bug lives on.
+type subscriptionResolverStage struct {
+	resolver *resolve.Resolver
+	plan     *plan.SubscriptionResponsePlan
+}
+
+func (s *subscriptionResolverStage) Setup(ctx context.Context, postProcessor *postprocess.Processor, resolveContext *resolve.Context, operation *Request, options ...ExecutionOptionsV2) {
+}
+
+func (s *subscriptionResolverStage) Plan(postProcessor *postprocess.Processor, operation *Request, report *operationreport.Report) (plan.Plan, error) {
+	return s.plan, nil
+}
+
+func (s *subscriptionResolverStage) Resolve(resolveContext *resolve.Context, planResult plan.Plan, writer resolve.SubscriptionResponseWriter) error {
+	subPlan := planResult.(*plan.SubscriptionResponsePlan)
+	return s.resolver.AsyncResolveGraphQLSubscription(resolveContext, subPlan.Response, writer, resolve.SubscriptionIdentifier{})
+}
+
+func (s *subscriptionResolverStage) Teardown() {}
+
+func (s *subscriptionResolverStage) Normalize(operation *Request) error         { return nil }
+func (s *subscriptionResolverStage) ValidateForSchema(operation *Request) error { return nil }
+func (s *subscriptionResolverStage) InputValidation(operation *Request) error   { return nil }
+
+// fakeSubscriptionStream is a minimal SubscriptionDataSource that emits messages
+// from a callback until the callback signals done.
+type fakeSubscriptionStream struct {
+	messageFunc func(counter int) (string, bool)
+	isDone      atomic.Bool
+}
+
+func newFakeSubscriptionStream(messageFunc func(counter int) (string, bool)) *fakeSubscriptionStream {
+	return &fakeSubscriptionStream{messageFunc: messageFunc}
+}
+
+func (f *fakeSubscriptionStream) UniqueRequestID(ctx *resolve.Context, input []byte, xxh *xxhash.Digest) error {
+	if _, err := xxh.WriteString("fakeSubscriptionStream"); err != nil {
+		return err
+	}
+	_, err := xxh.Write(input)
+	return err
+}
+
+func (f *fakeSubscriptionStream) Start(ctx *resolve.Context, input []byte, updater resolve.SubscriptionUpdater) error {
+	go func() {
+		counter := 0
+		for {
+			select {
+			case <-ctx.Context().Done():
+				updater.Done()
+				f.isDone.Store(true)
+				return
+			default:
+			}
+			message, done := f.messageFunc(counter)
+			updater.Update([]byte(message))
+			if done {
+				updater.Done()
+				f.isDone.Store(true)
+				return
+			}
+			counter++
+		}
+	}()
+	return nil
+}
+
+// subscriptionRecorder is a SubscriptionResponseWriter that captures each Flush()
+// as a complete message, and signals Complete().
+type subscriptionRecorder struct {
+	mu       sync.Mutex
+	buf      *bytes.Buffer
+	messages []string
+	complete atomic.Bool
+}
+
+func newSubscriptionRecorder() *subscriptionRecorder {
+	return &subscriptionRecorder{
+		buf: &bytes.Buffer{},
+	}
+}
+
+func (s *subscriptionRecorder) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Write(p)
+}
+
+func (s *subscriptionRecorder) Flush() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.messages = append(s.messages, s.buf.String())
+	s.buf.Reset()
+}
+
+func (s *subscriptionRecorder) Complete() {
+	s.complete.Store(true)
+}
+
+func (s *subscriptionRecorder) Messages() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, len(s.messages))
+	copy(out, s.messages)
+	return out
+}
+
+func (s *subscriptionRecorder) AwaitMessageCount(t *testing.T, count int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		s.mu.Lock()
+		current := len(s.messages)
+		s.mu.Unlock()
+		if current >= count {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %d messages, got: %v", count, s.Messages())
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func (s *subscriptionRecorder) AwaitComplete(t *testing.T, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		if s.complete.Load() {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for Complete()")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/v2/pkg/subscription/engine.go
+++ b/v2/pkg/subscription/engine.go
@@ -149,6 +149,19 @@ func (e *ExecutorEngine) startSubscription(ctx context.Context, id string, execu
 
 	defer e.bufferPool.Put(buf)
 
+	// ExecutorV2 (graphql-go-tools v2) drives subscriptions through the
+	// async resolver: the Execute call returns immediately after enqueuing
+	// the subscription, and the resolver event loop pushes upstream `next`
+	// frames into the writer asynchronously. The legacy poll loop below
+	// repeatedly calls Execute on a timer, which would (a) start a fresh
+	// subscription on every tick and (b) tear down the writer's flush
+	// callback in between ticks, silently dropping any update that arrives
+	// during the gap. Use a dedicated push-driven path for V2 instead.
+	if _, ok := executor.(*ExecutorV2); ok {
+		e.startSubscriptionV2(ctx, id, executor, buf, eventHandler)
+		return
+	}
+
 	if err := e.executeSubscription(ctx, buf, id, executor, eventHandler); err != nil {
 		e.logger.Error("subscription.Handle.startSubscription(): error executing subscription, terminating",
 			abstractlogger.Error(err),
@@ -171,6 +184,73 @@ func (e *ExecutorEngine) startSubscription(ctx context.Context, id string, execu
 		}
 	}
 
+}
+
+// startSubscriptionV2 is the push-driven subscription loop for the v2 engine.
+// Execute() returns immediately because the v2 resolver hands the subscription
+// off to its async event loop; from then on, every upstream frame arrives via
+// the writer's flush callback. We keep the callback active for the lifetime of
+// the subscription (until the request context is cancelled or the writer
+// signals completion) and let the resolver drive event delivery.
+func (e *ExecutorEngine) startSubscriptionV2(ctx context.Context, id string, executor Executor, buf *graphql.EngineResultWriter, eventHandler EventHandler) {
+	done := make(chan struct{})
+	var doneOnce sync.Once
+	signalDone := func() {
+		doneOnce.Do(func() { close(done) })
+	}
+
+	buf.SetFlushCallback(func(data []byte) {
+		e.logger.Debug("subscription.Handle.startSubscriptionV2()",
+			abstractlogger.ByteString("execution_result", data),
+		)
+		eventHandler.Emit(EventTypeOnSubscriptionData, id, data, nil)
+	})
+	defer buf.SetFlushCallback(nil)
+
+	completionWriter := &subscriptionCompletionWriter{
+		EngineResultWriter: buf,
+		onComplete:         signalDone,
+	}
+
+	if err := executor.Execute(completionWriter); err != nil {
+		e.logger.Error("subscription.Handle.startSubscriptionV2()",
+			abstractlogger.Error(err),
+		)
+		eventHandler.Emit(EventTypeOnError, id, nil, err)
+		return
+	}
+
+	// Some Execute paths can synchronously fill the buffer without going
+	// through Flush (e.g. when the planner produces an immediate validation
+	// error). Surface any pending bytes as a single data frame.
+	if buf.Len() > 0 {
+		data := buf.Bytes()
+		eventHandler.Emit(EventTypeOnSubscriptionData, id, data, nil)
+	}
+
+	select {
+	case <-ctx.Done():
+	case <-done:
+		// The resolver signalled completion (upstream closed the
+		// subscription). Mirror the signal at the framing layer so the
+		// websocket protocol can send a `complete` frame to the client.
+		eventHandler.Emit(EventTypeOnSubscriptionCompleted, id, nil, nil)
+	}
+}
+
+// subscriptionCompletionWriter wraps an EngineResultWriter and signals when
+// the resolver indicates the subscription has finished (Complete()) so the
+// outer goroutine can return without waiting for the request context to be
+// cancelled. Writes and Flushes are delegated unchanged.
+type subscriptionCompletionWriter struct {
+	*graphql.EngineResultWriter
+	onComplete func()
+}
+
+func (w *subscriptionCompletionWriter) Complete() {
+	if w.onComplete != nil {
+		w.onComplete()
+	}
 }
 
 func (e *ExecutorEngine) executeSubscription(ctx context.Context, buf *graphql.EngineResultWriter, id string, executor Executor, eventHandler EventHandler) error {


### PR DESCRIPTION
## Summary

Two-part fix for a use-after-free in the v2 async subscription path. Required by an upcoming federation+subscription PR in [`TykTechnologies/tyk`](https://github.com/TykTechnologies/tyk) that exercises this end-to-end through Apollo Router 2.14.0.

## The bug

`CustomExecutionEngineV2Executor.Execute` hands the in-flight `resolve.Context` off to the async resolver event loop and returns immediately. The deferred `putExecutionCtx` then calls `Free()` on that context — the resolver goroutine then dereferences `ctx.Context()` and crashes (SIGSEGV the first time an upstream emits an event; race detector flags `context.go:93` vs `context.go:115`).

A second issue surfaces once the use-after-free is fixed: `startSubscription`'s legacy poll loop calls `Execute` on a timer, starting a fresh upstream subscription on every tick and tearing down the writer's flush callback between ticks — silently dropping pushed events. The v2 executor needs a push-driven loop instead.

## Fix

Both parts must be merged together:

1. **`pkg/graphql/execution_engine_v2_custom.go`** — when the plan is a `*plan.SubscriptionResponsePlan`, the deferred release routes through the new `putExecutionCtxAfterAsyncSubscription`, which swaps a fresh `resolve.Context` into the pooled wrapper without freeing the in-flight one. The async resolver keeps full ownership of its context for the lifetime of the subscription. The pooled wrapper is safe for reuse — next caller does not inherit any per-request state.

2. **`pkg/subscription/engine.go`** — `startSubscription` now branches into the new `startSubscriptionV2` when the executor is `*ExecutorV2`. The new path keeps the flush callback active for the lifetime of the subscription, calls `Execute` exactly once, and waits on either `ctx.Done()` or a resolver `Complete()` signal via `subscriptionCompletionWriter`. On `Complete()` it emits `EventTypeOnSubscriptionCompleted` so the WS framing layer sends the `complete` frame to the client.

## Test

`TestCustomExecutionEngineV2Executor_AsyncSubscription_NoUseAfterFree` (added in `pkg/graphql/execution_engine_v2_custom_subscription_test.go`) — runs a real subscription plan through `Resolver.AsyncResolveGraphQLSubscription` against a fake stream emitting 3 events. Asserts: no panic, all 3 events delivered, `Complete()` reached. Reproduces the use-after-free crash on `master` (with `-race`); passes after the fix.

The full v2 test suite remains green:

```
cd v2 && go test -count=1 ./...
```

## Out of scope follow-up

Resolver concurrency: `Resolver.handleTriggerUpdate` dispatches per-update via `triggerUpdatePool.Submit`, which can reorder rapid back-to-back upstream `next` frames. The downstream Tyk test loosens its assertion from `assert.Equal` to `assert.ElementsMatch`. If strict per-subscription ordering becomes a contract elsewhere, a per-subscription serial dispatch in the resolver is the natural follow-up — but that's a behavior change with broader implications, so it stays out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)