### PR TITLE
[TT-17945] Fix stack overflow on cyclic fragment spreads

### DIFF
--- a/pkg/astnormalization/fragmentspread_depth.go
+++ b/pkg/astnormalization/fragmentspread_depth.go
@@ -50,18 +50,25 @@ func (r *FragmentSpreadDepth) Get(operation, definition *ast.Document, report *o
 	r.visitor.Walker = &r.walker
 
 	r.walker.Walk(operation, definition, report)
-	r.calc.calculatedNestedDepths(depths)
+	r.calc.calculatedNestedDepths(depths, report)
 }
 
 type nestedDepthCalc struct {
-	depths *Depths
+	depths    *Depths
+	report    *operationreport.Report
+	resolving map[string]bool
 }
 
-func (n *nestedDepthCalc) calculatedNestedDepths(depths *Depths) {
+func (n *nestedDepthCalc) calculatedNestedDepths(depths *Depths, report *operationreport.Report) {
 	n.depths = depths
+	n.report = report
+	n.resolving = make(map[string]bool, len(*depths))
 
 	for i := range *depths {
 		(*depths)[i].Depth = n.calculateNestedDepth(i)
+		if report.HasErrors() {
+			return
+		}
 	}
 }
 
@@ -72,10 +79,23 @@ func (n *nestedDepthCalc) calculateNestedDepth(i int) int {
 	return (*n.depths)[i].Depth + n.depthForFragment((*n.depths)[i].parentFragmentName)
 }
 
+// depthForFragment resolves the nested depth contributed by the fragment named name.
+// A fragment can only be resolved once at a time on the current call path: if it is
+// spread transitively from within itself (directly or through other fragments), that's
+// a fragment cycle, which would otherwise recurse until the goroutine stack overflows.
 func (n *nestedDepthCalc) depthForFragment(name ast.ByteSlice) int {
+	key := string(name)
+	if n.resolving[key] {
+		n.report.AddExternalError(operationreport.ErrFragmentSpreadFormsCycle(name))
+		return 0
+	}
+
 	for i := range *n.depths {
 		if bytes.Equal(name, (*n.depths)[i].SpreadName) {
-			return n.calculateNestedDepth(i)
+			n.resolving[key] = true
+			depth := n.calculateNestedDepth(i)
+			delete(n.resolving, key)
+			return depth
 		}
 	}
 	return 0

--- a/pkg/astnormalization/fragmentspread_depth_test.go
+++ b/pkg/astnormalization/fragmentspread_depth_test.go
@@ -2,7 +2,9 @@ package astnormalization
 
 import (
 	"fmt"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/TykTechnologies/graphql-go-tools/internal/pkg/unsafeparser"
 	"github.com/TykTechnologies/graphql-go-tools/pkg/asttransform"
@@ -73,6 +75,53 @@ func TestRealDepthCalculator_CalculateDepthForFragmentSpread(t *testing.T) {
 					frag2Field
 				}`, testDefinition, "frag2", 6)
 	})
+}
+
+// TestRealDepthCalculator_CyclicFragmentSpread guards against a stack overflow
+// (TT-17945): fragments that spread each other in a cycle used to make
+// calculateNestedDepth/depthForFragment recurse forever instead of failing
+// with a normal "fragment cycle" error.
+func TestRealDepthCalculator_CyclicFragmentSpread(t *testing.T) {
+	op := unsafeparser.ParseGraphqlDocumentString(`
+				subscription sub {
+					newMessage {
+						body
+					}
+				}
+				fragment frag1 on Subscription {
+					...frag2
+				}
+				fragment frag2 on Subscription {
+					...frag1
+				}`)
+	def := unsafeparser.ParseGraphqlDocumentString(testDefinition)
+	err := asttransform.MergeDefinitionWithBaseSchema(&def)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	report := operationreport.Report{}
+	calc := FragmentSpreadDepth{}
+	var depths Depths
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		calc.Get(&op, &def, &report, &depths)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("FragmentSpreadDepth.Get did not return - likely an infinite recursion regression")
+	}
+
+	if !report.HasErrors() {
+		t.Fatal("expected a fragment cycle error to be reported, got none")
+	}
+	if !strings.Contains(report.Error(), "forms fragment cycle") {
+		t.Fatalf("expected a fragment cycle error, got: %s", report.Error())
+	}
 }
 
 func BenchmarkFragmentSpreadDepthCalc_Get(b *testing.B) {

--- a/v2/pkg/astnormalization/fragmentspread_depth.go
+++ b/v2/pkg/astnormalization/fragmentspread_depth.go
@@ -50,18 +50,25 @@ func (r *FragmentSpreadDepth) Get(operation, definition *ast.Document, report *o
 	r.visitor.Walker = &r.walker
 
 	r.walker.Walk(operation, definition, report)
-	r.calc.calculatedNestedDepths(depths)
+	r.calc.calculatedNestedDepths(depths, report)
 }
 
 type nestedDepthCalc struct {
-	depths *Depths
+	depths    *Depths
+	report    *operationreport.Report
+	resolving map[string]bool
 }
 
-func (n *nestedDepthCalc) calculatedNestedDepths(depths *Depths) {
+func (n *nestedDepthCalc) calculatedNestedDepths(depths *Depths, report *operationreport.Report) {
 	n.depths = depths
+	n.report = report
+	n.resolving = make(map[string]bool, len(*depths))
 
 	for i := range *depths {
 		(*depths)[i].Depth = n.calculateNestedDepth(i)
+		if report.HasErrors() {
+			return
+		}
 	}
 }
 
@@ -72,10 +79,23 @@ func (n *nestedDepthCalc) calculateNestedDepth(i int) int {
 	return (*n.depths)[i].Depth + n.depthForFragment((*n.depths)[i].parentFragmentName)
 }
 
+// depthForFragment resolves the nested depth contributed by the fragment named name.
+// A fragment can only be resolved once at a time on the current call path: if it is
+// spread transitively from within itself (directly or through other fragments), that's
+// a fragment cycle, which would otherwise recurse until the goroutine stack overflows.
 func (n *nestedDepthCalc) depthForFragment(name ast.ByteSlice) int {
+	key := string(name)
+	if n.resolving[key] {
+		n.report.AddExternalError(operationreport.ErrFragmentSpreadFormsCycle(name))
+		return 0
+	}
+
 	for i := range *n.depths {
 		if bytes.Equal(name, (*n.depths)[i].SpreadName) {
-			return n.calculateNestedDepth(i)
+			n.resolving[key] = true
+			depth := n.calculateNestedDepth(i)
+			delete(n.resolving, key)
+			return depth
 		}
 	}
 	return 0

--- a/v2/pkg/astnormalization/fragmentspread_depth_test.go
+++ b/v2/pkg/astnormalization/fragmentspread_depth_test.go
@@ -1,7 +1,9 @@
 package astnormalization
 
 import (
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -73,6 +75,50 @@ func TestRealDepthCalculator_CalculateDepthForFragmentSpread(t *testing.T) {
 					frag2Field
 				}`, testDefinition, "frag2", 6)
 	})
