### PR TITLE
[TT-17578] Stop leaking websocket request context into engine fetches

### DIFF
--- a/pkg/subscription/executor_v2.go
+++ b/pkg/subscription/executor_v2.go
@@ -23,18 +23,6 @@ func WithExecutorV2HeaderModifier(headerModifier postprocess.HeaderModifier) Exe
 	}
 }
 
-type mergedContext struct {
-	context.Context
-	valueCtx context.Context
-}
-
-func (m *mergedContext) Value(key interface{}) interface{} {
-	if val := m.valueCtx.Value(key); val != nil {
-		return val
-	}
-	return m.Context.Value(key)
-}
-
 // ExecutorV2Pool - provides reusable executors
 type ExecutorV2Pool struct {
 	engine               *graphql.ExecutionEngineV2
@@ -84,8 +72,15 @@ func (e *ExecutorV2Pool) Put(executor Executor) error {
 	return nil
 }
 
+// flushWriterEngine abstracts *graphql.ExecutionEngineV2 so the executor's
+// context handling can be exercised in tests with a stub engine.
+type flushWriterEngine interface {
+	Execute(ctx context.Context, operation *graphql.Request, writer resolve.FlushWriter, options ...graphql.ExecutionOptionsV2) error
+	GetWebsocketBeforeStartHook() graphql.WebsocketBeforeStartHook
+}
+
 type ExecutorV2 struct {
-	engine         *graphql.ExecutionEngineV2
+	engine         flushWriterEngine
 	operation      *graphql.Request
 	context        context.Context
 	reqCtx         context.Context
@@ -99,12 +94,7 @@ func (e *ExecutorV2) Execute(writer resolve.FlushWriter) error {
 		options = append(options, graphql.WithAdditionalHttpHeaders(ctx.Request.Header))
 	}
 
-	// Merge the subscription context with the original request context
-	execCtx := context.Context(&mergedContext{
-		Context:  e.context,
-		valueCtx: e.reqCtx,
-	})
-
+	execCtx := e.context
 	if e.headerModifier != nil {
 		execCtx = postprocess.SetHeaderModifier(execCtx, e.headerModifier)
 	}

--- a/pkg/subscription/executor_v2_test.go
+++ b/pkg/subscription/executor_v2_test.go
@@ -1,0 +1,91 @@
+package subscription
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/TykTechnologies/graphql-go-tools/pkg/engine/resolve"
+	"github.com/TykTechnologies/graphql-go-tools/pkg/graphql"
+	"github.com/TykTechnologies/graphql-go-tools/pkg/postprocess"
+)
+
+// stubFlushWriterEngine captures the context the executor hands to the engine,
+// so we can assert what does (and does not) propagate to upstream fetches.
+type stubFlushWriterEngine struct {
+	gotCtx context.Context
+}
+
+func (s *stubFlushWriterEngine) Execute(ctx context.Context, _ *graphql.Request, _ resolve.FlushWriter, _ ...graphql.ExecutionOptionsV2) error {
+	s.gotCtx = ctx
+	return nil
+}
+
+func (s *stubFlushWriterEngine) GetWebsocketBeforeStartHook() graphql.WebsocketBeforeStartHook {
+	return nil
+}
+
+// TestExecutorV2DoesNotLeakRequestContextValuesToEngine guards against the
+// regression where the original websocket-upgrade request context leaked into
+// the engine execution context. The host application (e.g. Tyk) stores
+// request-scoped flags such as "this request is a websocket upgrade" as context
+// values on the initial request. Those values must NOT reach the engine that
+// fetches data from upstream/subgraphs, otherwise plain queries run over a
+// websocket connection are mistaken for websocket upgrades and return null.
+func TestExecutorV2DoesNotLeakRequestContextValuesToEngine(t *testing.T) {
+	type ctxKey string
+	const upgradeKey ctxKey = "graphqlIsWebSocketUpgrade"
+
+	// reqCtx simulates the original websocket request context carrying a flag.
+	reqCtx := context.WithValue(context.Background(), upgradeKey, true)
+
+	engine := &stubFlushWriterEngine{}
+	executor := &ExecutorV2{
+		engine:         engine,
+		operation:      &graphql.Request{},
+		context:        context.Background(),
+		reqCtx:         reqCtx,
+		headerModifier: func(http.Header) {},
+	}
+
+	if err := executor.Execute(nil); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if engine.gotCtx == nil {
+		t.Fatal("engine was not invoked")
+	}
+	if got := engine.gotCtx.Value(upgradeKey); got != nil {
+		t.Fatalf("request context value %q leaked into engine context: got %v, want nil", upgradeKey, got)
+	}
+	// The header modifier must still be propagated (preserves TT-17442's
+	// per-user connection/credential isolation).
+	if postprocess.GetHeaderModifier(engine.gotCtx) == nil {
+		t.Fatal("header modifier was not propagated to the engine context")
+	}
+}
+
+// TestExecutorV2PropagatesSubscriptionContextCancellation ensures the engine
+// context's lifetime is the per-subscription context (e.context), so cancelling
+// the subscription still cancels execution.
+func TestExecutorV2PropagatesSubscriptionContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	engine := &stubFlushWriterEngine{}
+	executor := &ExecutorV2{
+		engine:    engine,
+		operation: &graphql.Request{},
+		context:   ctx,
+		reqCtx:    context.Background(),
+	}
+
+	if err := executor.Execute(nil); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	cancel()
+
+	if engine.gotCtx.Err() != context.Canceled {
+		t.Fatalf("expected engine context to be canceled, got %v", engine.gotCtx.Err())
+	}
+}

--- a/v2/pkg/subscription/executor_v2.go
+++ b/v2/pkg/subscription/executor_v2.go
@@ -23,18 +23,6 @@ func WithExecutorV2HeaderModifier(headerModifier postprocess.HeaderModifier) Exe
 	}
 }
 
-type mergedContext struct {
-	context.Context
-	valueCtx context.Context
-}
-
-func (m *mergedContext) Value(key interface{}) interface{} {
-	if val := m.valueCtx.Value(key); val != nil {
-		return val
-	}
-	return m.Context.Value(key)
-}
-
 // ExecutorV2Pool - provides reusable executors
 type ExecutorV2Pool struct {
 	engine               *graphql.ExecutionEngineV2
@@ -84,8 +72,15 @@ func (e *ExecutorV2Pool) Put(executor Executor) error {
 	return nil
 }
 
+// subscriptionWriterEngine abstracts *graphql.ExecutionEngineV2 so the executor's
+// context handling can be exercised in tests with a stub engine.
+type subscriptionWriterEngine interface {
+	Execute(ctx context.Context, operation *graphql.Request, writer resolve.SubscriptionResponseWriter, options ...graphql.ExecutionOptionsV2) error
+	GetWebsocketBeforeStartHook() graphql.WebsocketBeforeStartHook
+}
+
 type ExecutorV2 struct {
-	engine         *graphql.ExecutionEngineV2
+	engine         subscriptionWriterEngine
 	operation      *graphql.Request
 	context        context.Context
 	reqCtx         context.Context
@@ -99,12 +94,7 @@ func (e *ExecutorV2) Execute(writer resolve.SubscriptionResponseWriter) error {
 		options = append(options, graphql.WithAdditionalHttpHeaders(ctx.Request.Header))
 	}
 
-	// Merge the subscription context with the original request context
-	execCtx := context.Context(&mergedContext{
-		Context:  e.context,
-		valueCtx: e.reqCtx,
-	})
-
+	execCtx := e.context
 	if e.headerModifier != nil {
 		execCtx = postprocess.SetHeaderModifier(execCtx, e.headerModifier)
 	}

--- a/v2/pkg/subscription/executor_v2_test.go
+++ b/v2/pkg/subscription/executor_v2_test.go
@@ -1,0 +1,91 @@
+package subscription
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/TykTechnologies/graphql-go-tools/v2/pkg/engine/postprocess"
+	"github.com/TykTechnologies/graphql-go-tools/v2/pkg/engine/resolve"
+	"github.com/TykTechnologies/graphql-go-tools/v2/pkg/graphql"
+)
+
+// stubSubscriptionWriterEngine captures the context the executor hands to the
+// engine, so we can assert what does (and does not) propagate to upstream fetches.
+type stubSubscriptionWriterEngine struct {
+	gotCtx context.Context
+}
+
+func (s *stubSubscriptionWriterEngine) Execute(ctx context.Context, _ *graphql.Request, _ resolve.SubscriptionResponseWriter, _ ...graphql.ExecutionOptionsV2) error {
+	s.gotCtx = ctx
+	return nil
+}
+
+func (s *stubSubscriptionWriterEngine) GetWebsocketBeforeStartHook() graphql.WebsocketBeforeStartHook {
+	return nil
+}
+
+// TestExecutorV2DoesNotLeakRequestContextValuesToEngine guards against the
+// regression where the original websocket-upgrade request context leaked into
+// the engine execution context. The host application (e.g. Tyk) stores
+// request-scoped flags such as "this request is a websocket upgrade" as context
+// values on the initial request. Those values must NOT reach the engine that
+// fetches data from upstream/subgraphs, otherwise plain queries run over a
+// websocket connection are mistaken for websocket upgrades and return null.
+func TestExecutorV2DoesNotLeakRequestContextValuesToEngine(t *testing.T) {
+	type ctxKey string
+	const upgradeKey ctxKey = "graphqlIsWebSocketUpgrade"
+
+	// reqCtx simulates the original websocket request context carrying a flag.
+	reqCtx := context.WithValue(context.Background(), upgradeKey, true)
+
+	engine := &stubSubscriptionWriterEngine{}
+	executor := &ExecutorV2{
+		engine:         engine,
+		operation:      &graphql.Request{},
+		context:        context.Background(),
+		reqCtx:         reqCtx,
+		headerModifier: func(http.Header) {},
+	}
+
+	if err := executor.Execute(nil); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if engine.gotCtx == nil {
+		t.Fatal("engine was not invoked")
+	}
+	if got := engine.gotCtx.Value(upgradeKey); got != nil {
+		t.Fatalf("request context value %q leaked into engine context: got %v, want nil", upgradeKey, got)
+	}
+	// The header modifier must still be propagated (preserves TT-17442's
+	// per-user connection/credential isolation).
+	if postprocess.GetHeaderModifier(engine.gotCtx) == nil {
+		t.Fatal("header modifier was not propagated to the engine context")
+	}
+}
+
+// TestExecutorV2PropagatesSubscriptionContextCancellation ensures the engine
+// context's lifetime is the per-subscription context (e.context), so cancelling
+// the subscription still cancels execution.
+func TestExecutorV2PropagatesSubscriptionContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	engine := &stubSubscriptionWriterEngine{}
+	executor := &ExecutorV2{
+		engine:    engine,
+		operation: &graphql.Request{},
+		context:   ctx,
+		reqCtx:    context.Background(),
+	}
+
+	if err := executor.Execute(nil); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	cancel()
+
+	if engine.gotCtx.Err() != context.Canceled {
+		t.Fatalf("expected engine context to be canceled, got %v", engine.gotCtx.Err())
+	}
+}