+}
+
+// TestRealDepthCalculator_CyclicFragmentSpread guards against a stack overflow
+// (TT-17945): fragments that spread each other in a cycle used to make
+// calculateNestedDepth/depthForFragment recurse forever instead of failing
+// with a normal "fragment cycle" error. FragmentSpreadDepth is currently
+// unused by v2's fragment inliner, but it's exported and hardened here too.
+func TestRealDepthCalculator_CyclicFragmentSpread(t *testing.T) {
+	op := unsafeparser.ParseGraphqlDocumentString(`
+				subscription sub {
+					newMessage {
+						body
+					}
+				}
+				fragment frag1 on Subscription {
+					...frag2
+				}
+				fragment frag2 on Subscription {
+					...frag1
+				}`)
+	def := unsafeparser.ParseGraphqlDocumentString(testDefinition)
+	err := asttransform.MergeDefinitionWithBaseSchema(&def)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	report := operationreport.Report{}
+	calc := FragmentSpreadDepth{}
+	var depths Depths
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		calc.Get(&op, &def, &report, &depths)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("FragmentSpreadDepth.Get did not return - likely an infinite recursion regression")
+	}
+
+	assert.True(t, report.HasErrors(), "expected a fragment cycle error to be reported")
+	assert.True(t, strings.Contains(report.Error(), "forms fragment cycle"), "expected a fragment cycle error, got: %s", report.Error())
 }
 
 func BenchmarkFragmentSpreadDepthCalc_Get(b *testing.B) {


### PR DESCRIPTION
## Summary
- Fixes an unrecoverable `fatal error: stack overflow` in `astnormalization.(*nestedDepthCalc)`: `calculateNestedDepth` and `depthForFragment` were mutually recursive with no cycle detection, so a GraphQL document whose fragments spread each other in a cycle (e.g. `fragment A { ...B }` / `fragment B { ...A }`) recursed forever during `Request.Normalize()`.
- This is remotely triggerable by a single crafted request against any consumer (e.g. Tyk Gateway) that exposes GraphQL, and crashes the whole process — Go's stack-overflow fatal error cannot be caught by `recover()`.
- Fix tracks fragment names currently being resolved on the active call path in `depthForFragment`; if a name is re-entered while still being resolved, it reports `operationreport.ErrFragmentSpreadFormsCycle` instead of recursing. `fragmentSpreadInlineVisitor.EnterDocument` already stops the walk on report errors, so no other call site needed to change.
- Applied the identical hardening to the `v2` module (`v2/pkg/astnormalization/fragmentspread_depth.go`). `FragmentSpreadDepth` is currently dead code there (v2's fragment inliner doesn't call it, so this specific crash isn't reachable through v2 today) but it's exported, byte-for-byte identical to the vulnerable v1 code, and cheap to harden preemptively.

Jira: https://tyktech.atlassian.net/browse/TT-17945
Related: https://github.com/TykTechnologies/tyk/pull/8567 (defense-in-depth reorder in the gateway itself)

## Test plan
- [x] Added `TestRealDepthCalculator_CyclicFragmentSpread` to both `pkg/astnormalization` and `v2/pkg/astnormalization`, each building a two-fragment cycle and asserting `FragmentSpreadDepth.Get` returns promptly with a "forms fragment cycle" error rather than hanging/crashing (guarded by a 5s timeout so a regression fails the test instead of hanging CI).
- [x] Verified the new test reproduces the original crash: temporarily reverted the v1 fix and confirmed the test times out with the goroutine stuck in the old recursive `calculateNestedDepth`/`depthForFragment` call chain.
- [x] `go test ./pkg/astnormalization/...` (both modules) — pass
- [x] `go test ./pkg/graphql/...` — pass
- [x] `go vet ./pkg/astnormalization/...` (both modules) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)