### PR DESCRIPTION
## Description

Fixes a regression introduced by #446 ([TT-17442] *Upstream WebSocket connection reuse ignores per-request auth headers*).

That change wrapped the subscription executor's execution context in a `mergedContext` whose `Value()` resolved from the original websocket-upgrade request context (`InitialHttpRequestContext`). Host applications (e.g. Tyk) store request-scoped flags — such as *"this request is a websocket upgrade"* — as **context values** on that request. Through `mergedContext` those values leaked into every upstream/subgraph fetch the engine performs.

The effect in Tyk GraphQL Federation: once a subscription opened a websocket connection, plain GraphQL **queries** run over that connection inherited the upgrade flag, so subgraphs tried to perform a websocket handshake on a normal HTTP fetch, the handshake failed, and the affected fields came back `null`.

## Fix

Build the execution context from `e.context` directly (no `mergedContext`) and only attach the per-request header modifier via `postprocess.SetHeaderModifier`. This:

- **Preserves TT-17442**: the header modifier still reaches the subscription client, so per-user upstream connections (and credentials) stay isolated. `TestSubscriptionClientDynamicHeadersIsolation` still passes.
- **Stops the leak**: transport-scoped request context values no longer propagate into upstream/subgraph fetches.

Cancellation/deadlines are unaffected — the execution context's lifetime was always derived from `e.context` (a per-subscription cancellable context off `context.Background()`), never from `reqCtx`.

Applied to both the v1 (`pkg/subscription`) and v2 (`v2/pkg/subscription`) engine trees.

## Tests

New `executor_v2_test.go` in both trees:
- request context values do **not** leak into the execution context;
- the header modifier is still propagated (TT-17442);
- cancellation still propagates from `e.context`.

All `pkg/subscription`, `v2/pkg/subscription`, and `graphql_datasource` suites pass in both trees.

> Draft — not for merge yet; paired with the Tyk gateway go.mod bump PR.

[TT-17442]: https://tyktech.atlassian.net/browse/TT-17442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