### PR TITLE
[TT-17921] Fix cross-request state leaks in subscriptions and the v2 execution engine

### DIFF
--- a/pkg/engine/datasource/graphql_datasource/graphql_sse_handler.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_sse_handler.go
@@ -43,13 +43,17 @@ func (h *gqlSSEConnectionHandler) StartBlocking(sub Subscription) {
 
 	dataCh := make(chan []byte)
 	errCh := make(chan []byte)
+	done := make(chan struct{})
 	defer func() {
 		close(dataCh)
 		close(errCh)
 		close(sub.next)
 	}()
 
-	go h.subscribe(reqCtx, sub, dataCh, errCh)
+	go func() {
+		defer close(done)
+		h.subscribe(reqCtx, sub, dataCh, errCh)
+	}()
 
 	for {
 		select {
@@ -57,6 +61,8 @@ func (h *gqlSSEConnectionHandler) StartBlocking(sub Subscription) {
 			sub.next <- data
 		case err := <-errCh:
 			sub.next <- err
+			return
+		case <-done:
 			return
 		case <-reqCtx.Done():
 			return

--- a/pkg/engine/datasource/graphql_datasource/graphql_sse_handler_test.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_sse_handler_test.go
@@ -499,3 +499,122 @@ func TestGraphQLSubscriptionClientSubscribe_SSE_Upstream_Dies(t *testing.T) {
 	}, time.Second, time.Millisecond*10, "server did not close")
 	serverCancel()
 }
+
+// TestSSEConnectionHandlerStartBlockingReturnsWhenUpstreamStops guards against the SSE handler
+// outliving its upstream. The subscribe goroutine returns without reporting anything on errCh
+// whenever the upstream is done with us - it sent "event: complete", it ended the stream, or the
+// subscription request itself failed. StartBlocking has to notice that and return as well,
+// otherwise the goroutine leaks and, because closing the subscription happens in its deferred
+// func, the client's subscription is never completed and stays open until the client disconnects.
+func TestSSEConnectionHandlerStartBlockingReturnsWhenUpstreamStops(t *testing.T) {
+	startBlocking := func(t *testing.T, serverURL string) chan []byte {
+		t.Helper()
+
+		reqCtx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+
+		next := make(chan []byte)
+		handler := newSSEConnectionHandler(reqCtx, http.DefaultClient, GraphQLSubscriptionOptions{
+			URL: serverURL,
+			Body: GraphQLBody{
+				Query: `subscription {messageAdded(roomName: "room"){text}}`,
+			},
+			UseSSE: true,
+		}, logger())
+
+		go handler.StartBlocking(Subscription{
+			ctx:  reqCtx,
+			next: next,
+		})
+
+		return next
+	}
+
+	requireMessage := func(t *testing.T, next chan []byte, expected string) {
+		t.Helper()
+
+		select {
+		case message, ok := <-next:
+			require.True(t, ok, "subscription was closed before the expected message arrived")
+			require.Equal(t, expected, string(message))
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for a message from the upstream")
+		}
+	}
+
+	requireSubscriptionClosed := func(t *testing.T, next chan []byte) {
+		t.Helper()
+
+		select {
+		case message, ok := <-next:
+			assert.False(t, ok, "expected the subscription to be closed, got another message: %s", message)
+		case <-time.After(time.Second):
+			t.Fatal("StartBlocking did not return after the upstream stopped sending events")
+		}
+	}
+
+	t.Run("on upstream complete event", func(t *testing.T) {
+		// Keeps the upstream connection open after the complete event, so the complete event
+		// itself is the only thing that can end the handler.
+		serverBlock := make(chan struct{})
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			flusher, ok := w.(http.Flusher)
+			require.True(t, ok)
+
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.Header().Set("Cache-Control", "no-cache")
+			w.Header().Set("Connection", "keep-alive")
+
+			_, _ = fmt.Fprintf(w, "event: next\ndata: %s\n\n", `{"data":{"messageAdded":{"text":"first"}}}`)
+			flusher.Flush()
+
+			_, _ = fmt.Fprint(w, "event: complete\n\n")
+			flusher.Flush()
+
+			<-serverBlock
+		}))
+		// LIFO: release the server handler before server.Close() waits for it.
+		defer server.Close()
+		defer close(serverBlock)
+
+		next := startBlocking(t, server.URL)
+
+		requireMessage(t, next, `{"data":{"messageAdded":{"text":"first"}}}`)
+		requireSubscriptionClosed(t, next)
+	})
+
+	t.Run("on upstream end of stream", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			flusher, ok := w.(http.Flusher)
+			require.True(t, ok)
+
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.Header().Set("Cache-Control", "no-cache")
+			w.Header().Set("Connection", "keep-alive")
+
+			_, _ = fmt.Fprintf(w, "data: %s\n\n", `{"data":{"messageAdded":{"text":"first"}}}`)
+			flusher.Flush()
+
+			// Returning ends the response body, which the handler reads as io.EOF.
+		}))
+		defer server.Close()
+
+		next := startBlocking(t, server.URL)
+
+		requireMessage(t, next, `{"data":{"messageAdded":{"text":"first"}}}`)
+		requireSubscriptionClosed(t, next)
+	})
+
+	t.Run("on failed subscription request", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer server.Close()
+
+		next := startBlocking(t, server.URL)
+
+		requireMessage(t, next, internalError)
+		requireSubscriptionClosed(t, next)
+	})
+}

--- a/pkg/engine/datasource/graphql_datasource/graphql_subscription_client.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_subscription_client.go
@@ -1,6 +1,7 @@
 package graphql_datasource
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"math"
@@ -9,7 +10,6 @@ import (
 	"time"
 
 	"github.com/buger/jsonparser"
-	"github.com/cespare/xxhash/v2"
 	nhooyrwebsocket "github.com/coder/websocket"
 	"github.com/jensneuse/abstractlogger"
 
@@ -20,14 +20,13 @@ const ackWaitTimeout = 30 * time.Second
 
 // SubscriptionClient allows running multiple subscriptions via the same WebSocket either SSE connection
 // It takes care of de-duplicating connections to the same origin under certain circumstances
-// If Hash(URL,Body,Headers) result in the same result, an existing connection is re-used
+// If URL and final headers are identical, an existing connection is re-used.
 type SubscriptionClient struct {
 	streamingClient            *http.Client
 	httpClient                 *http.Client
 	engineCtx                  context.Context
 	log                        abstractlogger.Logger
-	hashPool                   sync.Pool
-	handlers                   map[uint64]ConnectionHandler
+	handlers                   map[string]ConnectionHandler
 	handlersMu                 sync.Mutex
 	wsSubProtocol              string
 	onWsConnectionInitCallback *OnWsConnectionInitCallback
@@ -89,17 +88,12 @@ func NewGraphQLSubscriptionClient(httpClient, streamingClient *http.Client, engi
 		option(op)
 	}
 	return &SubscriptionClient{
-		httpClient:      httpClient,
-		streamingClient: streamingClient,
-		engineCtx:       engineCtx,
-		handlers:        make(map[uint64]ConnectionHandler),
-		log:             op.log,
-		readTimeout:     op.readTimeout,
-		hashPool: sync.Pool{
-			New: func() interface{} {
-				return xxhash.New()
-			},
-		},
+		httpClient:                 httpClient,
+		streamingClient:            streamingClient,
+		engineCtx:                  engineCtx,
+		handlers:                   make(map[string]ConnectionHandler),
+		log:                        op.log,
+		readTimeout:                op.readTimeout,
 		wsSubProtocol:              op.wsSubProtocol,
 		onWsConnectionInitCallback: op.onWsConnectionInitCallback,
 	}
@@ -158,8 +152,11 @@ func (c *SubscriptionClient) subscribeWS(reqCtx context.Context, options GraphQL
 		next:    next,
 	}
 
-	// each WS connection to an origin is uniquely identified by the Hash(URL,Headers,Body)
-	handlerID, err := c.generateHandlerIDHash(options)
+	connectionInitMessage, err := c.getConnectionInitMessage(reqCtx, options.URL, options.Header)
+	if err != nil {
+		return err
+	}
+	handlerID, err := connectionKey(options, connectionInitMessage)
 	if err != nil {
 		return err
 	}
@@ -175,14 +172,14 @@ func (c *SubscriptionClient) subscribeWS(reqCtx context.Context, options GraphQL
 		return nil
 	}
 
-	handler, err = c.newWSConnectionHandler(reqCtx, options)
+	handler, err = c.newWSConnectionHandler(reqCtx, options, connectionInitMessage)
 	if err != nil {
 		return err
 	}
 
 	c.handlers[handlerID] = handler
 
-	go func(handlerID uint64) {
+	go func(handlerID string) {
 		handler.StartBlocking(sub)
 		c.handlersMu.Lock()
 		delete(c.handlers, handlerID)
@@ -192,28 +189,19 @@ func (c *SubscriptionClient) subscribeWS(reqCtx context.Context, options GraphQL
 	return nil
 }
 
-// generateHandlerIDHash generates a Hash based on: URL and Headers to uniquely identify Upgrade Requests
-func (c *SubscriptionClient) generateHandlerIDHash(options GraphQLSubscriptionOptions) (uint64, error) {
-	var (
-		err error
-	)
-	xxh := c.hashPool.Get().(*xxhash.Digest)
-	defer c.hashPool.Put(xxh)
-	xxh.Reset()
-
-	_, err = xxh.WriteString(options.URL)
-	if err != nil {
-		return 0, err
+func connectionKey(options GraphQLSubscriptionOptions, connectionInitMessage []byte) (string, error) {
+	var key bytes.Buffer
+	key.WriteString(options.URL)
+	key.WriteByte(0)
+	if err := options.Header.Write(&key); err != nil {
+		return "", err
 	}
-	err = options.Header.Write(xxh)
-	if err != nil {
-		return 0, err
-	}
-
-	return xxh.Sum64(), nil
+	key.WriteByte(0)
+	key.Write(connectionInitMessage)
+	return key.String(), nil
 }
 
-func (c *SubscriptionClient) newWSConnectionHandler(reqCtx context.Context, options GraphQLSubscriptionOptions) (ConnectionHandler, error) {
+func (c *SubscriptionClient) newWSConnectionHandler(reqCtx context.Context, options GraphQLSubscriptionOptions, connectionInitMessage []byte) (ConnectionHandler, error) {
 	subProtocols := []string{ProtocolGraphQLWS, ProtocolGraphQLTWS}
 	if c.wsSubProtocol != "" {
 		subProtocols = []string{c.wsSubProtocol}
@@ -235,32 +223,27 @@ func (c *SubscriptionClient) newWSConnectionHandler(reqCtx context.Context, opti
 		return nil, fmt.Errorf("upgrade unsuccessful")
 	}
 
-	connectionInitMessage, err := c.getConnectionInitMessage(reqCtx, options.URL, options.Header)
-	if err != nil {
-		return nil, err
-	}
-
 	// init + ack
 	err = conn.Write(reqCtx, nhooyrwebsocket.MessageText, connectionInitMessage)
 	if err != nil {
 		return nil, err
 	}
 
-	if c.wsSubProtocol == "" {
-		c.wsSubProtocol = conn.Subprotocol()
-	}
-
 	if err := waitForAck(reqCtx, conn); err != nil {
 		return nil, err
 	}
 
-	switch c.wsSubProtocol {
+	protocol := c.wsSubProtocol
+	if protocol == "" {
+		protocol = conn.Subprotocol()
+	}
+	switch protocol {
 	case ProtocolGraphQLWS:
 		return newGQLWSConnectionHandler(c.engineCtx, conn, c.readTimeout, c.log), nil
 	case ProtocolGraphQLTWS:
 		return newGQLTWSConnectionHandler(c.engineCtx, conn, c.readTimeout, c.log), nil
 	default:
-		return nil, fmt.Errorf("unknown protocol %s", conn.Subprotocol())
+		return nil, fmt.Errorf("unknown protocol %s", protocol)
 	}
 }
 

--- a/pkg/engine/datasource/graphql_datasource/graphql_subscription_client_test.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_subscription_client_test.go
@@ -368,3 +368,189 @@ func TestSubscriptionClientDynamicHeadersIsolation(t *testing.T) {
 		assert.Contains(t, receivedHeaders, token)
 	}
 }
+
+type connectionInitTokenKey struct{}
+
+// acceptGraphQLWSServer starts a websocket server that negotiates the graphql-ws protocol, records
+// the connection_init message of every connection it accepts, acknowledges it and then keeps the
+// connection open so a second subscription can be multiplexed onto it.
+func acceptGraphQLWSServer(t *testing.T, record func(initMessage string)) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := nhooyrwebsocket.Accept(w, r, &nhooyrwebsocket.AcceptOptions{
+			Subprotocols: []string{ProtocolGraphQLWS},
+		})
+		if err != nil {
+			return
+		}
+		defer conn.Close(nhooyrwebsocket.StatusInternalError, "closing")
+
+		_, initMessage, err := conn.Read(r.Context())
+		if err != nil {
+			return
+		}
+		record(string(initMessage))
+
+		if err := conn.Write(r.Context(), nhooyrwebsocket.MessageText, []byte(`{"type":"connection_ack"}`)); err != nil {
+			return
+		}
+
+		for {
+			if _, _, err := conn.Read(r.Context()); err != nil {
+				return
+			}
+		}
+	}))
+}
+
+// TestSubscriptionClientConnectionInitIsolation guards against multiplexing two requests onto the
+// same upstream websocket when only their connection_init payloads differ. That payload is produced
+// by OnWsConnectionInitCallback, which is handed the request context precisely so it can forward the
+// calling user's credentials - reusing a connection that was authenticated with somebody else's
+// payload puts one user's subscription on another user's upstream session.
+func TestSubscriptionClientConnectionInitIsolation(t *testing.T) {
+	var (
+		mu            sync.Mutex
+		receivedInits []string
+	)
+
+	server := acceptGraphQLWSServer(t, func(initMessage string) {
+		mu.Lock()
+		receivedInits = append(receivedInits, initMessage)
+		mu.Unlock()
+	})
+	defer server.Close()
+
+	var callback OnWsConnectionInitCallback = func(ctx context.Context, url string, header http.Header) (json.RawMessage, error) {
+		token, _ := ctx.Value(connectionInitTokenKey{}).(string)
+		return json.RawMessage(fmt.Sprintf(`{"token":%q}`, token)), nil
+	}
+
+	client := NewGraphQLSubscriptionClient(http.DefaultClient, http.DefaultClient, context.Background(),
+		WithOnWsConnectionInitCallback(&callback),
+	)
+
+	options := GraphQLSubscriptionOptions{
+		URL:  "ws" + server.URL[4:],
+		Body: GraphQLBody{Query: `subscription {messageAdded(roomName: "room"){text}}`},
+	}
+
+	userTokens := []string{"user-1-token", "user-2-token"}
+	for _, token := range userTokens {
+		ctx := context.WithValue(context.Background(), connectionInitTokenKey{}, token)
+		next := make(chan []byte)
+		require.NoError(t, client.Subscribe(ctx, options, next))
+	}
+
+	assert.Eventuallyf(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(receivedInits) == len(userTokens)
+	}, time.Second, time.Millisecond*10, "expected one upstream connection per connection_init payload")
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	for _, token := range userTokens {
+		assert.Contains(t, receivedInits, fmt.Sprintf(`{"type":"connection_init","payload":{"token":"%s"}}`, token))
+	}
+}
+
+// TestSubscriptionClientDoesNotPinNegotiatedSubProtocol guards against one connection's negotiated
+// sub-protocol being written back onto the shared client - it would become the client wide default
+// and narrow the protocols offered to every upstream dialled afterwards.
+func TestSubscriptionClientDoesNotPinNegotiatedSubProtocol(t *testing.T) {
+	server := acceptGraphQLWSServer(t, func(string) {})
+	defer server.Close()
+
+	// No WithWSSubProtocol: the client offers both protocols and lets each connection negotiate.
+	client := NewGraphQLSubscriptionClient(http.DefaultClient, http.DefaultClient, context.Background())
+
+	next := make(chan []byte)
+	require.NoError(t, client.Subscribe(context.Background(), GraphQLSubscriptionOptions{
+		URL:  "ws" + server.URL[4:],
+		Body: GraphQLBody{Query: `subscription {messageAdded(roomName: "room"){text}}`},
+	}, next))
+
+	assert.Empty(t, client.wsSubProtocol,
+		"the protocol negotiated for a single connection must not be pinned onto the shared client")
+}
+
+// TestConnectionKey covers the key that decides whether an upstream websocket connection is reused.
+// It has to tell apart every part of the effective connection descriptor - anything it misses is a
+// connection shared between two requests that should not share one - while staying stable for
+// descriptors that are equal but were built in a different order.
+func TestConnectionKey(t *testing.T) {
+	const connectionInit = `{"type":"connection_init","payload":{"token":"A"}}`
+
+	baseOptions := func() GraphQLSubscriptionOptions {
+		return GraphQLSubscriptionOptions{
+			URL:    "ws://example.com/graphql",
+			Header: http.Header{"Authorization": {"Bearer A"}},
+		}
+	}
+
+	key := func(t *testing.T, options GraphQLSubscriptionOptions, initMessage string) string {
+		t.Helper()
+
+		result, err := connectionKey(options, []byte(initMessage))
+		require.NoError(t, err)
+		return result
+	}
+
+	base := key(t, baseOptions(), connectionInit)
+
+	t.Run("is stable for the same descriptor", func(t *testing.T) {
+		assert.Equal(t, base, key(t, baseOptions(), connectionInit))
+	})
+
+	t.Run("does not depend on the order the headers were set in", func(t *testing.T) {
+		first := http.Header{}
+		first.Set("Authorization", "Bearer A")
+		first.Set("X-Tenant", "tenant-1")
+
+		second := http.Header{}
+		second.Set("X-Tenant", "tenant-1")
+		second.Set("Authorization", "Bearer A")
+
+		firstOptions, secondOptions := baseOptions(), baseOptions()
+		firstOptions.Header, secondOptions.Header = first, second
+
+		assert.Equal(t, key(t, firstOptions, connectionInit), key(t, secondOptions, connectionInit))
+	})
+
+	t.Run("differs by url", func(t *testing.T) {
+		options := baseOptions()
+		options.URL = "ws://example.com/other-graphql"
+
+		assert.NotEqual(t, base, key(t, options, connectionInit))
+	})
+
+	t.Run("differs by header value", func(t *testing.T) {
+		options := baseOptions()
+		options.Header = http.Header{"Authorization": {"Bearer B"}}
+
+		assert.NotEqual(t, base, key(t, options, connectionInit))
+	})
+
+	t.Run("differs by an additional header", func(t *testing.T) {
+		options := baseOptions()
+		options.Header = http.Header{"Authorization": {"Bearer A"}, "X-Tenant": {"tenant-1"}}
+
+		assert.NotEqual(t, base, key(t, options, connectionInit))
+	})
+
+	t.Run("differs by connection init payload", func(t *testing.T) {
+		assert.NotEqual(t, base, key(t, baseOptions(), `{"type":"connection_init","payload":{"token":"B"}}`))
+	})
+
+	t.Run("handles options without headers", func(t *testing.T) {
+		options := baseOptions()
+		options.Header = nil
+
+		withoutHeaders := key(t, options, connectionInit)
+		assert.NotEqual(t, base, withoutHeaders)
+		assert.Equal(t, withoutHeaders, key(t, options, connectionInit))
+	})
+}

--- a/pkg/engine/datasource/httpclient/httpclient.go
+++ b/pkg/engine/datasource/httpclient/httpclient.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 
 	"github.com/buger/jsonparser"
 	bytetemplate "github.com/jensneuse/byte-template"
@@ -156,6 +157,48 @@ func SetInputHeader(input, headers []byte) []byte {
 	}
 	out, _ := sjson.SetRawBytes(input, HEADER, wrapQuotesIfString(headers))
 	return out
+}
+
+func ApplyHeaderModifier(input []byte, modifier func(http.Header)) []byte {
+	if modifier == nil {
+		return input
+	}
+	headerBytes, dataType, _, err := jsonparser.Get(input, HEADER)
+	if err != nil || dataType != jsonparser.Object {
+		return input
+	}
+	var h http.Header
+	if err := json.Unmarshal(headerBytes, &h); err != nil {
+		return input
+	}
+	modifier(h)
+	modifiedHeaderBytes, err := json.Marshal(h)
+	if err != nil {
+		return input
+	}
+	return SetInputHeader(input, modifiedHeaderBytes)
+}
+
+func MergeInputHeader(input []byte, upstreamHeaders http.Header) []byte {
+	if len(upstreamHeaders) == 0 {
+		return input
+	}
+	headerBytes, dataType, _, err := jsonparser.Get(input, HEADER)
+	var h http.Header
+	if err == nil && dataType == jsonparser.Object {
+		_ = json.Unmarshal(headerBytes, &h)
+	}
+	if h == nil {
+		h = make(http.Header)
+	}
+	for k, v := range upstreamHeaders {
+		h[k] = v
+	}
+	modifiedHeaderBytes, err := json.Marshal(h)
+	if err != nil {
+		return input
+	}
+	return SetInputHeader(input, modifiedHeaderBytes)
 }
 
 func SetInputQueryParams(input, queryParams []byte) []byte {

--- a/pkg/engine/datasource/httpclient/httpclient.go
+++ b/pkg/engine/datasource/httpclient/httpclient.go
@@ -160,45 +160,74 @@ func SetInputHeader(input, headers []byte) []byte {
 }
 
 func ApplyHeaderModifier(input []byte, modifier func(http.Header)) []byte {
-	if modifier == nil {
-		return input
-	}
-	headerBytes, dataType, _, err := jsonparser.Get(input, HEADER)
-	if err != nil || dataType != jsonparser.Object {
-		return input
-	}
-	var h http.Header
-	if err := json.Unmarshal(headerBytes, &h); err != nil {
-		return input
-	}
-	modifier(h)
-	modifiedHeaderBytes, err := json.Marshal(h)
+	modified, err := FinalizeInputHeaders(input, modifier, nil)
 	if err != nil {
 		return input
 	}
-	return SetInputHeader(input, modifiedHeaderBytes)
+	return modified
 }
 
 func MergeInputHeader(input []byte, upstreamHeaders http.Header) []byte {
-	if len(upstreamHeaders) == 0 {
-		return input
-	}
-	headerBytes, dataType, _, err := jsonparser.Get(input, HEADER)
-	var h http.Header
-	if err == nil && dataType == jsonparser.Object {
-		_ = json.Unmarshal(headerBytes, &h)
-	}
-	if h == nil {
-		h = make(http.Header)
-	}
-	for k, v := range upstreamHeaders {
-		h[k] = v
-	}
-	modifiedHeaderBytes, err := json.Marshal(h)
+	modified, err := FinalizeInputHeaders(input, nil, upstreamHeaders)
 	if err != nil {
 		return input
 	}
-	return SetInputHeader(input, modifiedHeaderBytes)
+	return modified
+}
+
+func FinalizeInputHeaders(input []byte, modifier func(http.Header), upstreamHeaders http.Header) ([]byte, error) {
+	if modifier == nil && len(upstreamHeaders) == 0 {
+		return input, nil
+	}
+
+	header, err := inputHeader(input)
+	if err != nil {
+		return nil, err
+	}
+	if modifier != nil {
+		modifier(header)
+	}
+	for key, values := range upstreamHeaders {
+		header[http.CanonicalHeaderKey(key)] = append([]string(nil), values...)
+	}
+	headerBytes, err := json.Marshal(header)
+	if err != nil {
+		return nil, fmt.Errorf("marshal datasource input header: %w", err)
+	}
+	modified, err := sjson.SetRawBytes(input, HEADER, headerBytes)
+	if err != nil {
+		return nil, fmt.Errorf("set datasource input header: %w", err)
+	}
+	return modified, nil
+}
+
+func inputHeader(input []byte) (http.Header, error) {
+	headerBytes, dataType, _, err := jsonparser.Get(input, HEADER)
+	if err != nil || dataType == jsonparser.Null {
+		return make(http.Header), nil
+	}
+	if dataType != jsonparser.Object {
+		return nil, fmt.Errorf("datasource input header must be an object, got %s", dataType)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(headerBytes, &raw); err != nil {
+		return nil, fmt.Errorf("unmarshal datasource input header: %w", err)
+	}
+	header := make(http.Header, len(raw))
+	for key, value := range raw {
+		var values []string
+		if err := json.Unmarshal(value, &values); err != nil {
+			var scalar string
+			if scalarErr := json.Unmarshal(value, &scalar); scalarErr != nil {
+				return nil, fmt.Errorf("unmarshal datasource input header %q: %w", key, err)
+			}
+			values = []string{scalar}
+		}
+		canonicalKey := http.CanonicalHeaderKey(key)
+		header[canonicalKey] = append(header[canonicalKey], values...)
+	}
+	return header, nil
 }
 
 func SetInputQueryParams(input, queryParams []byte) []byte {

--- a/pkg/engine/datasource/httpclient/httpclient.go
+++ b/pkg/engine/datasource/httpclient/httpclient.go
@@ -6,6 +6,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
+	"sync"
+	"unicode/utf8"
 
 	"github.com/buger/jsonparser"
 	bytetemplate "github.com/jensneuse/byte-template"
@@ -190,17 +193,22 @@ func FinalizeInputHeaders(input []byte, modifier func(http.Header), upstreamHead
 	for key, values := range upstreamHeaders {
 		header[http.CanonicalHeaderKey(key)] = append([]string(nil), values...)
 	}
-	headerBytes, err := json.Marshal(header)
-	if err != nil {
-		return nil, fmt.Errorf("marshal datasource input header: %w", err)
-	}
-	modified, err := sjson.SetRawBytes(input, HEADER, headerBytes)
+
+	buf := headerBufferPool.Get().(*[]byte)
+	defer headerBufferPool.Put(buf)
+	*buf = appendHeaderJSON((*buf)[:0], header)
+
+	modified, err := sjson.SetRawBytes(input, HEADER, *buf)
 	if err != nil {
 		return nil, fmt.Errorf("set datasource input header: %w", err)
 	}
 	return modified, nil
 }
 
+// inputHeader reads the "header" object out of a datasource input. It runs once
+// per fetch, so it walks the object with jsonparser rather than unmarshalling
+// it: encoding/json would allocate an intermediate map plus a json.RawMessage
+// and a []string per entry, all of which are thrown away again here.
 func inputHeader(input []byte) (http.Header, error) {
 	headerBytes, dataType, _, err := jsonparser.Get(input, HEADER)
 	if err != nil || dataType == jsonparser.Null {
@@ -210,24 +218,159 @@ func inputHeader(input []byte) (http.Header, error) {
 		return nil, fmt.Errorf("datasource input header must be an object, got %s", dataType)
 	}
 
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(headerBytes, &raw); err != nil {
-		return nil, fmt.Errorf("unmarshal datasource input header: %w", err)
-	}
-	header := make(http.Header, len(raw))
-	for key, value := range raw {
-		var values []string
-		if err := json.Unmarshal(value, &values); err != nil {
-			var scalar string
-			if scalarErr := json.Unmarshal(value, &scalar); scalarErr != nil {
-				return nil, fmt.Errorf("unmarshal datasource input header %q: %w", key, err)
+	header := make(http.Header)
+	err = jsonparser.ObjectEach(headerBytes, func(key, value []byte, valueType jsonparser.ValueType, _ int) error {
+		// ObjectEach hands back unescaped keys but raw values, so only the
+		// values need unescaping.
+		canonicalKey := http.CanonicalHeaderKey(string(key))
+		switch valueType {
+		case jsonparser.String:
+			// A scalar value is a realistic shape for hand-built or third-party
+			// datasource configs; treat it as a single-valued header.
+			unescaped, err := jsonparser.Unescape(value, nil)
+			if err != nil {
+				return fmt.Errorf("unescape datasource input header %q: %w", key, err)
 			}
-			values = []string{scalar}
+			header[canonicalKey] = append(header[canonicalKey], string(unescaped))
+		case jsonparser.Null:
+			// encoding/json decoded a null value into an empty list of values.
+			// Keep the key present with none so the round trip is unchanged.
+			if _, exists := header[canonicalKey]; !exists {
+				header[canonicalKey] = nil
+			}
+		case jsonparser.Array:
+			var valueErr error
+			if _, err := jsonparser.ArrayEach(value, func(item []byte, itemType jsonparser.ValueType, _ int, err error) {
+				if valueErr != nil {
+					return
+				}
+				if err != nil {
+					valueErr = err
+					return
+				}
+				if itemType != jsonparser.String {
+					valueErr = fmt.Errorf("datasource input header %q must hold strings, got %s", key, itemType)
+					return
+				}
+				unescaped, err := jsonparser.Unescape(item, nil)
+				if err != nil {
+					valueErr = err
+					return
+				}
+				header[canonicalKey] = append(header[canonicalKey], string(unescaped))
+			}); err != nil {
+				return fmt.Errorf("read datasource input header %q: %w", key, err)
+			}
+			if valueErr != nil {
+				return fmt.Errorf("read datasource input header %q: %w", key, valueErr)
+			}
+		default:
+			return fmt.Errorf("datasource input header %q must be a string or a list of strings, got %s", key, valueType)
 		}
-		canonicalKey := http.CanonicalHeaderKey(key)
-		header[canonicalKey] = append(header[canonicalKey], values...)
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 	return header, nil
+}
+
+// headerBufferPool holds the scratch buffers appendHeaderJSON serializes into.
+// The bytes are handed to sjson, which copies them into the returned input, so
+// a buffer can go straight back into the pool.
+var headerBufferPool = sync.Pool{
+	New: func() interface{} {
+		buf := make([]byte, 0, 512)
+		return &buf
+	},
+}
+
+// appendHeaderJSON writes header as a JSON object. It replaces
+// json.Marshal(http.Header), which spends a reflection walk and a dozen
+// allocations on a shape that is known statically here.
+func appendHeaderJSON(dst []byte, header http.Header) []byte {
+	keys := make([]string, 0, len(header))
+	for key := range header {
+		keys = append(keys, key)
+	}
+	// encoding/json emits map keys in sorted order, and the serialized input is
+	// not just passed along: it is what a subscription's connection and trigger
+	// keys are derived from. An unstable key order would stop equivalent
+	// subscriptions from sharing an upstream connection.
+	sort.Strings(keys)
+
+	dst = append(dst, '{')
+	for i, key := range keys {
+		if i > 0 {
+			dst = append(dst, ',')
+		}
+		dst = appendJSONString(dst, key)
+		dst = append(dst, ':')
+		values := header[key]
+		if values == nil {
+			dst = append(dst, 'n', 'u', 'l', 'l')
+			continue
+		}
+		dst = append(dst, '[')
+		for j, value := range values {
+			if j > 0 {
+				dst = append(dst, ',')
+			}
+			dst = appendJSONString(dst, value)
+		}
+		dst = append(dst, ']')
+	}
+	return append(dst, '}')
+}
+
+const hexDigits = "0123456789abcdef"
+
+// appendJSONString appends s as a JSON string literal, matching encoding/json
+// with HTML escaping disabled. HTML escaping is deliberately left off: Do()
+// reads header values back out with jsonparser, which does not unescape them,
+// so a "&" would reach the upstream verbatim.
+func appendJSONString(dst []byte, s string) []byte {
+	dst = append(dst, '"')
+	start := 0
+	for i := 0; i < len(s); {
+		if b := s[i]; b < utf8.RuneSelf {
+			if b >= 0x20 && b != '"' && b != '\\' {
+				i++
+				continue
+			}
+			dst = append(dst, s[start:i]...)
+			switch b {
+			case '"', '\\':
+				dst = append(dst, '\\', b)
+			case '\n':
+				dst = append(dst, '\\', 'n')
+			case '\r':
+				dst = append(dst, '\\', 'r')
+			case '\t':
+				dst = append(dst, '\\', 't')
+			default:
+				dst = append(dst, '\\', 'u', '0', '0', hexDigits[b>>4], hexDigits[b&0xf])
+			}
+			i++
+			start = i
+			continue
+		}
+		char, size := utf8.DecodeRuneInString(s[i:])
+		switch {
+		case char == utf8.RuneError && size == 1:
+			dst = append(dst, s[start:i]...)
+			dst = append(dst, "\\ufffd"...)
+		case char == '\u2028' || char == '\u2029':
+			dst = append(dst, s[start:i]...)
+			dst = append(dst, '\\', 'u', '2', '0', '2', hexDigits[char&0xf])
+		default:
+			i += size
+			continue
+		}
+		i += size
+		start = i
+	}
+	return append(append(dst, s[start:]...), '"')
 }
 
 func SetInputQueryParams(input, queryParams []byte) []byte {

--- a/pkg/engine/datasource/httpclient/httpclient_test.go
+++ b/pkg/engine/datasource/httpclient/httpclient_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -11,7 +12,9 @@ import (
 	"testing"
 
 	"github.com/andybalholm/brotli"
+	"github.com/buger/jsonparser"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/TykTechnologies/graphql-go-tools/internal/pkg/quotes"
 	"github.com/TykTechnologies/graphql-go-tools/pkg/lexer/literal"
@@ -87,10 +90,10 @@ func TestApplyHeaderModifier(t *testing.T) {
 		assert.Equal(t, string(in), string(out))
 	})
 
-	t.Run("no existing header key is a no-op", func(t *testing.T) {
+	t.Run("no existing header key creates one", func(t *testing.T) {
 		in := []byte(`{"method":"GET"}`)
 		out := ApplyHeaderModifier(in, setAuth("new"))
-		assert.Equal(t, `{"method":"GET"}`, string(out))
+		assert.Equal(t, `{"header":{"Authorization":["new"]},"method":"GET"}`, string(out))
 	})
 
 	t.Run("non-object header value is a no-op", func(t *testing.T) {
@@ -133,11 +136,124 @@ func TestMergeInputHeader(t *testing.T) {
 		assert.Equal(t, `{"header":{"Authorization":["new"],"X-Client":["alpha"]}}`, string(out))
 	})
 
-	t.Run("non-object existing header value is replaced entirely", func(t *testing.T) {
+	t.Run("non-object existing header value is left untouched", func(t *testing.T) {
 		in := []byte(`{"header":[1,2,3]}`)
 		out := MergeInputHeader(in, http.Header{"Authorization": []string{"secret"}})
-		assert.Equal(t, `{"header":{"Authorization":["secret"]}}`, string(out))
+		assert.Equal(t, `{"header":[1,2,3]}`, string(out))
 	})
+}
+
+// TestFinalizeInputHeaders covers FinalizeInputHeaders directly - behavior that
+// ApplyHeaderModifier/MergeInputHeader can't exercise on their own since each
+// only ever passes one of modifier/upstreamHeaders (never both), and both
+// wrappers swallow the error return instead of surfacing it.
+func TestFinalizeInputHeaders(t *testing.T) {
+	t.Run("nil modifier and empty upstream headers returns input unchanged", func(t *testing.T) {
+		in := []byte(`{"method":"GET","header":{"Authorization":["old"]}}`)
+
+		out, err := FinalizeInputHeaders(in, nil, nil)
+		require.NoError(t, err)
+		assert.Equal(t, string(in), string(out))
+
+		out, err = FinalizeInputHeaders(in, nil, http.Header{})
+		require.NoError(t, err)
+		assert.Equal(t, string(in), string(out))
+	})
+
+	t.Run("modifier normalizes scalar and mixed-case values", func(t *testing.T) {
+		in := []byte(`{"header":{"authorization":"first","Authorization":["second","third"]}}`)
+		out, err := FinalizeInputHeaders(in, func(header http.Header) {
+			header.Add("AUTHORIZATION", "current")
+		}, nil)
+		require.NoError(t, err)
+
+		var decoded struct {
+			Header http.Header `json:"header"`
+		}
+		require.NoError(t, json.Unmarshal(out, &decoded))
+		assert.ElementsMatch(t, []string{"first", "second", "third", "current"}, decoded.Header.Values("Authorization"))
+	})
+
+	t.Run("upstream headers take final precedence over the modifier, other modifier keys survive", func(t *testing.T) {
+		in := []byte(`{"header":{}}`)
+		out, err := FinalizeInputHeaders(in, func(header http.Header) {
+			header.Set("Authorization", "from-modifier")
+			header.Set("X-Trace", "abc")
+		}, http.Header{"Authorization": {"from-upstream"}})
+		require.NoError(t, err)
+
+		var decoded struct {
+			Header http.Header `json:"header"`
+		}
+		require.NoError(t, json.Unmarshal(out, &decoded))
+		assert.Equal(t, []string{"from-upstream"}, decoded.Header.Values("Authorization"),
+			"upstream headers must take final precedence over whatever the modifier set")
+		assert.Equal(t, []string{"abc"}, decoded.Header.Values("X-Trace"),
+			"keys the modifier set that upstream headers don't mention must survive")
+	})
+
+	t.Run("malformed header value returns an error", func(t *testing.T) {
+		_, err := FinalizeInputHeaders([]byte(`{"header":{"Authorization":42}}`), func(http.Header) {}, nil)
+		assert.Error(t, err)
+	})
+}
+
+// TestApplyHeaderModifierCreatesMissingHeader guards against the case where a
+// datasource's input has no "header" key at all yet - ApplyHeaderModifier must
+// still be able to add one, not silently no-op.
+func TestApplyHeaderModifierCreatesMissingHeader(t *testing.T) {
+	in := []byte(`{"method":"GET"}`)
+	out := ApplyHeaderModifier(in, func(header http.Header) {
+		header.Set("Authorization", "new")
+	})
+
+	headerBytes, dataType, _, err := jsonparser.Get(out, HEADER)
+	require.NoError(t, err, "ApplyHeaderModifier must create a \"header\" key when none exists yet, got %s", out)
+	require.Equal(t, jsonparser.Object, dataType)
+
+	var decoded struct {
+		Header http.Header `json:"header"`
+	}
+	require.NoError(t, json.Unmarshal(headerBytes, &decoded.Header))
+	assert.Equal(t, []string{"new"}, decoded.Header.Values("Authorization"))
+}
+
+// TestApplyHeaderModifierAppliesDespiteScalarHeaderValue guards against a
+// datasource input whose "header" object mixes scalar and array-shaped values -
+// a realistic shape for hand-built or third-party datasource configs. The
+// modifier must still be applied to the other keys, rather than the whole
+// operation being silently abandoned because one value didn't parse as
+// []string.
+func TestApplyHeaderModifierAppliesDespiteScalarHeaderValue(t *testing.T) {
+	in := []byte(`{"header":{"Authorization":"first"}}`)
+	out := ApplyHeaderModifier(in, func(header http.Header) {
+		header.Set("X-Trace", "abc")
+	})
+	assert.Contains(t, string(out), `"X-Trace"`,
+		"a scalar-valued existing header entry must not silently prevent the modifier from being applied, got %s", out)
+}
+
+// TestApplyHeaderModifierCanonicalizesHeaderKeyCasing guards against header
+// keys surviving as raw, non-canonical JSON object keys - e.g. "authorization"
+// and "Authorization" must be treated as the same header, not two independent
+// entries.
+func TestApplyHeaderModifierCanonicalizesHeaderKeyCasing(t *testing.T) {
+	in := []byte(`{"header":{"authorization":["legacy"]}}`)
+	out := ApplyHeaderModifier(in, func(header http.Header) {
+		header.Add("Authorization", "current")
+	})
+
+	headerBytes, _, _, err := jsonparser.Get(out, HEADER)
+	require.NoError(t, err)
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(headerBytes, &raw))
+
+	_, hasLowercase := raw["authorization"]
+	assert.False(t, hasLowercase, `header keys must be canonicalized; found a raw "authorization" key in %s`, out)
+
+	var values []string
+	require.NoError(t, json.Unmarshal(raw["Authorization"], &values))
+	assert.Equal(t, []string{"legacy", "current"}, values)
 }
 
 func TestHttpClientDo(t *testing.T) {

--- a/pkg/engine/datasource/httpclient/httpclient_test.go
+++ b/pkg/engine/datasource/httpclient/httpclient_test.go
@@ -76,6 +76,70 @@ func TestHttpClient(t *testing.T) {
 	assert.Equal(t, `{"body":{"variables":{"foo":{"bar":$$0$$}}}}`, string(in))
 }
 
+func TestApplyHeaderModifier(t *testing.T) {
+	setAuth := func(value string) func(http.Header) {
+		return func(header http.Header) { header.Set("Authorization", value) }
+	}
+
+	t.Run("nil modifier returns input unchanged", func(t *testing.T) {
+		in := []byte(`{"method":"GET","header":{"Authorization":["old"]}}`)
+		out := ApplyHeaderModifier(in, nil)
+		assert.Equal(t, string(in), string(out))
+	})
+
+	t.Run("no existing header key is a no-op", func(t *testing.T) {
+		in := []byte(`{"method":"GET"}`)
+		out := ApplyHeaderModifier(in, setAuth("new"))
+		assert.Equal(t, `{"method":"GET"}`, string(out))
+	})
+
+	t.Run("non-object header value is a no-op", func(t *testing.T) {
+		in := []byte(`{"method":"GET","header":[1,2,3]}`)
+		out := ApplyHeaderModifier(in, setAuth("new"))
+		assert.Equal(t, `{"method":"GET","header":[1,2,3]}`, string(out))
+	})
+
+	t.Run("existing header object is rewritten by the modifier", func(t *testing.T) {
+		in := []byte(`{"method":"GET","header":{"Authorization":["old"]}}`)
+		out := ApplyHeaderModifier(in, setAuth("new"))
+		assert.Equal(t, `{"method":"GET","header":{"Authorization":["new"]}}`, string(out))
+	})
+
+	t.Run("modifier can add a key alongside existing ones", func(t *testing.T) {
+		in := []byte(`{"header":{"Authorization":["old"]}}`)
+		out := ApplyHeaderModifier(in, func(header http.Header) {
+			header.Set("X-Trace", "abc")
+		})
+		assert.Equal(t, `{"header":{"Authorization":["old"],"X-Trace":["abc"]}}`, string(out))
+	})
+}
+
+func TestMergeInputHeader(t *testing.T) {
+	t.Run("empty upstream headers is a no-op", func(t *testing.T) {
+		in := []byte(`{"method":"GET"}`)
+		assert.Equal(t, `{"method":"GET"}`, string(MergeInputHeader(in, nil)))
+		assert.Equal(t, `{"method":"GET"}`, string(MergeInputHeader(in, http.Header{})))
+	})
+
+	t.Run("no existing header key creates one", func(t *testing.T) {
+		in := []byte(`{"method":"GET"}`)
+		out := MergeInputHeader(in, http.Header{"Authorization": []string{"secret"}})
+		assert.Equal(t, `{"header":{"Authorization":["secret"]},"method":"GET"}`, string(out))
+	})
+
+	t.Run("matching keys are overwritten, other keys are preserved", func(t *testing.T) {
+		in := []byte(`{"header":{"Authorization":["old"],"X-Client":["alpha"]}}`)
+		out := MergeInputHeader(in, http.Header{"Authorization": []string{"new"}})
+		assert.Equal(t, `{"header":{"Authorization":["new"],"X-Client":["alpha"]}}`, string(out))
+	})
+
+	t.Run("non-object existing header value is replaced entirely", func(t *testing.T) {
+		in := []byte(`{"header":[1,2,3]}`)
+		out := MergeInputHeader(in, http.Header{"Authorization": []string{"secret"}})
+		assert.Equal(t, `{"header":{"Authorization":["secret"]}}`, string(out))
+	})
+}
+
 func TestHttpClientDo(t *testing.T) {
 
 	runTest := func(ctx context.Context, input []byte, expectedOutput string) func(t *testing.T) {

--- a/pkg/engine/datasource/httpclient/httpclient_test.go
+++ b/pkg/engine/datasource/httpclient/httpclient_test.go
@@ -5,10 +5,14 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
+	"strconv"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/andybalholm/brotli"
@@ -398,4 +402,286 @@ func TestHttpClientDo(t *testing.T) {
 			t.Run("net", runTest(background, input, `ok`))
 		})
 	})
+}
+
+// benchFinalizeInputSink keeps the compiler from eliding the benchmarked call.
+var benchFinalizeInputSink []byte
+
+// benchFinalizeInput mirrors what the loader hands to FinalizeInputHeaders: a
+// fully rendered fetch input - query body and all - carrying a header object of
+// the size a real datasource config produces.
+func benchFinalizeInput() []byte {
+	return []byte(`{"method":"POST","url":"http://localhost:4001/graphql",` +
+		`"body":{"query":"query($representations: [_Any!]!){_entities(representations: $representations){... on Product {name price reviews {body author {username}}}}}",` +
+		`"variables":{"representations":[{"__typename":"Product","upc":"top-1"},{"__typename":"Product","upc":"top-2"}]}},` +
+		`"header":{"Authorization":["Bearer abcdefghijklmnop"],"X-Request-Id":["7f3c9a12"],` +
+		`"X-Forwarded-For":["10.0.0.1"],"Content-Type":["application/json"],"X-Tyk-Api-Name":["reviews"]}}`)
+}
+
+// BenchmarkFinalizeInputHeaders measures the per-fetch cost of finalizing the
+// headers. The gateway always installs a header modifier, so "modifier only" is
+// the case that matters in production; "nothing to do" measures the early
+// return every other embedder gets.
+func BenchmarkFinalizeInputHeaders(b *testing.B) {
+	input := benchFinalizeInput()
+	upstreamHeaders := http.Header{
+		"X-Upstream-Tenant": []string{"acme"},
+		"Authorization":     []string{"Bearer upstream"},
+	}
+	// modifier mirrors the gateway's: default in what is missing, then rewrite
+	// every value (tyk/internal/graphengine/graphql_go_tools_v2.go).
+	modifier := func(header http.Header) {
+		for key := range upstreamHeaders {
+			if header.Get(key) == "" {
+				header.Set(key, upstreamHeaders.Get(key))
+			}
+		}
+		for key := range header {
+			header.Set(key, header.Get(key))
+		}
+	}
+
+	for _, benchmark := range []struct {
+		name            string
+		modifier        func(http.Header)
+		upstreamHeaders http.Header
+	}{
+		{name: "nothing to do"},
+		{name: "modifier only", modifier: modifier},
+		{name: "upstream headers only", upstreamHeaders: upstreamHeaders},
+		{name: "modifier and upstream headers", modifier: modifier, upstreamHeaders: upstreamHeaders},
+	} {
+		b.Run(benchmark.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				out, err := FinalizeInputHeaders(input, benchmark.modifier, benchmark.upstreamHeaders)
+				if err != nil {
+					b.Fatal(err)
+				}
+				benchFinalizeInputSink = out
+			}
+		})
+	}
+}
+
+// TestInputHeader covers the read half of FinalizeInputHeaders directly. It
+// walks the JSON with jsonparser rather than unmarshalling it, so every shape
+// encoding/json used to handle has to be handled explicitly here.
+func TestInputHeader(t *testing.T) {
+	t.Run("missing header key yields an empty header", func(t *testing.T) {
+		header, err := inputHeader([]byte(`{"method":"GET"}`))
+		require.NoError(t, err)
+		assert.Empty(t, header)
+	})
+
+	t.Run("null header yields an empty header", func(t *testing.T) {
+		header, err := inputHeader([]byte(`{"header":null}`))
+		require.NoError(t, err)
+		assert.Empty(t, header)
+	})
+
+	t.Run("non-object header is an error", func(t *testing.T) {
+		_, err := inputHeader([]byte(`{"header":[1,2,3]}`))
+		assert.Error(t, err)
+	})
+
+	t.Run("array and scalar values are both accepted", func(t *testing.T) {
+		header, err := inputHeader([]byte(`{"header":{"X-List":["a","b"],"X-Scalar":"c"}}`))
+		require.NoError(t, err)
+		assert.Equal(t, []string{"a", "b"}, header.Values("X-List"))
+		assert.Equal(t, []string{"c"}, header.Values("X-Scalar"))
+	})
+
+	t.Run("keys are canonicalized and merged", func(t *testing.T) {
+		header, err := inputHeader([]byte(`{"header":{"authorization":"first","AUTHORIZATION":["second"]}}`))
+		require.NoError(t, err)
+		assert.Len(t, header, 1, "differently cased keys must collapse into one entry")
+		assert.ElementsMatch(t, []string{"first", "second"}, header.Values("Authorization"))
+	})
+
+	t.Run("escaped values are unescaped", func(t *testing.T) {
+		header, err := inputHeader([]byte(`{"header":{"X-Escaped":["a\"b\\c\nd&e"]}}`))
+		require.NoError(t, err)
+		assert.Equal(t, []string{"a\"b\\c\nd&e"}, header.Values("X-Escaped"))
+	})
+
+	t.Run("null value keeps the key with no values", func(t *testing.T) {
+		header, err := inputHeader([]byte(`{"header":{"X-Empty":null}}`))
+		require.NoError(t, err)
+		values, exists := header["X-Empty"]
+		assert.True(t, exists, "the key must survive the round trip")
+		assert.Nil(t, values)
+	})
+
+	t.Run("non-string values are an error", func(t *testing.T) {
+		_, err := inputHeader([]byte(`{"header":{"X-Number":42}}`))
+		assert.Error(t, err)
+
+		_, err = inputHeader([]byte(`{"header":{"X-Number":[42]}}`))
+		assert.Error(t, err, "a non-string list entry must be reported, not silently dropped")
+
+		_, err = inputHeader([]byte(`{"header":{"X-Object":{"nested":"value"}}}`))
+		assert.Error(t, err)
+	})
+}
+
+// TestAppendJSONString pins appendJSONString against the encoder it replaces:
+// encoding/json with HTML escaping disabled. The escaping rules are subtle
+// enough (short forms, \u00xx for the remaining control bytes, U+2028/U+2029,
+// invalid UTF-8) that a table of expectations would only restate the
+// implementation - comparing against the standard library is the real check.
+func TestAppendJSONString(t *testing.T) {
+	for _, value := range []string{
+		"",
+		"plain",
+		`with "quotes"`,
+		`with \backslash`,
+		"tab\tnewline\ncarriage\rreturn",
+		"control\x00\x01\x1f",
+		"delete\x7f",
+		"html & <tags> 'quoted'",
+		"unicode: äöü 日本語 🎉",
+		"line\u2028separator\u2029paragraph",
+		"invalid utf8: \xff\xfe",
+		"Bearer eyJhbGciOiJIUzI1NiJ9.e30.abc-_123",
+	} {
+		t.Run(strconv.Quote(value), func(t *testing.T) {
+			var expected bytes.Buffer
+			encoder := json.NewEncoder(&expected)
+			encoder.SetEscapeHTML(false)
+			require.NoError(t, encoder.Encode(value))
+
+			assert.Equal(t,
+				strings.TrimSuffix(expected.String(), "\n"),
+				string(appendJSONString(nil, value)))
+		})
+	}
+}
+
+// TestAppendHeaderJSON pins the object appendJSONString's values end up in -
+// most importantly its key order, which subscription connection keys are
+// derived from and which therefore has to be stable across requests.
+func TestAppendHeaderJSON(t *testing.T) {
+	t.Run("empty header", func(t *testing.T) {
+		assert.Equal(t, `{}`, string(appendHeaderJSON(nil, http.Header{})))
+	})
+
+	t.Run("keys are sorted", func(t *testing.T) {
+		header := http.Header{
+			"X-Zulu":        []string{"z"},
+			"Authorization": []string{"a"},
+			"X-Alpha":       []string{"m"},
+		}
+		expected := `{"Authorization":["a"],"X-Alpha":["m"],"X-Zulu":["z"]}`
+		assert.Equal(t, expected, string(appendHeaderJSON(nil, header)))
+		// Map iteration order varies per run; repeat to make an accidental
+		// dependency on it show up.
+		for i := 0; i < 20; i++ {
+			assert.Equal(t, expected, string(appendHeaderJSON(nil, header)))
+		}
+	})
+
+	t.Run("multiple values and a nil value", func(t *testing.T) {
+		header := http.Header{"X-Multi": []string{"a", "b"}, "X-Nil": nil}
+		assert.Equal(t, `{"X-Multi":["a","b"],"X-Nil":null}`, string(appendHeaderJSON(nil, header)))
+	})
+
+	t.Run("appends to the existing buffer", func(t *testing.T) {
+		out := appendHeaderJSON([]byte(`prefix:`), http.Header{"A": []string{"b"}})
+		assert.Equal(t, `prefix:{"A":["b"]}`, string(out))
+	})
+}
+
+// TestFinalizeInputHeadersKeepsAwkwardHeaderNames guards the header object
+// being rebuilt as a whole rather than key by key: a "." in a header name is
+// legal (RFC 9110 tchar) but is path syntax to sjson, so a per-key set would
+// nest it instead of writing it out.
+func TestFinalizeInputHeadersKeepsAwkwardHeaderNames(t *testing.T) {
+	in := []byte(`{"header":{"X.Dotted":["one"],"X-Star*":["two"]}}`)
+	out, err := FinalizeInputHeaders(in, func(header http.Header) {
+		header.Set("X-Added", "three")
+	}, nil)
+	require.NoError(t, err)
+
+	header, err := inputHeader(out)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"one"}, header.Values("X.Dotted"))
+	assert.Equal(t, []string{"two"}, header.Values("X-Star*"))
+	assert.Equal(t, []string{"three"}, header.Values("X-Added"))
+}
+
+// TestFinalizeInputHeadersValueReachesUpstreamVerbatim pins the one visible
+// difference from the encoding/json round trip this used to do: json.Marshal
+// escapes "&", "<" and ">" as \u0026 and friends, while Do() reads header
+// values back out with jsonparser, which does not unescape them - so those
+// values used to reach the upstream mangled.
+func TestFinalizeInputHeadersValueReachesUpstreamVerbatim(t *testing.T) {
+	const value = `a&b<c>d`
+
+	received := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received <- r.Header.Get("X-Ampersand")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	input := SetInputMethod(nil, []byte("GET"))
+	input = SetInputURL(input, []byte(server.URL))
+	input, err := FinalizeInputHeaders(input, func(header http.Header) {
+		header.Set("X-Ampersand", value)
+	}, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, Do(http.DefaultClient, context.Background(), input, &bytes.Buffer{}))
+	assert.Equal(t, value, <-received)
+}
+
+// TestFinalizeInputHeadersResultOutlivesThePooledBuffer guards the scratch
+// buffer the header JSON is serialized into: it goes back to the pool as soon
+// as sjson has written the new input, so an already-returned result must not
+// still be pointing at it.
+func TestFinalizeInputHeadersResultOutlivesThePooledBuffer(t *testing.T) {
+	in := []byte(`{"header":{"Authorization":["original"]}}`)
+
+	first, err := FinalizeInputHeaders(in, func(header http.Header) {
+		header.Set("Authorization", "first")
+	}, nil)
+	require.NoError(t, err)
+	firstCopy := string(first)
+
+	for i := 0; i < 10; i++ {
+		_, err := FinalizeInputHeaders(in, func(header http.Header) {
+			header.Set("Authorization", "second-with-a-much-longer-value-to-force-the-buffer-to-grow")
+			header.Set("X-Padding", strings.Repeat("p", 512))
+		}, nil)
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, firstCopy, string(first),
+		"a finalized input must not alias the pooled serialization buffer")
+}
+
+// TestFinalizeInputHeadersConcurrent exercises the shared serialization buffer
+// pool from several goroutines at once - the whole point of this call site is
+// that it runs per request, concurrently.
+func TestFinalizeInputHeadersConcurrent(t *testing.T) {
+	in := []byte(`{"header":{"X-Static":["value"]},"body":{"query":"{ hello }"}}`)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			value := fmt.Sprintf("caller-%d", i)
+			expected := fmt.Sprintf(`{"header":{"X-Caller":["caller-%d"],"X-Static":["value"]},"body":{"query":"{ hello }"}}`, i)
+			for j := 0; j < 50; j++ {
+				out, err := FinalizeInputHeaders(in, func(header http.Header) {
+					header.Set("X-Caller", value)
+				}, nil)
+				assert.NoError(t, err)
+				assert.Equal(t, expected, string(out))
+			}
+		}(i)
+	}
+	wg.Wait()
 }

--- a/pkg/engine/resolve/dataloader.go
+++ b/pkg/engine/resolve/dataloader.go
@@ -172,6 +172,9 @@ func (d *dataLoader) Load(ctx *Context, fetch *SingleFetch, responsePair *BufPai
 		if err := fetch.InputTemplate.Render(ctx, nil, buf.Data); err != nil {
 			return err
 		}
+		if err := finalizePreparedInput(ctx, buf.Data); err != nil {
+			return err
+		}
 
 		pair := d.getResultBufPair()
 		err = d.fetcher.Fetch(ctx, fetch, buf.Data, pair)
@@ -250,6 +253,9 @@ func (d *dataLoader) resolveBatchFetch(ctx *Context, batchFetch *BatchFetch, fet
 		if err := batchFetch.Fetch.InputTemplate.Render(ctx, fetchParams[i], bufPair.Data); err != nil {
 			return nil, err
 		}
+		if err := finalizePreparedInput(ctx, bufPair.Data); err != nil {
+			return nil, err
+		}
 
 		inputBufs = append(inputBufs, bufPair.Data)
 	}
@@ -295,6 +301,9 @@ func (d *dataLoader) resolveSingleFetch(ctx *Context, fetch *SingleFetch, fetchP
 		bufPair := d.resourceProvider.getBufPair()
 		*bufSlice = append(*bufSlice, bufPair)
 		if err := fetch.InputTemplate.Render(ctx, val, bufPair.Data); err != nil {
+			return nil, err
+		}
+		if err := finalizePreparedInput(ctx, bufPair.Data); err != nil {
 			return nil, err
 		}
 

--- a/pkg/engine/resolve/fetcher.go
+++ b/pkg/engine/resolve/fetcher.go
@@ -1,32 +1,28 @@
 package resolve
 
 import (
-	"hash"
 	"sync"
-
-	"github.com/cespare/xxhash/v2"
 
 	"github.com/TykTechnologies/graphql-go-tools/pkg/fastbuffer"
 	"github.com/TykTechnologies/graphql-go-tools/pkg/pool"
 )
 
+type inflightFetchKey struct {
+	fetch *SingleFetch
+	input string
+}
+
 type Fetcher struct {
 	EnableSingleFlightLoader bool
-	hash64Pool               sync.Pool
 	inflightFetchPool        sync.Pool
 	bufPairPool              sync.Pool
 	inflightFetchMu          *sync.Mutex
-	inflightFetches          map[uint64]*inflightFetch
+	inflightFetches          map[inflightFetchKey]*inflightFetch
 }
 
 func NewFetcher(enableSingleFlightLoader bool) *Fetcher {
 	return &Fetcher{
 		EnableSingleFlightLoader: enableSingleFlightLoader,
-		hash64Pool: sync.Pool{
-			New: func() interface{} {
-				return xxhash.New()
-			},
-		},
 		inflightFetchPool: sync.Pool{
 			New: func() interface{} {
 				return &inflightFetch{
@@ -43,7 +39,7 @@ func NewFetcher(enableSingleFlightLoader bool) *Fetcher {
 			},
 		},
 		inflightFetchMu: &sync.Mutex{},
-		inflightFetches: map[uint64]*inflightFetch{},
+		inflightFetches: map[inflightFetchKey]*inflightFetch{},
 	}
 }
 
@@ -70,10 +66,7 @@ func (f *Fetcher) Fetch(ctx *Context, fetch *SingleFetch, preparedInput *fastbuf
 		return
 	}
 
-	hash64 := f.getHash64()
-	_, _ = hash64.Write(preparedInput.Bytes())
-	fetchID := hash64.Sum64()
-	f.putHash64(hash64)
+	fetchID := inflightFetchKey{fetch: fetch, input: string(preparedInput.Bytes())}
 
 	f.inflightFetchMu.Lock()
 	inflight, ok := f.inflightFetches[fetchID]
@@ -184,13 +177,4 @@ func (f *Fetcher) hookCtx(ctx *Context) HookContext {
 	return HookContext{
 		CurrentPath: ctx.path(),
 	}
-}
-
-func (f *Fetcher) getHash64() hash.Hash64 {
-	return f.hash64Pool.Get().(hash.Hash64)
-}
-
-func (f *Fetcher) putHash64(h hash.Hash64) {
-	h.Reset()
-	f.hash64Pool.Put(h)
 }

--- a/pkg/engine/resolve/fetcher_test.go
+++ b/pkg/engine/resolve/fetcher_test.go
@@ -1,0 +1,87 @@
+package resolve
+
+import (
+	"context"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/TykTechnologies/graphql-go-tools/pkg/fastbuffer"
+)
+
+// blockingDataSource lets a test deterministically overlap two concurrent
+// fetches: Load reports it started (so the test knows both fetches are
+// in-flight at once), then waits to be released before writing its own,
+// distinct output.
+type blockingDataSource struct {
+	name    string
+	started chan<- string
+	release <-chan struct{}
+}
+
+func (d *blockingDataSource) Load(_ context.Context, _ []byte, w io.Writer) error {
+	d.started <- d.name
+	<-d.release
+	_, err := w.Write([]byte(d.name))
+	return err
+}
+
+// TestFetcherSingleFlightIncludesFetchIdentity guards against the single-flight
+// in-flight key being derived only from the rendered input bytes. Two
+// structurally different fetches (different SingleFetch/DataSource) that
+// happen to render identical input must not be coalesced into one shared
+// in-flight request - each must still call its own DataSource.Load and get
+// back its own response.
+func TestFetcherSingleFlightIncludesFetchIdentity(t *testing.T) {
+	fetcher := NewFetcher(true)
+
+	started := make(chan string, 2)
+	release := make(chan struct{})
+
+	input := fastbuffer.New()
+	input.WriteString(`{"body":{"query":"{same}"}}`)
+
+	fetches := []*SingleFetch{
+		{DataSource: &blockingDataSource{name: "first", started: started, release: release}},
+		{DataSource: &blockingDataSource{name: "second", started: started, release: release}},
+	}
+	outputs := []*BufPair{NewBufPair(), NewBufPair()}
+
+	var wg sync.WaitGroup
+	errs := make([]error, len(fetches))
+	for i := range fetches {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			errs[i] = fetcher.Fetch(NewContext(context.Background()), fetches[i], input, outputs[i])
+		}(i)
+	}
+
+	seen := map[string]bool{}
+	for range fetches {
+		select {
+		case name := <-started:
+			seen[name] = true
+		case <-time.After(2 * time.Second):
+			close(release)
+			wg.Wait()
+			t.Fatal("distinct fetches with identical rendered input were coalesced by single-flight - the second DataSource.Load never started")
+		}
+	}
+	close(release)
+	wg.Wait()
+
+	for _, err := range errs {
+		require.NoError(t, err)
+	}
+
+	assert.True(t, seen["first"] && seen["second"],
+		"both distinct data sources must have been invoked, got: %v", seen)
+
+	assert.Equal(t, "first", outputs[0].Data.String())
+	assert.Equal(t, "second", outputs[1].Data.String())
+}

--- a/pkg/engine/resolve/request_headers_test.go
+++ b/pkg/engine/resolve/request_headers_test.go
@@ -1,0 +1,50 @@
+package resolve
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestContextFreeClearsRequestHeaderOptions guards against a pooled Context
+// leaking one request's UpstreamHeaders/HeaderModifier into the next request
+// that reuses it after Free().
+func TestContextFreeClearsRequestHeaderOptions(t *testing.T) {
+	ctx := NewContext(context.Background())
+	ctx.UpstreamHeaders = http.Header{"Authorization": {"Bearer stale"}}
+	ctx.HeaderModifier = func(http.Header) {}
+
+	ctx.Free()
+
+	assert.Nil(t, ctx.UpstreamHeaders, "Context.Free() must clear UpstreamHeaders so a reused Context doesn't leak it into an unrelated later request")
+	assert.Nil(t, ctx.HeaderModifier, "Context.Free() must clear HeaderModifier so a reused Context doesn't leak it into an unrelated later request")
+}
+
+// TestContextCloneIsolatesRequestHeaderOptions guards against clone() either
+// dropping UpstreamHeaders/HeaderModifier entirely, or sharing the same
+// underlying maps as the original - both would let unrelated concurrent work
+// on the original Context (or the original's later reuse) affect a clone that
+// should be independent.
+func TestContextCloneIsolatesRequestHeaderOptions(t *testing.T) {
+	ctx := NewContext(context.Background())
+	ctx.Request.Header = http.Header{"Authorization": {"Bearer current"}}
+	ctx.UpstreamHeaders = http.Header{"Authorization": {"Bearer current"}}
+	ctx.HeaderModifier = func(header http.Header) { header.Set("X-Caller", "current") }
+
+	clone := ctx.clone()
+
+	require.NotNil(t, clone.HeaderModifier, "clone() must preserve HeaderModifier, not drop it")
+	require.NotNil(t, clone.UpstreamHeaders, "clone() must preserve UpstreamHeaders, not drop it")
+
+	// Mutating the original's maps after cloning must not affect the clone -
+	// otherwise a cloned Context used for independent field resolution could
+	// be changed by unrelated work still using the original.
+	ctx.Request.Header.Set("Authorization", "Bearer changed")
+	ctx.UpstreamHeaders.Set("Authorization", "Bearer changed")
+
+	assert.Equal(t, "Bearer current", clone.Request.Header.Get("Authorization"))
+	assert.Equal(t, "Bearer current", clone.UpstreamHeaders.Get("Authorization"))
+}

--- a/pkg/engine/resolve/resolve.go
+++ b/pkg/engine/resolve/resolve.go
@@ -14,14 +14,14 @@ import (
 	"sync"
 	"time"
 
-	"github.com/buger/jsonparser"
-	"github.com/cespare/xxhash/v2"
-	"github.com/tidwall/gjson"
 	"github.com/TykTechnologies/graphql-go-tools/internal/pkg/unsafebytes"
 	"github.com/TykTechnologies/graphql-go-tools/pkg/engine/datasource/httpclient"
 	"github.com/TykTechnologies/graphql-go-tools/pkg/fastbuffer"
 	"github.com/TykTechnologies/graphql-go-tools/pkg/lexer/literal"
 	"github.com/TykTechnologies/graphql-go-tools/pkg/pool"
+	"github.com/buger/jsonparser"
+	"github.com/cespare/xxhash/v2"
+	"github.com/tidwall/gjson"
 )
 
 var (
@@ -199,7 +199,7 @@ func (c *Context) clone() Context {
 	return Context{
 		ctx:             c.ctx,
 		Variables:       variables,
-		Request:         c.Request,
+		Request:         Request{Header: c.Request.Header.Clone()},
 		pathElements:    pathElements,
 		patches:         patches,
 		usedBuffers:     make([]*bytes.Buffer, 0, 48),
@@ -209,6 +209,8 @@ func (c *Context) clone() Context {
 		beforeFetchHook: c.beforeFetchHook,
 		afterFetchHook:  c.afterFetchHook,
 		position:        c.position,
+		UpstreamHeaders: c.UpstreamHeaders.Clone(),
+		HeaderModifier:  c.HeaderModifier,
 	}
 }
 
@@ -230,6 +232,8 @@ func (c *Context) Free() {
 	c.position = Position{}
 	c.dataLoader = nil
 	c.RenameTypeNames = nil
+	c.UpstreamHeaders = nil
+	c.HeaderModifier = nil
 }
 
 func (c *Context) SetBeforeFetchHook(hook BeforeFetchHook) {
@@ -582,11 +586,9 @@ func (r *Resolver) ResolveGraphQLSubscription(ctx *Context, subscription *GraphQ
 	copy(subscriptionInput, rendered)
 	r.freeBufPair(buf)
 
-	if ctx.HeaderModifier != nil {
-		subscriptionInput = httpclient.ApplyHeaderModifier(subscriptionInput, ctx.HeaderModifier)
-	}
-	if len(ctx.UpstreamHeaders) > 0 {
-		subscriptionInput = httpclient.MergeInputHeader(subscriptionInput, ctx.UpstreamHeaders)
+	subscriptionInput, err = httpclient.FinalizeInputHeaders(subscriptionInput, ctx.HeaderModifier, ctx.UpstreamHeaders)
+	if err != nil {
+		return err
 	}
 	c, cancel := context.WithCancel(ctx.Context())
 	defer cancel()
@@ -1445,24 +1447,27 @@ func (r *Resolver) prepareSingleFetch(ctx *Context, fetch *SingleFetch, data []b
 	if err != nil {
 		return err
 	}
-	
-	inputBytes := preparedInput.Bytes()
-	if ctx.HeaderModifier != nil {
-		inputBytes = httpclient.ApplyHeaderModifier(inputBytes, ctx.HeaderModifier)
-	}
-	if len(ctx.UpstreamHeaders) > 0 {
-		inputBytes = httpclient.MergeInputHeader(inputBytes, ctx.UpstreamHeaders)
-	}
-	if len(inputBytes) > 0 && (len(inputBytes) != preparedInput.Len() || &inputBytes[0] != &preparedInput.Bytes()[0]) {
-		preparedInput.Reset()
-		preparedInput.WriteBytes(inputBytes)
-	} else if len(inputBytes) == 0 && preparedInput.Len() > 0 {
-		preparedInput.Reset()
+	if err = finalizePreparedInput(ctx, preparedInput); err != nil {
+		return err
 	}
 
 	buf := r.getBufPair()
 	set.buffers[fetch.BufferId] = buf
 	return
+}
+
+func finalizePreparedInput(ctx *Context, preparedInput *fastbuffer.FastBuffer) error {
+	if ctx.HeaderModifier == nil && len(ctx.UpstreamHeaders) == 0 {
+		return nil
+	}
+
+	input, err := httpclient.FinalizeInputHeaders(preparedInput.Bytes(), ctx.HeaderModifier, ctx.UpstreamHeaders)
+	if err != nil {
+		return err
+	}
+	preparedInput.Reset()
+	preparedInput.WriteBytes(input)
+	return nil
 }
 
 func (r *Resolver) resolveBatchFetch(ctx *Context, fetch *BatchFetch, preparedInput *fastbuffer.FastBuffer, buf *BufPair) error {

--- a/pkg/engine/resolve/resolve.go
+++ b/pkg/engine/resolve/resolve.go
@@ -17,8 +17,8 @@ import (
 	"github.com/buger/jsonparser"
 	"github.com/cespare/xxhash/v2"
 	"github.com/tidwall/gjson"
-
 	"github.com/TykTechnologies/graphql-go-tools/internal/pkg/unsafebytes"
+	"github.com/TykTechnologies/graphql-go-tools/pkg/engine/datasource/httpclient"
 	"github.com/TykTechnologies/graphql-go-tools/pkg/fastbuffer"
 	"github.com/TykTechnologies/graphql-go-tools/pkg/lexer/literal"
 	"github.com/TykTechnologies/graphql-go-tools/pkg/pool"
@@ -135,6 +135,8 @@ type Context struct {
 	afterFetchHook   AfterFetchHook
 	position         Position
 	RenameTypeNames  []RenameTypeName
+	UpstreamHeaders  http.Header
+	HeaderModifier   func(http.Header)
 }
 
 type Request struct {
@@ -580,6 +582,12 @@ func (r *Resolver) ResolveGraphQLSubscription(ctx *Context, subscription *GraphQ
 	copy(subscriptionInput, rendered)
 	r.freeBufPair(buf)
 
+	if ctx.HeaderModifier != nil {
+		subscriptionInput = httpclient.ApplyHeaderModifier(subscriptionInput, ctx.HeaderModifier)
+	}
+	if len(ctx.UpstreamHeaders) > 0 {
+		subscriptionInput = httpclient.MergeInputHeader(subscriptionInput, ctx.UpstreamHeaders)
+	}
 	c, cancel := context.WithCancel(ctx.Context())
 	defer cancel()
 	resolverDone := r.ctx.Done()
@@ -1434,6 +1442,24 @@ func (r *Resolver) resolveParallelFetch(ctx *Context, fetch *ParallelFetch, data
 
 func (r *Resolver) prepareSingleFetch(ctx *Context, fetch *SingleFetch, data []byte, set *resultSet, preparedInput *fastbuffer.FastBuffer) (err error) {
 	err = fetch.InputTemplate.Render(ctx, data, preparedInput)
+	if err != nil {
+		return err
+	}
+	
+	inputBytes := preparedInput.Bytes()
+	if ctx.HeaderModifier != nil {
+		inputBytes = httpclient.ApplyHeaderModifier(inputBytes, ctx.HeaderModifier)
+	}
+	if len(ctx.UpstreamHeaders) > 0 {
+		inputBytes = httpclient.MergeInputHeader(inputBytes, ctx.UpstreamHeaders)
+	}
+	if len(inputBytes) > 0 && (len(inputBytes) != preparedInput.Len() || &inputBytes[0] != &preparedInput.Bytes()[0]) {
+		preparedInput.Reset()
+		preparedInput.WriteBytes(inputBytes)
+	} else if len(inputBytes) == 0 && preparedInput.Len() > 0 {
+		preparedInput.Reset()
+	}
+
 	buf := r.getBufPair()
 	set.buffers[fetch.BufferId] = buf
 	return

--- a/pkg/graphql/execution_engine_test.go
+++ b/pkg/graphql/execution_engine_test.go
@@ -30,12 +30,20 @@ type roundTripperTestCase struct {
 	expectedBody     string
 	sendStatusCode   int
 	sendResponseBody string
+	// capturedHeaders, if non-nil, receives a clone of req.Header for every
+	// request handled by this round tripper, in call order. Test-only
+	// instrumentation for tests asserting on per-request header behavior.
+	capturedHeaders *[]http.Header
 }
 
 func createTestRoundTripper(t *testing.T, testCase roundTripperTestCase) testRoundTripper {
 	return func(req *http.Request) *http.Response {
 		assert.Equal(t, testCase.expectedHost, req.URL.Host)
 		assert.Equal(t, testCase.expectedPath, req.URL.Path)
+
+		if testCase.capturedHeaders != nil {
+			*testCase.capturedHeaders = append(*testCase.capturedHeaders, req.Header.Clone())
+		}
 
 		if len(testCase.expectedBody) > 0 {
 			var receivedBodyBytes []byte

--- a/pkg/graphql/execution_engine_v2.go
+++ b/pkg/graphql/execution_engine_v2.go
@@ -167,7 +167,9 @@ func WithBeforeFetchHook(hook resolve.BeforeFetchHook) ExecutionOptionsV2 {
 
 func WithUpstreamHeaders(header http.Header) ExecutionOptionsV2 {
 	return func(postProcessor *postprocess.Processor, resolveContext *resolve.Context) {
-		postProcessor.AddPostProcessor(postprocess.NewProcessInjectHeader(header))
+		if resolveContext != nil {
+			resolveContext.UpstreamHeaders = header
+		}
 	}
 }
 
@@ -206,10 +208,10 @@ func WithAdditionalHttpHeaders(headers http.Header, excludeByKeys ...string) Exe
 
 func WithHeaderModifier(modifier postprocess.HeaderModifier) ExecutionOptionsV2 {
 	return func(postProcessor *postprocess.Processor, resolveContext *resolve.Context) {
-		if modifier == nil {
+		if modifier == nil || resolveContext == nil {
 			return
 		}
-		postProcessor.AddPostProcessor(postprocess.NewProcessModifyHeader(modifier))
+		resolveContext.HeaderModifier = modifier
 	}
 }
 

--- a/pkg/graphql/execution_engine_v2.go
+++ b/pkg/graphql/execution_engine_v2.go
@@ -22,7 +22,6 @@ import (
 	"github.com/TykTechnologies/graphql-go-tools/pkg/engine/plan"
 	"github.com/TykTechnologies/graphql-go-tools/pkg/engine/resolve"
 	"github.com/TykTechnologies/graphql-go-tools/pkg/operationreport"
-	"github.com/TykTechnologies/graphql-go-tools/pkg/pool"
 	"github.com/TykTechnologies/graphql-go-tools/pkg/postprocess"
 )
 
@@ -153,6 +152,11 @@ type ExecutionEngineV2 struct {
 	customExecutionEngineExecutor *CustomExecutionEngineV2Executor
 }
 
+type executionPlanCacheKey struct {
+	document      string
+	operationName string
+}
+
 type WebsocketBeforeStartHook interface {
 	OnBeforeStart(reqCtx context.Context, operation *Request) error
 }
@@ -168,7 +172,7 @@ func WithBeforeFetchHook(hook resolve.BeforeFetchHook) ExecutionOptionsV2 {
 func WithUpstreamHeaders(header http.Header) ExecutionOptionsV2 {
 	return func(postProcessor *postprocess.Processor, resolveContext *resolve.Context) {
 		if resolveContext != nil {
-			resolveContext.UpstreamHeaders = header
+			resolveContext.UpstreamHeaders = header.Clone()
 		}
 	}
 }
@@ -320,17 +324,17 @@ func (e *ExecutionEngineV2) Execute(ctx context.Context, operation *Request, wri
 }
 
 func (e *ExecutionEngineV2) getCachedPlan(postProcessor *postprocess.Processor, request *Request, definition *ast.Document, operationName string, report *operationreport.Report) plan.Plan {
-
-	hash := pool.Hash64.Get()
-	hash.Reset()
-	defer pool.Hash64.Put(hash)
-	err := astprinter.Print(&request.document, definition, hash)
+	var printedDocument bytes.Buffer
+	err := astprinter.Print(&request.document, definition, &printedDocument)
 	if err != nil {
 		report.AddInternalError(err)
 		return nil
 	}
 
-	cacheKey := hash.Sum64()
+	cacheKey := executionPlanCacheKey{
+		document:      printedDocument.String(),
+		operationName: operationName,
+	}
 
 	if cached, ok := e.executionPlanCache.Get(cacheKey); ok {
 		if p, ok := cached.(plan.Plan); ok {
@@ -341,6 +345,12 @@ func (e *ExecutionEngineV2) getCachedPlan(postProcessor *postprocess.Processor, 
 
 	e.plannerMu.Lock()
 	defer e.plannerMu.Unlock()
+	if cached, ok := e.executionPlanCache.Get(cacheKey); ok {
+		if p, ok := cached.(plan.Plan); ok {
+			request.isDocumentRecyclable = true
+			return p
+		}
+	}
 	planResult := e.planner.Plan(&request.document, definition, operationName, report)
 	if report.HasErrors() {
 		return nil

--- a/pkg/graphql/execution_engine_v2_header_options_test.go
+++ b/pkg/graphql/execution_engine_v2_header_options_test.go
@@ -1,0 +1,198 @@
+package graphql
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/jensneuse/abstractlogger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/TykTechnologies/graphql-go-tools/pkg/engine/datasource/graphql_datasource"
+	"github.com/TykTechnologies/graphql-go-tools/pkg/engine/plan"
+	"github.com/TykTechnologies/graphql-go-tools/pkg/engine/resolve"
+	"github.com/TykTechnologies/graphql-go-tools/pkg/fastbuffer"
+	"github.com/TykTechnologies/graphql-go-tools/pkg/operationreport"
+	"github.com/TykTechnologies/graphql-go-tools/pkg/postprocess"
+	"github.com/TykTechnologies/graphql-go-tools/pkg/starwars"
+)
+
+// These tests verify that WithHeaderModifier/WithUpstreamHeaders are applied
+// fresh on every Execute call - including when the underlying plan is served
+// from the engine's plan cache - rather than only once at plan-build time.
+// Each test calls Execute twice on the SAME engine with the SAME query but a
+// DIFFERENT header option value, so the second call is guaranteed to hit the
+// plan cache.
+
+// newHeaderOptionsTestEngine builds a single ExecutionEngineV2 whose one
+// upstream datasource has a baseline "Authorization" header configured (so
+// WithHeaderModifier has an existing "header" JSON object to rewrite) and
+// whose RoundTripper records every outgoing request's headers, in call order.
+func newHeaderOptionsTestEngine(t *testing.T) (engine *ExecutionEngineV2, capturedHeaders *[]http.Header) {
+	t.Helper()
+
+	schema := starwarsSchema(t)
+	capturedHeaders = &[]http.Header{}
+
+	dataSources := []plan.DataSourceConfiguration{
+		{
+			RootNodes: []plan.TypeField{
+				{TypeName: "Query", FieldNames: []string{"hero"}},
+			},
+			ChildNodes: []plan.TypeField{
+				{TypeName: "Character", FieldNames: []string{"name"}},
+			},
+			Factory: &graphql_datasource.Factory{
+				HTTPClient: testNetHttpClient(t, roundTripperTestCase{
+					expectedHost:     "example.com",
+					expectedPath:     "/",
+					sendResponseBody: `{"data":{"hero":{"name":"Luke Skywalker"}}}`,
+					sendStatusCode:   200,
+					capturedHeaders:  capturedHeaders,
+				}),
+			},
+			Custom: graphql_datasource.ConfigJson(graphql_datasource.Configuration{
+				Fetch: graphql_datasource.FetchConfiguration{
+					URL:    "https://example.com/",
+					Method: "GET",
+					Header: http.Header{"Authorization": []string{"placeholder"}},
+				},
+			}),
+		},
+	}
+
+	engineConf := NewEngineV2Configuration(schema)
+	engineConf.SetDataSources(dataSources)
+	engineConf.SetFieldConfigurations([]plan.FieldConfiguration{})
+
+	var err error
+	engine, err = NewExecutionEngineV2(context.Background(), abstractlogger.Noop{}, engineConf)
+	require.NoError(t, err)
+
+	return engine, capturedHeaders
+}
+
+func heroRequest(t *testing.T) Request {
+	return loadStarWarsQuery(starwars.FileSimpleHeroQuery, nil)(t)
+}
+
+func TestExecutionEngineV2_Execute_HeaderModifierAppliedPerRequest(t *testing.T) {
+	engine, capturedHeaders := newHeaderOptionsTestEngine(t)
+	ctx := context.Background()
+
+	setAuthHeader := func(value string) postprocess.HeaderModifier {
+		return func(header http.Header) { header.Set("Authorization", value) }
+	}
+
+	// First call: this is a plan-cache MISS, so it populates the cache.
+	op1 := heroRequest(t)
+	w1 := NewEngineResultWriter()
+	err := engine.Execute(ctx, &op1, &w1, WithHeaderModifier(setAuthHeader("value-A")))
+	require.NoError(t, err)
+	require.Equal(t, `{"data":{"hero":{"name":"Luke Skywalker"}}}`, w1.String())
+
+	// Second call: DIFFERENT header value, but the SAME query text -> plan-cache HIT.
+	op2 := heroRequest(t)
+	w2 := NewEngineResultWriter()
+	err = engine.Execute(ctx, &op2, &w2, WithHeaderModifier(setAuthHeader("value-B")))
+	require.NoError(t, err)
+	require.Equal(t, `{"data":{"hero":{"name":"Luke Skywalker"}}}`, w2.String())
+
+	// Sanity check: both calls really did hash to the same cached plan.
+	require.Equal(t, 1, engine.executionPlanCache.Len(), "test setup invariant: both calls must hash to the same cached plan")
+
+	require.Len(t, *capturedHeaders, 2)
+	assert.Equal(t, "value-A", (*capturedHeaders)[0].Get("Authorization"))
+	assert.Equal(t, "value-B", (*capturedHeaders)[1].Get("Authorization"),
+		"the second call must use its own header value, not a value cached from the first call")
+}
+
+func TestExecutionEngineV2_Execute_UpstreamHeadersAppliedPerRequest(t *testing.T) {
+	engine, capturedHeaders := newHeaderOptionsTestEngine(t)
+	ctx := context.Background()
+
+	authHeader := func(value string) http.Header {
+		return http.Header{"Authorization": []string{value}}
+	}
+
+	// First call: this is a plan-cache MISS, so it populates the cache.
+	op1 := heroRequest(t)
+	w1 := NewEngineResultWriter()
+	err := engine.Execute(ctx, &op1, &w1, WithUpstreamHeaders(authHeader("value-A")))
+	require.NoError(t, err)
+	require.Equal(t, `{"data":{"hero":{"name":"Luke Skywalker"}}}`, w1.String())
+
+	// Second call: DIFFERENT header value, but the SAME query text -> plan-cache HIT.
+	op2 := heroRequest(t)
+	w2 := NewEngineResultWriter()
+	err = engine.Execute(ctx, &op2, &w2, WithUpstreamHeaders(authHeader("value-B")))
+	require.NoError(t, err)
+	require.Equal(t, `{"data":{"hero":{"name":"Luke Skywalker"}}}`, w2.String())
+
+	require.Equal(t, 1, engine.executionPlanCache.Len(), "test setup invariant: both calls must hash to the same cached plan")
+
+	require.Len(t, *capturedHeaders, 2)
+	assert.Equal(t, "value-A", (*capturedHeaders)[0].Get("Authorization"))
+	assert.Equal(t, "value-B", (*capturedHeaders)[1].Get("Authorization"),
+		"the second call must use its own header value, not a value cached from the first call")
+}
+
+func TestExecutionEngineV2_Plan_HeaderModifierIsRequestScoped(t *testing.T) {
+	schema := starwarsSchema(t)
+
+	dataSources := []plan.DataSourceConfiguration{
+		{
+			RootNodes: []plan.TypeField{
+				{TypeName: "Query", FieldNames: []string{"hero"}},
+			},
+			ChildNodes: []plan.TypeField{
+				{TypeName: "Character", FieldNames: []string{"name"}},
+			},
+			Factory: &graphql_datasource.Factory{},
+			Custom: graphql_datasource.ConfigJson(graphql_datasource.Configuration{
+				Fetch: graphql_datasource.FetchConfiguration{
+					URL:    "https://example.com/",
+					Method: "GET",
+					Header: http.Header{"Authorization": []string{"placeholder"}},
+				},
+			}),
+		},
+	}
+
+	engineConf := NewEngineV2Configuration(schema)
+	engineConf.SetDataSources(dataSources)
+	engineConf.SetFieldConfigurations([]plan.FieldConfiguration{})
+
+	engine, err := NewExecutionEngineV2(context.Background(), abstractlogger.Noop{}, engineConf)
+	require.NoError(t, err)
+
+	operation := heroRequest(t)
+	require.NoError(t, engine.Normalize(&operation))
+
+	execCtx := newInternalExecutionContext()
+	WithHeaderModifier(func(header http.Header) {
+		header.Set("Authorization", "value-A")
+	})(execCtx.postProcessor, execCtx.resolveContext)
+
+	var report operationreport.Report
+	planResult, err := engine.Plan(execCtx.postProcessor, &operation, &report)
+	require.NoError(t, err)
+	require.False(t, report.HasErrors())
+	require.Equal(t, 1, engine.executionPlanCache.Len())
+
+	syncPlan, ok := planResult.(*plan.SynchronousResponsePlan)
+	require.True(t, ok)
+	obj, ok := syncPlan.Response.Data.(*resolve.Object)
+	require.True(t, ok)
+	singleFetch, ok := obj.Fetch.(*resolve.SingleFetch)
+	require.True(t, ok)
+
+	renderedBuf := fastbuffer.New()
+	renderCtx := resolve.NewContext(context.Background())
+	err = singleFetch.InputTemplate.Render(renderCtx, nil, renderedBuf)
+	require.NoError(t, err)
+
+	assert.NotContains(t, renderedBuf.String(), "value-A",
+		"the cached plan must not contain any per-request header value frozen into its static InputTemplate segments")
+}

--- a/pkg/graphql/execution_engine_v2_test.go
+++ b/pkg/graphql/execution_engine_v2_test.go
@@ -193,6 +193,20 @@ func TestWithHeaderModifier(t *testing.T) {
 	})
 }
 
+// TestWithUpstreamHeadersCopiesInput guards against WithUpstreamHeaders holding
+// onto the caller's http.Header by reference. If a caller mutates or reuses
+// that map after Execute returns (or while a request is still in flight),
+// resolveContext.UpstreamHeaders must not be affected.
+func TestWithUpstreamHeadersCopiesInput(t *testing.T) {
+	headers := http.Header{"Authorization": {"Bearer original"}}
+	resolveContext := &resolve.Context{}
+
+	WithUpstreamHeaders(headers)(nil, resolveContext)
+	headers.Set("Authorization", "Bearer mutated")
+
+	assert.Equal(t, "Bearer original", resolveContext.UpstreamHeaders.Get("Authorization"))
+}
+
 type ExecutionEngineV2TestCase struct {
 	schema                            *Schema
 	operation                         func(t *testing.T) Request
@@ -2402,6 +2416,86 @@ func TestExecutionEngineV2_GetCachedPlan(t *testing.T) {
 		assert.Equal(t, 2, engine.executionPlanCache.Len())
 		assert.NotEqual(t, cachedPlan, oldestCachedPlan.(*plan.SubscriptionResponsePlan))
 	})
+}
+
+// TestExecutionEngineV2_GetCachedPlan_DifferentOperationNameSameDocument guards
+// against the plan cache key being derived only from the printed document text.
+// A single document can contain multiple named operations; selecting a
+// different one via OperationName must not be served a plan cached for a
+// different operation just because the underlying document text is identical.
+func TestExecutionEngineV2_GetCachedPlan_DifferentOperationNameSameDocument(t *testing.T) {
+	schema, err := NewSchemaFromString(testSubscriptionDefinition)
+	require.NoError(t, err)
+
+	combinedQuery := testSubscriptionLastRegisteredUserOperation + "\n" + testSubscriptionLiveUserCountOperation
+
+	lastRegisteredUserRequest := Request{
+		OperationName: "LastRegisteredUser",
+		Variables:     nil,
+		Query:         combinedQuery,
+	}
+	validationResult, err := lastRegisteredUserRequest.ValidateForSchema(schema)
+	require.NoError(t, err)
+	require.True(t, validationResult.Valid)
+	normalizationResult, err := lastRegisteredUserRequest.Normalize(schema)
+	require.NoError(t, err)
+	require.True(t, normalizationResult.Successful)
+
+	liveUserCountRequest := Request{
+		OperationName: "LiveUserCount",
+		Variables:     nil,
+		Query:         combinedQuery,
+	}
+	validationResult, err = liveUserCountRequest.ValidateForSchema(schema)
+	require.NoError(t, err)
+	require.True(t, validationResult.Valid)
+	normalizationResult, err = liveUserCountRequest.Normalize(schema)
+	require.NoError(t, err)
+	require.True(t, normalizationResult.Successful)
+
+	engineConfig := NewEngineV2Configuration(schema)
+	engineConfig.SetDataSources([]plan.DataSourceConfiguration{
+		{
+			RootNodes: []plan.TypeField{
+				{
+					TypeName:   "Subscription",
+					FieldNames: []string{"lastRegisteredUser", "liveUserCount"},
+				},
+			},
+			ChildNodes: []plan.TypeField{
+				{
+					TypeName:   "User",
+					FieldNames: []string{"id", "username", "email"},
+				},
+			},
+			Factory: &graphql_datasource.Factory{},
+			Custom: graphql_datasource.ConfigJson(graphql_datasource.Configuration{
+				Subscription: graphql_datasource.SubscriptionConfiguration{
+					URL: "http://localhost:8080",
+				},
+			}),
+		},
+	})
+
+	engine, err := NewExecutionEngineV2(context.Background(), abstractlogger.NoopLogger, engineConfig)
+	require.NoError(t, err)
+	require.Equal(t, 0, engine.executionPlanCache.Len())
+
+	firstExecCtx := newInternalExecutionContext()
+	report := operationreport.Report{}
+	firstPlan := engine.getCachedPlan(firstExecCtx.postProcessor, &lastRegisteredUserRequest, &schema.document, lastRegisteredUserRequest.OperationName, &report)
+	require.False(t, report.HasErrors())
+	require.Equal(t, 1, engine.executionPlanCache.Len())
+
+	secondExecCtx := newInternalExecutionContext()
+	report = operationreport.Report{}
+	secondPlan := engine.getCachedPlan(secondExecCtx.postProcessor, &liveUserCountRequest, &schema.document, liveUserCountRequest.OperationName, &report)
+	require.False(t, report.HasErrors())
+
+	assert.Equal(t, 2, engine.executionPlanCache.Len(),
+		"the plan cache key must include operationName - two requests selecting different named operations out of the same document text must not collide into one cache entry")
+	assert.NotEqual(t, firstPlan, secondPlan,
+		"a request for \"LiveUserCount\" must not be served the cached plan built for \"LastRegisteredUser\" just because the printed document text is identical")
 }
 
 func BenchmarkExecutionEngineV2(b *testing.B) {

--- a/pkg/graphql/execution_engine_v2_test.go
+++ b/pkg/graphql/execution_engine_v2_test.go
@@ -174,22 +174,22 @@ func TestWithHeaderModifier(t *testing.T) {
 		}
 	}
 
-	t.Run("should add modify header postprocess", func(t *testing.T) {
+	t.Run("should set header modifier on resolve context", func(t *testing.T) {
 		processor := &postprocess.Processor{}
-		require.Equal(t, 0, processor.Count())
+		resolveContext := &resolve.Context{}
 
 		optionFunc := WithHeaderModifier(headerModifier)
-		optionFunc(processor, nil)
-		assert.Equal(t, 1, processor.Count())
+		optionFunc(processor, resolveContext)
+		assert.NotNil(t, resolveContext.HeaderModifier)
 	})
 
-	t.Run("should not touch post processor if no modifier is provided", func(t *testing.T) {
+	t.Run("should not touch resolve context if no modifier is provided", func(t *testing.T) {
 		processor := &postprocess.Processor{}
-		require.Equal(t, 0, processor.Count())
+		resolveContext := &resolve.Context{}
 
 		optionFunc := WithHeaderModifier(nil)
-		optionFunc(processor, nil)
-		assert.Equal(t, 0, processor.Count())
+		optionFunc(processor, resolveContext)
+		assert.Nil(t, resolveContext.HeaderModifier)
 	})
 }
 

--- a/pkg/graphql/schema.go
+++ b/pkg/graphql/schema.go
@@ -37,9 +37,18 @@ type Schema struct {
 	hash         uint64
 }
 
+// Hash returns the hash of the schema. The value is computed once, while the schema is
+// built, so that concurrent readers never write to it. See calcHash.
 func (s *Schema) Hash() (uint64, error) {
+	return s.hash, nil
+}
+
+// calcHash calculates the hash of the schema. It must only be called while the schema is
+// being built, never from a request path: a schema is shared between all requests of an
+// API, so a lazy write here is a data race between concurrent callers of Hash.
+func (s *Schema) calcHash() error {
 	if s.hash != 0 {
-		return s.hash, nil
+		return nil
 	}
 	h := pool.Hash64.Get()
 	h.Reset()
@@ -47,10 +56,10 @@ func (s *Schema) Hash() (uint64, error) {
 	printer := astprinter.Printer{}
 	err := printer.Print(&s.document, nil, h)
 	if err != nil {
-		return 0, err
+		return err
 	}
 	s.hash = h.Sum64()
-	return s.hash, nil
+	return nil
 }
 
 func NewSchemaFromReader(reader io.Reader) (*Schema, error) {
@@ -115,6 +124,7 @@ func (s *Schema) Normalize() (result NormalizationResult, err error) {
 
 	s.rawSchema = normalizedSchema.rawSchema
 	s.document = normalizedSchema.document
+	s.hash = normalizedSchema.hash
 	s.isNormalized = true
 	return NormalizationResult{Successful: true, Errors: nil}, nil
 }
@@ -454,11 +464,16 @@ func createSchema(schemaContent []byte, mergeWithBaseSchema bool) (*Schema, erro
 		rawSchema = rawSchemaBuffer.Bytes()
 	}
 
-	return &Schema{
+	schema := &Schema{
 		rawInput:  schemaContent,
 		rawSchema: rawSchema,
 		document:  document,
-	}, nil
+	}
+	if err := schema.calcHash(); err != nil {
+		return nil, err
+	}
+
+	return schema, nil
 }
 
 func SchemaIntrospection(schema *Schema) (*ExecutionResult, error) {

--- a/pkg/graphql/schema_test.go
+++ b/pkg/graphql/schema_test.go
@@ -3,6 +3,7 @@ package graphql
 import (
 	"bytes"
 	"io"
+	"sync"
 	"testing"
 
 	"github.com/sebdah/goldie"
@@ -2026,3 +2027,103 @@ type VehiclesEdge {
   """A cursor for use in pagination"""
   cursor: String!
 }`
+
+func TestSchema_Hash(t *testing.T) {
+	const schemaDefinition = "type Query { hello: String }"
+
+	// The hash is the identity of the schema for Request.validForSchema, so every constructor has
+	// to produce one. There is a single &Schema{} literal behind all of them; this keeps it that way.
+	t.Run("should be available right after construction", func(t *testing.T) {
+		constructors := map[string]func() (*Schema, error){
+			"from string": func() (*Schema, error) {
+				return NewSchemaFromString(schemaDefinition)
+			},
+			"from reader": func() (*Schema, error) {
+				return NewSchemaFromReader(bytes.NewBufferString(schemaDefinition))
+			},
+		}
+
+		for name, newSchema := range constructors {
+			t.Run(name, func(t *testing.T) {
+				schema, err := newSchema()
+				require.NoError(t, err)
+
+				hash, err := schema.Hash()
+				require.NoError(t, err)
+				assert.NotZero(t, hash, "the hash has to be computed while the schema is built, not on first use")
+
+				again, err := schema.Hash()
+				require.NoError(t, err)
+				assert.Equal(t, hash, again, "Hash() has to be a pure read")
+			})
+		}
+	})
+
+	t.Run("should follow the document after normalization", func(t *testing.T) {
+		// The extension is merged into the type by normalization, so the document - and with it the
+		// hash - really does change.
+		schema, err := NewSchemaFromString("type Query { hello: String }\nextend type Query { world: String }")
+		require.NoError(t, err)
+		beforeNormalization, err := schema.Hash()
+		require.NoError(t, err)
+
+		normalizationResult, err := schema.Normalize()
+		require.NoError(t, err)
+		require.True(t, normalizationResult.Successful)
+
+		afterNormalization, err := schema.Hash()
+		require.NoError(t, err)
+
+		// What the hash has to describe now is the document the schema currently holds.
+		normalized, err := createSchema(schema.rawSchema, false)
+		require.NoError(t, err)
+		expected, err := normalized.Hash()
+		require.NoError(t, err)
+
+		assert.Equal(t, expected, afterNormalization, "Hash() has to describe the document the schema holds")
+		assert.NotEqual(t, beforeNormalization, afterNormalization, "normalization changed the document, so it has to change the hash")
+	})
+
+	// A schema is shared between every request of an API, so a lazy write in Hash() is a data race
+	// between concurrent requests. The expected value comes from a second, identical schema, so that
+	// the schema under test is still cold when the goroutines start: reading its hash up front would
+	// hide exactly the defect this guards. Only reports under -race.
+	t.Run("should be safe to read concurrently", func(t *testing.T) {
+		reference, err := NewSchemaFromString(schemaDefinition)
+		require.NoError(t, err)
+		_, err = reference.Normalize()
+		require.NoError(t, err)
+		expected, err := reference.Hash()
+		require.NoError(t, err)
+		require.NotZero(t, expected)
+
+		schema, err := NewSchemaFromString(schemaDefinition)
+		require.NoError(t, err)
+		_, err = schema.Normalize()
+		require.NoError(t, err)
+
+		var waitGroup sync.WaitGroup
+		for i := 0; i < 50; i++ {
+			waitGroup.Add(3)
+			go func() {
+				defer waitGroup.Done()
+				hash, err := schema.Hash()
+				assert.NoError(t, err)
+				assert.Equal(t, expected, hash)
+			}()
+			// Both callers on the request path used to trigger the lazy write.
+			go func() {
+				defer waitGroup.Done()
+				request := Request{Query: "{ hello }"}
+				_, err := request.ValidateForSchema(schema)
+				assert.NoError(t, err)
+			}()
+			go func() {
+				defer waitGroup.Done()
+				request := Request{Query: "{ hello }"}
+				assert.False(t, request.IsValidated(schema))
+			}()
+		}
+		waitGroup.Wait()
+	})
+}

--- a/pkg/subscription/websocket/handler.go
+++ b/pkg/subscription/websocket/handler.go
@@ -30,6 +30,7 @@ var DefaultProtocol = ProtocolGraphQLTransportWS
 
 // HandleOptions can be used to pass options to the websocket handler.
 type HandleOptions struct {
+	Context                          context.Context
 	Logger                           abstractlogger.Logger
 	Protocol                         Protocol
 	WebSocketInitFunc                InitFunc
@@ -40,6 +41,13 @@ type HandleOptions struct {
 	CustomReadErrorTimeOut           time.Duration
 	CustomSubscriptionEngine         subscription.Engine
 	CustomSubscriptionExecutionRetry int
+}
+
+// WithContext sets the parent context used by the subscription handler.
+func WithContext(ctx context.Context) HandleOptionFunc {
+	return func(opts *HandleOptions) {
+		opts.Context = ctx
+	}
 }
 
 // HandleOptionFunc can be used to define option functions.
@@ -142,6 +150,7 @@ func WithProtocolFromRequestHeaders(req *http.Request) HandleOptionFunc {
 // behavior. By default, it uses the 'graphql-transport-ws' protocol.
 func Handle(done chan bool, errChan chan error, conn net.Conn, executorPool subscription.ExecutorPool, options ...HandleOptionFunc) {
 	definedOptions := HandleOptions{
+		Context:  context.Background(),
 		Logger:   abstractlogger.Noop{},
 		Protocol: DefaultProtocol,
 	}
@@ -206,7 +215,10 @@ func HandleWithOptions(done chan bool, errChan chan error, conn net.Conn, execut
 	}
 
 	close(done)
-	subscriptionHandler.Handle(context.Background()) // Blocking
+	if options.Context == nil {
+		options.Context = context.Background()
+	}
+	subscriptionHandler.Handle(options.Context) // Blocking
 }
 
 func createProtocolHandler(handleOptions HandleOptions, client subscription.TransportClient) (protocolHandler subscription.Protocol, err error) {

--- a/pkg/subscription/websocket/handler_test.go
+++ b/pkg/subscription/websocket/handler_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -22,6 +23,15 @@ import (
 	"github.com/TykTechnologies/graphql-go-tools/pkg/testing/subscriptiontesting"
 )
 
+func TestWithContext(t *testing.T) {
+	ctx := context.WithValue(context.Background(), struct{}{}, "request")
+	options := HandleOptions{}
+
+	WithContext(ctx)(&options)
+
+	assert.Equal(t, ctx, options.Context)
+}
+
 func TestHandleWithOptions(t *testing.T) {
 	t.Run("should handle protocol graphql-ws", func(t *testing.T) {
 		chatServer := httptest.NewServer(subscriptiontesting.ChatGraphQLEndpointHandler())
@@ -30,7 +40,7 @@ func TestHandleWithOptions(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		executorPoolV2 := setupExecutorPoolV2(t, ctx, chatServer.URL, nil)
+		executorPoolV2 := setupExecutorPoolV2(t, ctx, chatServer.URL, nil, httpclient.DefaultNetHttpClient)
 		serverConn, _ := net.Pipe()
 		testClient := NewTestClient(false)
 
@@ -105,7 +115,7 @@ func TestHandleWithOptions(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		executorPoolV2 := setupExecutorPoolV2(t, ctx, chatServer.URL, nil)
+		executorPoolV2 := setupExecutorPoolV2(t, ctx, chatServer.URL, nil, httpclient.DefaultNetHttpClient)
 		serverConn, _ := net.Pipe()
 		testClient := NewTestClient(false)
 
@@ -180,7 +190,7 @@ func TestHandleWithOptions(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		executorPoolV2 := setupExecutorPoolV2(t, ctx, chatServer.URL, &FailingOnBeforeStartHook{})
+		executorPoolV2 := setupExecutorPoolV2(t, ctx, chatServer.URL, &FailingOnBeforeStartHook{}, httpclient.DefaultNetHttpClient)
 		serverConn, _ := net.Pipe()
 		testClient := NewTestClient(false)
 
@@ -220,6 +230,142 @@ func TestHandleWithOptions(t *testing.T) {
 	})
 }
 
+type ctxCaptureKey struct{}
+
+// contextCapturingRoundTripper records the context.Context attached to the last outbound
+// request it forwards, so a test can assert what a caller-supplied context actually reached
+// the real upstream HTTP call.
+type contextCapturingRoundTripper struct {
+	next http.RoundTripper
+
+	mu   sync.Mutex
+	last context.Context
+}
+
+func (c *contextCapturingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	c.mu.Lock()
+	c.last = req.Context()
+	c.mu.Unlock()
+	return c.next.RoundTrip(req)
+}
+
+func (c *contextCapturingRoundTripper) lastContext() context.Context {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.last
+}
+
+func TestHandleWithOptions_ContextValuePropagatesToUpstreamRequest(t *testing.T) {
+	chatServer := httptest.NewServer(subscriptiontesting.ChatGraphQLEndpointHandler())
+	defer chatServer.Close()
+
+	poolCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	capturingTransport := &contextCapturingRoundTripper{next: http.DefaultTransport}
+	capturingClient := &http.Client{Transport: capturingTransport}
+
+	executorPoolV2 := setupExecutorPoolV2(t, poolCtx, chatServer.URL, nil, capturingClient)
+	serverConn, _ := net.Pipe()
+	testClient := NewTestClient(false)
+
+	handleCtx := context.WithValue(context.Background(), ctxCaptureKey{}, "expected-value")
+
+	done := make(chan bool)
+	errChan := make(chan error)
+	go Handle(
+		done,
+		errChan,
+		serverConn,
+		executorPoolV2,
+		WithContext(handleCtx),
+		WithCustomClient(testClient),
+		WithCustomSubscriptionUpdateInterval(50*time.Millisecond),
+		WithCustomKeepAliveInterval(3600*time.Second),
+	)
+
+	require.Eventually(t, func() bool {
+		<-done
+		return true
+	}, 1*time.Second, 2*time.Millisecond)
+
+	testClient.writeMessageFromClient([]byte(`{"type":"connection_init"}`))
+	assert.Eventually(t, func() bool {
+		expectedMessage := []byte(`{"type":"connection_ack"}`)
+		actualMessage := testClient.readMessageToClient()
+		assert.Equal(t, expectedMessage, actualMessage)
+		return true
+	}, 1*time.Second, 2*time.Millisecond, "never satisfied on connection_init")
+
+	testClient.writeMessageFromClient([]byte(`{"id":"1","type":"subscribe","payload":{"query":"{ room(name:\"#my_room\") { name } }"}}`))
+	assert.Eventually(t, func() bool {
+		expectedMessage := []byte(`{"id":"1","type":"next","payload":{"data":{"room":{"name":"#my_room"}}}}`)
+		actualMessage := testClient.readMessageToClient()
+		assert.Equal(t, expectedMessage, actualMessage)
+		expectedMessage = []byte(`{"id":"1","type":"complete"}`)
+		actualMessage = testClient.readMessageToClient()
+		assert.Equal(t, expectedMessage, actualMessage)
+		return true
+	}, 2*time.Second, 2*time.Millisecond, "never satisfied on room query")
+
+	capturedCtx := capturingTransport.lastContext()
+	require.NotNil(t, capturedCtx, "expected the upstream request to have been made with a non-nil context")
+	assert.Equal(t, "expected-value", capturedCtx.Value(ctxCaptureKey{}),
+		"expected the context value set via WithContext to propagate to the outbound upstream request")
+}
+
+func TestHandleWithOptions_CanceledContextAbortsOperation(t *testing.T) {
+	chatServer := httptest.NewServer(subscriptiontesting.ChatGraphQLEndpointHandler())
+	defer chatServer.Close()
+
+	poolCtx, cancelPool := context.WithCancel(context.Background())
+	defer cancelPool()
+
+	executorPoolV2 := setupExecutorPoolV2(t, poolCtx, chatServer.URL, nil, httpclient.DefaultNetHttpClient)
+	serverConn, _ := net.Pipe()
+	testClient := NewTestClient(false)
+
+	handleCtx, cancelHandle := context.WithCancel(context.Background())
+	cancelHandle() // canceled before Handle even starts
+
+	done := make(chan bool)
+	errChan := make(chan error)
+	go Handle(
+		done,
+		errChan,
+		serverConn,
+		executorPoolV2,
+		WithContext(handleCtx),
+		WithCustomClient(testClient),
+		WithCustomSubscriptionUpdateInterval(50*time.Millisecond),
+		WithCustomKeepAliveInterval(3600*time.Second),
+	)
+
+	require.Eventually(t, func() bool {
+		<-done
+		return true
+	}, 1*time.Second, 2*time.Millisecond)
+
+	testClient.writeMessageFromClient([]byte(`{"type":"connection_init"}`))
+	assert.Eventually(t, func() bool {
+		expectedMessage := []byte(`{"type":"connection_ack"}`)
+		actualMessage := testClient.readMessageToClient()
+		assert.Equal(t, expectedMessage, actualMessage)
+		return true
+	}, 1*time.Second, 2*time.Millisecond, "never satisfied on connection_init")
+
+	// A context that's already canceled before Handle even starts is Done() from the very first
+	// check onwards, so the connection is torn down right after handling connection_init - the
+	// subscribe message below is written but never processed, and no further response ever arrives.
+	testClient.writeMessageFromClient([]byte(`{"id":"1","type":"subscribe","payload":{"query":"{ room(name:\"#my_room\") { name } }"}}`))
+	select {
+	case actualMessage := <-testClient.messageToClient:
+		t.Fatalf("expected no further response once the context was already canceled before Handle started, got %s", actualMessage)
+	case <-time.After(300 * time.Millisecond):
+		// expected: the canceled context tore down the connection before the query could be processed.
+	}
+}
+
 func TestWithProtocolFromRequestHeaders(t *testing.T) {
 	runTest := func(headerKey string, headerValue string, expectedProtocol Protocol) func(t *testing.T) {
 		return func(t *testing.T) {
@@ -247,7 +393,7 @@ func TestWithProtocolFromRequestHeaders(t *testing.T) {
 	})
 }
 
-func setupExecutorPoolV2(t *testing.T, ctx context.Context, chatServerURL string, onBeforeStartHook graphql.WebsocketBeforeStartHook) *subscription.ExecutorV2Pool {
+func setupExecutorPoolV2(t *testing.T, ctx context.Context, chatServerURL string, onBeforeStartHook graphql.WebsocketBeforeStartHook, httpClient *http.Client) *subscription.ExecutorV2Pool {
 	chatSchemaBytes, err := subscriptiontesting.LoadSchemaFromExamplesDirectoryWithinPkg()
 	require.NoError(t, err)
 
@@ -268,7 +414,7 @@ func setupExecutorPoolV2(t *testing.T, ctx context.Context, chatServerURL string
 				{TypeName: "Message", FieldNames: []string{"text", "createdBy"}},
 			},
 			Factory: &graphql_datasource.Factory{
-				HTTPClient: httpclient.DefaultNetHttpClient,
+				HTTPClient: httpClient,
 			},
 			Custom: graphql_datasource.ConfigJson(graphql_datasource.Configuration{
 				Fetch: graphql_datasource.FetchConfiguration{

--- a/pkg/subscription/websocket/handler_test.go
+++ b/pkg/subscription/websocket/handler_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestWithContext(t *testing.T) {
-	ctx := context.WithValue(context.Background(), struct{}{}, "request")
+	ctx := context.WithValue(context.Background(), ctxCaptureKey{}, "request")
 	options := HandleOptions{}
 
 	WithContext(ctx)(&options)

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_sse_handler.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_sse_handler.go
@@ -45,13 +45,17 @@ func (h *gqlSSEConnectionHandler) StartBlocking(sub Subscription) {
 
 	dataCh := make(chan []byte)
 	errCh := make(chan []byte)
+	done := make(chan struct{})
 	defer func() {
 		close(dataCh)
 		close(errCh)
 		sub.updater.Done()
 	}()
 
-	go h.subscribe(reqCtx, sub, dataCh, errCh)
+	go func() {
+		defer close(done)
+		h.subscribe(reqCtx, sub, dataCh, errCh)
+	}()
 
 	for {
 		select {
@@ -59,6 +63,8 @@ func (h *gqlSSEConnectionHandler) StartBlocking(sub Subscription) {
 			sub.updater.Update(data)
 		case data := <-errCh:
 			sub.updater.Update(data)
+			return
+		case <-done:
 			return
 		case <-reqCtx.Done():
 			return

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_sse_handler_test.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_sse_handler_test.go
@@ -525,3 +525,102 @@ func TestGraphQLSubscriptionClientSubscribe_SSE_Upstream_Dies(t *testing.T) {
 	}, time.Second, time.Millisecond*10, "server did not close")
 	serverCancel()
 }
+
+// TestSSEConnectionHandlerStartBlockingReturnsWhenUpstreamStops guards against the SSE handler
+// outliving its upstream. The subscribe goroutine returns without reporting anything on errCh
+// whenever the upstream is done with us - it sent "event: complete", it ended the stream, or the
+// subscription request itself failed. StartBlocking has to notice that and return as well,
+// otherwise the goroutine leaks and, because updater.Done() is called from its deferred func, the
+// client's subscription is never completed and stays open until the client disconnects.
+func TestSSEConnectionHandlerStartBlockingReturnsWhenUpstreamStops(t *testing.T) {
+	startBlocking := func(t *testing.T, serverURL string) *testSubscriptionUpdater {
+		t.Helper()
+
+		reqCtx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+
+		updater := &testSubscriptionUpdater{}
+		handler := newSSEConnectionHandler(resolve.NewContext(reqCtx), http.DefaultClient, GraphQLSubscriptionOptions{
+			URL: serverURL,
+			Body: GraphQLBody{
+				Query: `subscription {messageAdded(roomName: "room"){text}}`,
+			},
+			UseSSE: true,
+		}, logger())
+
+		go handler.StartBlocking(Subscription{
+			ctx:     reqCtx,
+			updater: updater,
+		})
+
+		return updater
+	}
+
+	t.Run("on upstream complete event", func(t *testing.T) {
+		// Keeps the upstream connection open after the complete event, so the complete event
+		// itself is the only thing that can end the handler.
+		serverBlock := make(chan struct{})
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			flusher, ok := w.(http.Flusher)
+			require.True(t, ok)
+
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.Header().Set("Cache-Control", "no-cache")
+			w.Header().Set("Connection", "keep-alive")
+
+			_, _ = fmt.Fprintf(w, "event: next\ndata: %s\n\n", `{"data":{"messageAdded":{"text":"first"}}}`)
+			flusher.Flush()
+
+			_, _ = fmt.Fprint(w, "event: complete\n\n")
+			flusher.Flush()
+
+			<-serverBlock
+		}))
+		// LIFO: release the server handler before server.Close() waits for it.
+		defer server.Close()
+		defer close(serverBlock)
+
+		updater := startBlocking(t, server.URL)
+
+		updater.AwaitUpdates(t, time.Second, 1)
+		updater.AwaitDone(t, time.Second)
+		assert.Equal(t, `{"data":{"messageAdded":{"text":"first"}}}`, updater.updates[0])
+	})
+
+	t.Run("on upstream end of stream", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			flusher, ok := w.(http.Flusher)
+			require.True(t, ok)
+
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.Header().Set("Cache-Control", "no-cache")
+			w.Header().Set("Connection", "keep-alive")
+
+			_, _ = fmt.Fprintf(w, "data: %s\n\n", `{"data":{"messageAdded":{"text":"first"}}}`)
+			flusher.Flush()
+
+			// Returning ends the response body, which the handler reads as io.EOF.
+		}))
+		defer server.Close()
+
+		updater := startBlocking(t, server.URL)
+
+		updater.AwaitUpdates(t, time.Second, 1)
+		updater.AwaitDone(t, time.Second)
+		assert.Equal(t, `{"data":{"messageAdded":{"text":"first"}}}`, updater.updates[0])
+	})
+
+	t.Run("on failed subscription request", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer server.Close()
+
+		updater := startBlocking(t, server.URL)
+
+		updater.AwaitUpdates(t, time.Second, 1)
+		updater.AwaitDone(t, time.Second)
+		assert.Equal(t, internalError, updater.updates[0])
+	})
+}

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_subscription_client.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_subscription_client.go
@@ -2,6 +2,7 @@ package graphql_datasource
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"math"
 	"net/http"
@@ -22,14 +23,13 @@ const ackWaitTimeout = 30 * time.Second
 
 // SubscriptionClient allows running multiple subscriptions via the same WebSocket either SSE connection
 // It takes care of de-duplicating connections to the same origin under certain circumstances
-// If Hash(URL,Body,Headers) result in the same result, an existing connection is re-used
+// If the full effective connection descriptor is identical, an existing connection is re-used.
 type SubscriptionClient struct {
 	streamingClient            *http.Client
 	httpClient                 *http.Client
 	engineCtx                  context.Context
 	log                        abstractlogger.Logger
-	hashPool                   sync.Pool
-	handlers                   map[uint64]ConnectionHandler
+	handlers                   map[string]ConnectionHandler
 	handlersMu                 sync.Mutex
 	wsSubProtocol              string
 	onWsConnectionInitCallback *OnWsConnectionInitCallback
@@ -91,17 +91,12 @@ func NewGraphQLSubscriptionClient(httpClient, streamingClient *http.Client, engi
 		option(op)
 	}
 	return &SubscriptionClient{
-		httpClient:      httpClient,
-		streamingClient: streamingClient,
-		engineCtx:       engineCtx,
-		handlers:        make(map[uint64]ConnectionHandler),
-		log:             op.log,
-		readTimeout:     op.readTimeout,
-		hashPool: sync.Pool{
-			New: func() interface{} {
-				return xxhash.New()
-			},
-		},
+		httpClient:                 httpClient,
+		streamingClient:            streamingClient,
+		engineCtx:                  engineCtx,
+		handlers:                   make(map[string]ConnectionHandler),
+		log:                        op.log,
+		readTimeout:                op.readTimeout,
 		wsSubProtocol:              op.wsSubProtocol,
 		onWsConnectionInitCallback: op.onWsConnectionInitCallback,
 	}
@@ -181,8 +176,23 @@ func (c *SubscriptionClient) subscribeWS(reqCtx *resolve.Context, options GraphQ
 		updater: updater,
 	}
 
-	// each WS connection to an origin is uniquely identified by the Hash(URL,Headers,Body)
-	handlerID, err := c.generateHandlerIDHash(reqCtx, options)
+	connectionInitMessage, err := c.getConnectionInitMessage(reqCtx.Context(), options.URL, options.Header)
+	if err != nil {
+		return err
+	}
+	if len(options.InitialPayload) > 0 {
+		connectionInitMessage, err = jsonparser.Set(connectionInitMessage, options.InitialPayload, "payload")
+		if err != nil {
+			return err
+		}
+	}
+	if options.Body.Extensions != nil {
+		connectionInitMessage, err = jsonparser.Set(connectionInitMessage, options.Body.Extensions, "payload", "extensions")
+		if err != nil {
+			return err
+		}
+	}
+	handlerID, err := connectionKey(reqCtx, options, connectionInitMessage)
 	if err != nil {
 		return err
 	}
@@ -198,14 +208,14 @@ func (c *SubscriptionClient) subscribeWS(reqCtx *resolve.Context, options GraphQ
 		return nil
 	}
 
-	handler, err = c.newWSConnectionHandler(reqCtx.Context(), options)
+	handler, err = c.newWSConnectionHandler(reqCtx.Context(), options, connectionInitMessage)
 	if err != nil {
 		return err
 	}
 
 	c.handlers[handlerID] = handler
 
-	go func(handlerID uint64) {
+	go func(handlerID string) {
 		handler.StartBlocking(sub)
 		c.handlersMu.Lock()
 		delete(c.handlers, handlerID)
@@ -215,18 +225,39 @@ func (c *SubscriptionClient) subscribeWS(reqCtx *resolve.Context, options GraphQ
 	return nil
 }
 
-func (c *SubscriptionClient) generateHandlerIDHash(ctx *resolve.Context, options GraphQLSubscriptionOptions) (uint64, error) {
-	xxh := c.hashPool.Get().(*xxhash.Digest)
-	defer c.hashPool.Put(xxh)
-	xxh.Reset()
-	err := c.requestHash(ctx, options, xxh)
-	if err != nil {
-		return 0, err
+func connectionKey(ctx *resolve.Context, options GraphQLSubscriptionOptions, connectionInitMessage []byte) (string, error) {
+	forwardedHeaders := make(http.Header)
+	for _, headerName := range options.ForwardedClientHeaderNames {
+		canonicalName := textproto.CanonicalMIMEHeaderKey(headerName)
+		forwardedHeaders[canonicalName] = append([]string(nil), ctx.Request.Header[canonicalName]...)
 	}
-	return xxh.Sum64(), nil
+	for _, headerRegexp := range options.ForwardedClientHeaderRegularExpressions {
+		for headerName, values := range ctx.Request.Header {
+			if headerRegexp.MatchString(headerName) {
+				canonicalName := textproto.CanonicalMIMEHeaderKey(headerName)
+				forwardedHeaders[canonicalName] = append([]string(nil), values...)
+			}
+		}
+	}
+	descriptor := struct {
+		URL            string
+		Header         http.Header
+		Forwarded      http.Header
+		ConnectionInit string
+	}{
+		URL:            options.URL,
+		Header:         options.Header,
+		Forwarded:      forwardedHeaders,
+		ConnectionInit: string(connectionInitMessage),
+	}
+	key, err := json.Marshal(descriptor)
+	if err != nil {
+		return "", err
+	}
+	return string(key), nil
 }
 
-// generateHandlerIDHash generates a Hash based on: URL and Headers to uniquely identify Upgrade Requests
+// requestHash contributes the subscription descriptor to the resolver's candidate trigger ID.
 func (c *SubscriptionClient) requestHash(ctx *resolve.Context, options GraphQLSubscriptionOptions, xxh *xxhash.Digest) (err error) {
 	if _, err = xxh.WriteString(options.URL); err != nil {
 		return err
@@ -274,7 +305,7 @@ func (c *SubscriptionClient) requestHash(ctx *resolve.Context, options GraphQLSu
 	return nil
 }
 
-func (c *SubscriptionClient) newWSConnectionHandler(reqCtx context.Context, options GraphQLSubscriptionOptions) (ConnectionHandler, error) {
+func (c *SubscriptionClient) newWSConnectionHandler(reqCtx context.Context, options GraphQLSubscriptionOptions, connectionInitMessage []byte) (ConnectionHandler, error) {
 	subProtocols := []string{ProtocolGraphQLWS, ProtocolGraphQLTWS}
 	if c.wsSubProtocol != "" {
 		subProtocols = []string{c.wsSubProtocol}
@@ -296,46 +327,27 @@ func (c *SubscriptionClient) newWSConnectionHandler(reqCtx context.Context, opti
 		return nil, fmt.Errorf("upgrade unsuccessful")
 	}
 
-	connectionInitMessage, err := c.getConnectionInitMessage(reqCtx, options.URL, options.Header)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(options.InitialPayload) > 0 {
-		connectionInitMessage, err = jsonparser.Set(connectionInitMessage, options.InitialPayload, "payload")
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if options.Body.Extensions != nil {
-		connectionInitMessage, err = jsonparser.Set(connectionInitMessage, options.Body.Extensions, "payload", "extensions")
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	// init + ack
 	err = conn.Write(reqCtx, websocket.MessageText, connectionInitMessage)
 	if err != nil {
 		return nil, err
 	}
 
-	if c.wsSubProtocol == "" {
-		c.wsSubProtocol = conn.Subprotocol()
-	}
-
 	if err := waitForAck(reqCtx, conn); err != nil {
 		return nil, err
 	}
 
-	switch c.wsSubProtocol {
+	protocol := c.wsSubProtocol
+	if protocol == "" {
+		protocol = conn.Subprotocol()
+	}
+	switch protocol {
 	case ProtocolGraphQLWS:
 		return newGQLWSConnectionHandler(c.engineCtx, conn, c.readTimeout, c.log), nil
 	case ProtocolGraphQLTWS:
 		return newGQLTWSConnectionHandler(c.engineCtx, conn, c.readTimeout, c.log), nil
 	default:
-		return nil, fmt.Errorf("unknown protocol %s", conn.Subprotocol())
+		return nil, fmt.Errorf("unknown protocol %s", protocol)
 	}
 }
 

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_subscription_client_test.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_subscription_client_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"strconv"
 	"sync"
 	"testing"
@@ -294,4 +295,239 @@ func TestWebsocketSubscriptionClientWithServerDisconnect(t *testing.T) {
 		defer client.handlersMu.Unlock()
 		return len(client.handlers) == 0
 	}, time.Second, time.Millisecond, "client handlers not 0")
+}
+
+type connectionInitTokenKey struct{}
+
+// acceptGraphQLWSServer starts a websocket server that negotiates the graphql-ws protocol, records
+// the connection_init message of every connection it accepts, acknowledges it and then keeps the
+// connection open so a second subscription can be multiplexed onto it.
+func acceptGraphQLWSServer(t *testing.T, record func(initMessage string)) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+			Subprotocols: []string{ProtocolGraphQLWS},
+		})
+		if err != nil {
+			return
+		}
+		defer conn.Close(websocket.StatusInternalError, "closing")
+
+		_, initMessage, err := conn.Read(r.Context())
+		if err != nil {
+			return
+		}
+		record(string(initMessage))
+
+		if err := conn.Write(r.Context(), websocket.MessageText, []byte(`{"type":"connection_ack"}`)); err != nil {
+			return
+		}
+
+		for {
+			if _, _, err := conn.Read(r.Context()); err != nil {
+				return
+			}
+		}
+	}))
+}
+
+// TestSubscriptionClientConnectionInitIsolation guards against multiplexing two requests onto the
+// same upstream websocket when only their connection_init payloads differ. That payload is produced
+// by OnWsConnectionInitCallback, which is handed the request context precisely so it can forward the
+// calling user's credentials - reusing a connection that was authenticated with somebody else's
+// payload puts one user's subscription on another user's upstream session.
+func TestSubscriptionClientConnectionInitIsolation(t *testing.T) {
+	var (
+		mu            sync.Mutex
+		receivedInits []string
+	)
+
+	server := acceptGraphQLWSServer(t, func(initMessage string) {
+		mu.Lock()
+		receivedInits = append(receivedInits, initMessage)
+		mu.Unlock()
+	})
+	defer server.Close()
+
+	var callback OnWsConnectionInitCallback = func(ctx context.Context, url string, header http.Header) (json.RawMessage, error) {
+		token, _ := ctx.Value(connectionInitTokenKey{}).(string)
+		return json.RawMessage(fmt.Sprintf(`{"token":%q}`, token)), nil
+	}
+
+	client := NewGraphQLSubscriptionClient(http.DefaultClient, http.DefaultClient, context.Background(),
+		WithOnWsConnectionInitCallback(&callback),
+	)
+
+	options := GraphQLSubscriptionOptions{
+		URL:  "ws" + server.URL[4:],
+		Body: GraphQLBody{Query: `subscription {messageAdded(roomName: "room"){text}}`},
+	}
+
+	userTokens := []string{"user-1-token", "user-2-token"}
+	for _, token := range userTokens {
+		ctx := context.WithValue(context.Background(), connectionInitTokenKey{}, token)
+		require.NoError(t, client.Subscribe(resolve.NewContext(ctx), options, &testSubscriptionUpdater{}))
+	}
+
+	assert.Eventuallyf(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(receivedInits) == len(userTokens)
+	}, time.Second, time.Millisecond*10, "expected one upstream connection per connection_init payload")
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	for _, token := range userTokens {
+		assert.Contains(t, receivedInits, fmt.Sprintf(`{"type":"connection_init","payload":{"token":"%s"}}`, token))
+	}
+}
+
+// TestSubscriptionClientDoesNotPinNegotiatedSubProtocol guards against one connection's negotiated
+// sub-protocol being written back onto the shared client - it would become the client wide default
+// and narrow the protocols offered to every upstream dialled afterwards.
+func TestSubscriptionClientDoesNotPinNegotiatedSubProtocol(t *testing.T) {
+	server := acceptGraphQLWSServer(t, func(string) {})
+	defer server.Close()
+
+	// No WithWSSubProtocol: the client offers both protocols and lets each connection negotiate.
+	client := NewGraphQLSubscriptionClient(http.DefaultClient, http.DefaultClient, context.Background())
+
+	require.NoError(t, client.Subscribe(resolve.NewContext(context.Background()), GraphQLSubscriptionOptions{
+		URL:  "ws" + server.URL[4:],
+		Body: GraphQLBody{Query: `subscription {messageAdded(roomName: "room"){text}}`},
+	}, &testSubscriptionUpdater{}))
+
+	assert.Empty(t, client.wsSubProtocol,
+		"the protocol negotiated for a single connection must not be pinned onto the shared client")
+}
+
+// TestConnectionKey covers the key that decides whether an upstream websocket connection is reused.
+// It has to tell apart every part of the effective connection descriptor - including the client
+// headers that will be forwarded to the subgraph - while staying stable for descriptors that are
+// equal but were built in a different order.
+func TestConnectionKey(t *testing.T) {
+	const connectionInit = `{"type":"connection_init","payload":{"token":"A"}}`
+
+	newCtx := func(clientHeaders http.Header) *resolve.Context {
+		ctx := resolve.NewContext(context.Background())
+		ctx.Request.Header = clientHeaders
+		return ctx
+	}
+
+	baseOptions := func() GraphQLSubscriptionOptions {
+		return GraphQLSubscriptionOptions{
+			URL:    "ws://example.com/graphql",
+			Header: http.Header{"Authorization": {"Bearer A"}},
+		}
+	}
+
+	key := func(t *testing.T, ctx *resolve.Context, options GraphQLSubscriptionOptions, initMessage string) string {
+		t.Helper()
+
+		result, err := connectionKey(ctx, options, []byte(initMessage))
+		require.NoError(t, err)
+		return result
+	}
+
+	base := key(t, newCtx(nil), baseOptions(), connectionInit)
+
+	t.Run("is stable for the same descriptor", func(t *testing.T) {
+		assert.Equal(t, base, key(t, newCtx(nil), baseOptions(), connectionInit))
+	})
+
+	t.Run("does not depend on the order the headers were set in", func(t *testing.T) {
+		first := http.Header{}
+		first.Set("Authorization", "Bearer A")
+		first.Set("X-Tenant", "tenant-1")
+
+		second := http.Header{}
+		second.Set("X-Tenant", "tenant-1")
+		second.Set("Authorization", "Bearer A")
+
+		firstOptions, secondOptions := baseOptions(), baseOptions()
+		firstOptions.Header, secondOptions.Header = first, second
+
+		assert.Equal(t,
+			key(t, newCtx(nil), firstOptions, connectionInit),
+			key(t, newCtx(nil), secondOptions, connectionInit),
+		)
+	})
+
+	t.Run("differs by url", func(t *testing.T) {
+		options := baseOptions()
+		options.URL = "ws://example.com/other-graphql"
+
+		assert.NotEqual(t, base, key(t, newCtx(nil), options, connectionInit))
+	})
+
+	t.Run("differs by header value", func(t *testing.T) {
+		options := baseOptions()
+		options.Header = http.Header{"Authorization": {"Bearer B"}}
+
+		assert.NotEqual(t, base, key(t, newCtx(nil), options, connectionInit))
+	})
+
+	t.Run("differs by an additional header", func(t *testing.T) {
+		options := baseOptions()
+		options.Header = http.Header{"Authorization": {"Bearer A"}, "X-Tenant": {"tenant-1"}}
+
+		assert.NotEqual(t, base, key(t, newCtx(nil), options, connectionInit))
+	})
+
+	t.Run("differs by connection init payload", func(t *testing.T) {
+		assert.NotEqual(t, base, key(t, newCtx(nil), baseOptions(), `{"type":"connection_init","payload":{"token":"B"}}`))
+	})
+
+	t.Run("handles options without headers", func(t *testing.T) {
+		options := baseOptions()
+		options.Header = nil
+
+		withoutHeaders := key(t, newCtx(nil), options, connectionInit)
+		assert.NotEqual(t, base, withoutHeaders)
+		assert.Equal(t, withoutHeaders, key(t, newCtx(nil), options, connectionInit))
+	})
+
+	t.Run("forwarded client headers", func(t *testing.T) {
+		forwardedByName := baseOptions()
+		forwardedByName.ForwardedClientHeaderNames = []string{"X-Tenant"}
+
+		forwardedByRegexp := baseOptions()
+		forwardedByRegexp.ForwardedClientHeaderRegularExpressions = []*regexp.Regexp{regexp.MustCompile("^X-.*")}
+
+		clientHeader := func(value string) http.Header {
+			header := http.Header{}
+			header.Set("X-Tenant", value)
+			return header
+		}
+
+		t.Run("match when the forwarded value is the same", func(t *testing.T) {
+			assert.Equal(t,
+				key(t, newCtx(clientHeader("tenant-1")), forwardedByName, connectionInit),
+				key(t, newCtx(clientHeader("tenant-1")), forwardedByName, connectionInit),
+			)
+		})
+
+		t.Run("differ when the forwarded value differs", func(t *testing.T) {
+			assert.NotEqual(t,
+				key(t, newCtx(clientHeader("tenant-1")), forwardedByName, connectionInit),
+				key(t, newCtx(clientHeader("tenant-2")), forwardedByName, connectionInit),
+			)
+		})
+
+		t.Run("differ when a header matched by a regular expression differs", func(t *testing.T) {
+			assert.NotEqual(t,
+				key(t, newCtx(clientHeader("tenant-1")), forwardedByRegexp, connectionInit),
+				key(t, newCtx(clientHeader("tenant-2")), forwardedByRegexp, connectionInit),
+			)
+		})
+
+		t.Run("ignore client headers that are not forwarded", func(t *testing.T) {
+			assert.Equal(t,
+				key(t, newCtx(clientHeader("tenant-1")), baseOptions(), connectionInit),
+				key(t, newCtx(clientHeader("tenant-2")), baseOptions(), connectionInit),
+			)
+		})
+	})
 }

--- a/v2/pkg/engine/datasource/httpclient/httpclient.go
+++ b/v2/pkg/engine/datasource/httpclient/httpclient.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
+	"net/http"
 
 	"github.com/buger/jsonparser"
 	bytetemplate "github.com/jensneuse/byte-template"
@@ -162,6 +163,47 @@ func SetInputHeader(input, headers []byte) []byte {
 	return out
 }
 
+func ApplyHeaderModifier(input []byte, modifier func(http.Header)) []byte {
+	if modifier == nil {
+		return input
+	}
+	headerBytes, dataType, _, err := jsonparser.Get(input, HEADER)
+	if err != nil || dataType != jsonparser.Object {
+		return input
+	}
+	var h http.Header
+	if err := json.Unmarshal(headerBytes, &h); err != nil {
+		return input
+	}
+	modifier(h)
+	modifiedHeaderBytes, err := json.Marshal(h)
+	if err != nil {
+		return input
+	}
+	return SetInputHeader(input, modifiedHeaderBytes)
+}
+
+func MergeInputHeader(input []byte, upstreamHeaders http.Header) []byte {
+	if len(upstreamHeaders) == 0 {
+		return input
+	}
+	headerBytes, dataType, _, err := jsonparser.Get(input, HEADER)
+	var h http.Header
+	if err == nil && dataType == jsonparser.Object {
+		_ = json.Unmarshal(headerBytes, &h)
+	}
+	if h == nil {
+		h = make(http.Header)
+	}
+	for k, v := range upstreamHeaders {
+		h[k] = v
+	}
+	modifiedHeaderBytes, err := json.Marshal(h)
+	if err != nil {
+		return input
+	}
+	return SetInputHeader(input, modifiedHeaderBytes)
+}
 func SetForwardedClientHeaderNames(input, headers []byte) []byte {
 	if len(headers) == 0 {
 		return input

--- a/v2/pkg/engine/datasource/httpclient/httpclient.go
+++ b/v2/pkg/engine/datasource/httpclient/httpclient.go
@@ -6,6 +6,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
+	"sync"
+	"unicode/utf8"
 
 	"github.com/buger/jsonparser"
 	bytetemplate "github.com/jensneuse/byte-template"
@@ -195,17 +198,22 @@ func FinalizeInputHeaders(input []byte, modifier func(http.Header), upstreamHead
 	for key, values := range upstreamHeaders {
 		header[http.CanonicalHeaderKey(key)] = append([]string(nil), values...)
 	}
-	headerBytes, err := json.Marshal(header)
-	if err != nil {
-		return nil, fmt.Errorf("marshal datasource input header: %w", err)
-	}
-	modified, err := sjson.SetRawBytes(input, HEADER, headerBytes)
+
+	buf := headerBufferPool.Get().(*[]byte)
+	defer headerBufferPool.Put(buf)
+	*buf = appendHeaderJSON((*buf)[:0], header)
+
+	modified, err := sjson.SetRawBytes(input, HEADER, *buf)
 	if err != nil {
 		return nil, fmt.Errorf("set datasource input header: %w", err)
 	}
 	return modified, nil
 }
 
+// inputHeader reads the "header" object out of a datasource input. It runs once
+// per fetch, so it walks the object with jsonparser rather than unmarshalling
+// it: encoding/json would allocate an intermediate map plus a json.RawMessage
+// and a []string per entry, all of which are thrown away again here.
 func inputHeader(input []byte) (http.Header, error) {
 	headerBytes, dataType, _, err := jsonparser.Get(input, HEADER)
 	if err != nil || dataType == jsonparser.Null {
@@ -215,25 +223,161 @@ func inputHeader(input []byte) (http.Header, error) {
 		return nil, fmt.Errorf("datasource input header must be an object, got %s", dataType)
 	}
 
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(headerBytes, &raw); err != nil {
-		return nil, fmt.Errorf("unmarshal datasource input header: %w", err)
-	}
-	header := make(http.Header, len(raw))
-	for key, value := range raw {
-		var values []string
-		if err := json.Unmarshal(value, &values); err != nil {
-			var scalar string
-			if scalarErr := json.Unmarshal(value, &scalar); scalarErr != nil {
-				return nil, fmt.Errorf("unmarshal datasource input header %q: %w", key, err)
+	header := make(http.Header)
+	err = jsonparser.ObjectEach(headerBytes, func(key, value []byte, valueType jsonparser.ValueType, _ int) error {
+		// ObjectEach hands back unescaped keys but raw values, so only the
+		// values need unescaping.
+		canonicalKey := http.CanonicalHeaderKey(string(key))
+		switch valueType {
+		case jsonparser.String:
+			// A scalar value is a realistic shape for hand-built or third-party
+			// datasource configs; treat it as a single-valued header.
+			unescaped, err := jsonparser.Unescape(value, nil)
+			if err != nil {
+				return fmt.Errorf("unescape datasource input header %q: %w", key, err)
 			}
-			values = []string{scalar}
+			header[canonicalKey] = append(header[canonicalKey], string(unescaped))
+		case jsonparser.Null:
+			// encoding/json decoded a null value into an empty list of values.
+			// Keep the key present with none so the round trip is unchanged.
+			if _, exists := header[canonicalKey]; !exists {
+				header[canonicalKey] = nil
+			}
+		case jsonparser.Array:
+			var valueErr error
+			if _, err := jsonparser.ArrayEach(value, func(item []byte, itemType jsonparser.ValueType, _ int, err error) {
+				if valueErr != nil {
+					return
+				}
+				if err != nil {
+					valueErr = err
+					return
+				}
+				if itemType != jsonparser.String {
+					valueErr = fmt.Errorf("datasource input header %q must hold strings, got %s", key, itemType)
+					return
+				}
+				unescaped, err := jsonparser.Unescape(item, nil)
+				if err != nil {
+					valueErr = err
+					return
+				}
+				header[canonicalKey] = append(header[canonicalKey], string(unescaped))
+			}); err != nil {
+				return fmt.Errorf("read datasource input header %q: %w", key, err)
+			}
+			if valueErr != nil {
+				return fmt.Errorf("read datasource input header %q: %w", key, valueErr)
+			}
+		default:
+			return fmt.Errorf("datasource input header %q must be a string or a list of strings, got %s", key, valueType)
 		}
-		canonicalKey := http.CanonicalHeaderKey(key)
-		header[canonicalKey] = append(header[canonicalKey], values...)
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 	return header, nil
 }
+
+// headerBufferPool holds the scratch buffers appendHeaderJSON serializes into.
+// The bytes are handed to sjson, which copies them into the returned input, so
+// a buffer can go straight back into the pool.
+var headerBufferPool = sync.Pool{
+	New: func() interface{} {
+		buf := make([]byte, 0, 512)
+		return &buf
+	},
+}
+
+// appendHeaderJSON writes header as a JSON object. It replaces
+// json.Marshal(http.Header), which spends a reflection walk and a dozen
+// allocations on a shape that is known statically here.
+func appendHeaderJSON(dst []byte, header http.Header) []byte {
+	keys := make([]string, 0, len(header))
+	for key := range header {
+		keys = append(keys, key)
+	}
+	// encoding/json emits map keys in sorted order, and the serialized input is
+	// not just passed along: it is what a subscription's connection and trigger
+	// keys are derived from. An unstable key order would stop equivalent
+	// subscriptions from sharing an upstream connection.
+	sort.Strings(keys)
+
+	dst = append(dst, '{')
+	for i, key := range keys {
+		if i > 0 {
+			dst = append(dst, ',')
+		}
+		dst = appendJSONString(dst, key)
+		dst = append(dst, ':')
+		values := header[key]
+		if values == nil {
+			dst = append(dst, 'n', 'u', 'l', 'l')
+			continue
+		}
+		dst = append(dst, '[')
+		for j, value := range values {
+			if j > 0 {
+				dst = append(dst, ',')
+			}
+			dst = appendJSONString(dst, value)
+		}
+		dst = append(dst, ']')
+	}
+	return append(dst, '}')
+}
+
+const hexDigits = "0123456789abcdef"
+
+// appendJSONString appends s as a JSON string literal, matching encoding/json
+// with HTML escaping disabled. HTML escaping is deliberately left off: Do()
+// reads header values back out with jsonparser, which does not unescape them,
+// so a "&" would reach the upstream verbatim.
+func appendJSONString(dst []byte, s string) []byte {
+	dst = append(dst, '"')
+	start := 0
+	for i := 0; i < len(s); {
+		if b := s[i]; b < utf8.RuneSelf {
+			if b >= 0x20 && b != '"' && b != '\\' {
+				i++
+				continue
+			}
+			dst = append(dst, s[start:i]...)
+			switch b {
+			case '"', '\\':
+				dst = append(dst, '\\', b)
+			case '\n':
+				dst = append(dst, '\\', 'n')
+			case '\r':
+				dst = append(dst, '\\', 'r')
+			case '\t':
+				dst = append(dst, '\\', 't')
+			default:
+				dst = append(dst, '\\', 'u', '0', '0', hexDigits[b>>4], hexDigits[b&0xf])
+			}
+			i++
+			start = i
+			continue
+		}
+		char, size := utf8.DecodeRuneInString(s[i:])
+		switch {
+		case char == utf8.RuneError && size == 1:
+			dst = append(dst, s[start:i]...)
+			dst = append(dst, "\\ufffd"...)
+		case char == '\u2028' || char == '\u2029':
+			dst = append(dst, s[start:i]...)
+			dst = append(dst, '\\', 'u', '2', '0', '2', hexDigits[char&0xf])
+		default:
+			i += size
+			continue
+		}
+		i += size
+		start = i
+	}
+	return append(append(dst, s[start:]...), '"')
+}
+
 func SetForwardedClientHeaderNames(input, headers []byte) []byte {
 	if len(headers) == 0 {
 		return input

--- a/v2/pkg/engine/datasource/httpclient/httpclient.go
+++ b/v2/pkg/engine/datasource/httpclient/httpclient.go
@@ -3,6 +3,7 @@ package httpclient
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 
@@ -164,45 +165,74 @@ func SetInputHeader(input, headers []byte) []byte {
 }
 
 func ApplyHeaderModifier(input []byte, modifier func(http.Header)) []byte {
-	if modifier == nil {
-		return input
-	}
-	headerBytes, dataType, _, err := jsonparser.Get(input, HEADER)
-	if err != nil || dataType != jsonparser.Object {
-		return input
-	}
-	var h http.Header
-	if err := json.Unmarshal(headerBytes, &h); err != nil {
-		return input
-	}
-	modifier(h)
-	modifiedHeaderBytes, err := json.Marshal(h)
+	modified, err := FinalizeInputHeaders(input, modifier, nil)
 	if err != nil {
 		return input
 	}
-	return SetInputHeader(input, modifiedHeaderBytes)
+	return modified
 }
 
 func MergeInputHeader(input []byte, upstreamHeaders http.Header) []byte {
-	if len(upstreamHeaders) == 0 {
-		return input
-	}
-	headerBytes, dataType, _, err := jsonparser.Get(input, HEADER)
-	var h http.Header
-	if err == nil && dataType == jsonparser.Object {
-		_ = json.Unmarshal(headerBytes, &h)
-	}
-	if h == nil {
-		h = make(http.Header)
-	}
-	for k, v := range upstreamHeaders {
-		h[k] = v
-	}
-	modifiedHeaderBytes, err := json.Marshal(h)
+	modified, err := FinalizeInputHeaders(input, nil, upstreamHeaders)
 	if err != nil {
 		return input
 	}
-	return SetInputHeader(input, modifiedHeaderBytes)
+	return modified
+}
+
+func FinalizeInputHeaders(input []byte, modifier func(http.Header), upstreamHeaders http.Header) ([]byte, error) {
+	if modifier == nil && len(upstreamHeaders) == 0 {
+		return input, nil
+	}
+
+	header, err := inputHeader(input)
+	if err != nil {
+		return nil, err
+	}
+	if modifier != nil {
+		modifier(header)
+	}
+	for key, values := range upstreamHeaders {
+		header[http.CanonicalHeaderKey(key)] = append([]string(nil), values...)
+	}
+	headerBytes, err := json.Marshal(header)
+	if err != nil {
+		return nil, fmt.Errorf("marshal datasource input header: %w", err)
+	}
+	modified, err := sjson.SetRawBytes(input, HEADER, headerBytes)
+	if err != nil {
+		return nil, fmt.Errorf("set datasource input header: %w", err)
+	}
+	return modified, nil
+}
+
+func inputHeader(input []byte) (http.Header, error) {
+	headerBytes, dataType, _, err := jsonparser.Get(input, HEADER)
+	if err != nil || dataType == jsonparser.Null {
+		return make(http.Header), nil
+	}
+	if dataType != jsonparser.Object {
+		return nil, fmt.Errorf("datasource input header must be an object, got %s", dataType)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(headerBytes, &raw); err != nil {
+		return nil, fmt.Errorf("unmarshal datasource input header: %w", err)
+	}
+	header := make(http.Header, len(raw))
+	for key, value := range raw {
+		var values []string
+		if err := json.Unmarshal(value, &values); err != nil {
+			var scalar string
+			if scalarErr := json.Unmarshal(value, &scalar); scalarErr != nil {
+				return nil, fmt.Errorf("unmarshal datasource input header %q: %w", key, err)
+			}
+			values = []string{scalar}
+		}
+		canonicalKey := http.CanonicalHeaderKey(key)
+		header[canonicalKey] = append(header[canonicalKey], values...)
+	}
+	return header, nil
 }
 func SetForwardedClientHeaderNames(input, headers []byte) []byte {
 	if len(headers) == 0 {

--- a/v2/pkg/engine/datasource/httpclient/httpclient_test.go
+++ b/v2/pkg/engine/datasource/httpclient/httpclient_test.go
@@ -5,10 +5,14 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
+	"strconv"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/andybalholm/brotli"
@@ -419,4 +423,286 @@ func TestHttpClientDo(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Contains(t, out.String(), `"Authorization":["****"]`)
 	})
+}
+
+// benchFinalizeInputSink keeps the compiler from eliding the benchmarked call.
+var benchFinalizeInputSink []byte
+
+// benchFinalizeInput mirrors what the loader hands to FinalizeInputHeaders: a
+// fully rendered fetch input - query body and all - carrying a header object of
+// the size a real datasource config produces.
+func benchFinalizeInput() []byte {
+	return []byte(`{"method":"POST","url":"http://localhost:4001/graphql",` +
+		`"body":{"query":"query($representations: [_Any!]!){_entities(representations: $representations){... on Product {name price reviews {body author {username}}}}}",` +
+		`"variables":{"representations":[{"__typename":"Product","upc":"top-1"},{"__typename":"Product","upc":"top-2"}]}},` +
+		`"header":{"Authorization":["Bearer abcdefghijklmnop"],"X-Request-Id":["7f3c9a12"],` +
+		`"X-Forwarded-For":["10.0.0.1"],"Content-Type":["application/json"],"X-Tyk-Api-Name":["reviews"]}}`)
+}
+
+// BenchmarkFinalizeInputHeaders measures the per-fetch cost of finalizing the
+// headers. The gateway always installs a header modifier, so "modifier only" is
+// the case that matters in production; "nothing to do" measures the early
+// return every other embedder gets.
+func BenchmarkFinalizeInputHeaders(b *testing.B) {
+	input := benchFinalizeInput()
+	upstreamHeaders := http.Header{
+		"X-Upstream-Tenant": []string{"acme"},
+		"Authorization":     []string{"Bearer upstream"},
+	}
+	// modifier mirrors the gateway's: default in what is missing, then rewrite
+	// every value (tyk/internal/graphengine/graphql_go_tools_v2.go).
+	modifier := func(header http.Header) {
+		for key := range upstreamHeaders {
+			if header.Get(key) == "" {
+				header.Set(key, upstreamHeaders.Get(key))
+			}
+		}
+		for key := range header {
+			header.Set(key, header.Get(key))
+		}
+	}
+
+	for _, benchmark := range []struct {
+		name            string
+		modifier        func(http.Header)
+		upstreamHeaders http.Header
+	}{
+		{name: "nothing to do"},
+		{name: "modifier only", modifier: modifier},
+		{name: "upstream headers only", upstreamHeaders: upstreamHeaders},
+		{name: "modifier and upstream headers", modifier: modifier, upstreamHeaders: upstreamHeaders},
+	} {
+		b.Run(benchmark.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				out, err := FinalizeInputHeaders(input, benchmark.modifier, benchmark.upstreamHeaders)
+				if err != nil {
+					b.Fatal(err)
+				}
+				benchFinalizeInputSink = out
+			}
+		})
+	}
+}
+
+// TestInputHeader covers the read half of FinalizeInputHeaders directly. It
+// walks the JSON with jsonparser rather than unmarshalling it, so every shape
+// encoding/json used to handle has to be handled explicitly here.
+func TestInputHeader(t *testing.T) {
+	t.Run("missing header key yields an empty header", func(t *testing.T) {
+		header, err := inputHeader([]byte(`{"method":"GET"}`))
+		require.NoError(t, err)
+		assert.Empty(t, header)
+	})
+
+	t.Run("null header yields an empty header", func(t *testing.T) {
+		header, err := inputHeader([]byte(`{"header":null}`))
+		require.NoError(t, err)
+		assert.Empty(t, header)
+	})
+
+	t.Run("non-object header is an error", func(t *testing.T) {
+		_, err := inputHeader([]byte(`{"header":[1,2,3]}`))
+		assert.Error(t, err)
+	})
+
+	t.Run("array and scalar values are both accepted", func(t *testing.T) {
+		header, err := inputHeader([]byte(`{"header":{"X-List":["a","b"],"X-Scalar":"c"}}`))
+		require.NoError(t, err)
+		assert.Equal(t, []string{"a", "b"}, header.Values("X-List"))
+		assert.Equal(t, []string{"c"}, header.Values("X-Scalar"))
+	})
+
+	t.Run("keys are canonicalized and merged", func(t *testing.T) {
+		header, err := inputHeader([]byte(`{"header":{"authorization":"first","AUTHORIZATION":["second"]}}`))
+		require.NoError(t, err)
+		assert.Len(t, header, 1, "differently cased keys must collapse into one entry")
+		assert.ElementsMatch(t, []string{"first", "second"}, header.Values("Authorization"))
+	})
+
+	t.Run("escaped values are unescaped", func(t *testing.T) {
+		header, err := inputHeader([]byte(`{"header":{"X-Escaped":["a\"b\\c\nd&e"]}}`))
+		require.NoError(t, err)
+		assert.Equal(t, []string{"a\"b\\c\nd&e"}, header.Values("X-Escaped"))
+	})
+
+	t.Run("null value keeps the key with no values", func(t *testing.T) {
+		header, err := inputHeader([]byte(`{"header":{"X-Empty":null}}`))
+		require.NoError(t, err)
+		values, exists := header["X-Empty"]
+		assert.True(t, exists, "the key must survive the round trip")
+		assert.Nil(t, values)
+	})
+
+	t.Run("non-string values are an error", func(t *testing.T) {
+		_, err := inputHeader([]byte(`{"header":{"X-Number":42}}`))
+		assert.Error(t, err)
+
+		_, err = inputHeader([]byte(`{"header":{"X-Number":[42]}}`))
+		assert.Error(t, err, "a non-string list entry must be reported, not silently dropped")
+
+		_, err = inputHeader([]byte(`{"header":{"X-Object":{"nested":"value"}}}`))
+		assert.Error(t, err)
+	})
+}
+
+// TestAppendJSONString pins appendJSONString against the encoder it replaces:
+// encoding/json with HTML escaping disabled. The escaping rules are subtle
+// enough (short forms, \u00xx for the remaining control bytes, U+2028/U+2029,
+// invalid UTF-8) that a table of expectations would only restate the
+// implementation - comparing against the standard library is the real check.
+func TestAppendJSONString(t *testing.T) {
+	for _, value := range []string{
+		"",
+		"plain",
+		`with "quotes"`,
+		`with \backslash`,
+		"tab\tnewline\ncarriage\rreturn",
+		"control\x00\x01\x1f",
+		"delete\x7f",
+		"html & <tags> 'quoted'",
+		"unicode: äöü 日本語 🎉",
+		"line\u2028separator\u2029paragraph",
+		"invalid utf8: \xff\xfe",
+		"Bearer eyJhbGciOiJIUzI1NiJ9.e30.abc-_123",
+	} {
+		t.Run(strconv.Quote(value), func(t *testing.T) {
+			var expected bytes.Buffer
+			encoder := json.NewEncoder(&expected)
+			encoder.SetEscapeHTML(false)
+			require.NoError(t, encoder.Encode(value))
+
+			assert.Equal(t,
+				strings.TrimSuffix(expected.String(), "\n"),
+				string(appendJSONString(nil, value)))
+		})
+	}
+}
+
+// TestAppendHeaderJSON pins the object appendJSONString's values end up in -
+// most importantly its key order, which subscription connection keys are
+// derived from and which therefore has to be stable across requests.
+func TestAppendHeaderJSON(t *testing.T) {
+	t.Run("empty header", func(t *testing.T) {
+		assert.Equal(t, `{}`, string(appendHeaderJSON(nil, http.Header{})))
+	})
+
+	t.Run("keys are sorted", func(t *testing.T) {
+		header := http.Header{
+			"X-Zulu":        []string{"z"},
+			"Authorization": []string{"a"},
+			"X-Alpha":       []string{"m"},
+		}
+		expected := `{"Authorization":["a"],"X-Alpha":["m"],"X-Zulu":["z"]}`
+		assert.Equal(t, expected, string(appendHeaderJSON(nil, header)))
+		// Map iteration order varies per run; repeat to make an accidental
+		// dependency on it show up.
+		for i := 0; i < 20; i++ {
+			assert.Equal(t, expected, string(appendHeaderJSON(nil, header)))
+		}
+	})
+
+	t.Run("multiple values and a nil value", func(t *testing.T) {
+		header := http.Header{"X-Multi": []string{"a", "b"}, "X-Nil": nil}
+		assert.Equal(t, `{"X-Multi":["a","b"],"X-Nil":null}`, string(appendHeaderJSON(nil, header)))
+	})
+
+	t.Run("appends to the existing buffer", func(t *testing.T) {
+		out := appendHeaderJSON([]byte(`prefix:`), http.Header{"A": []string{"b"}})
+		assert.Equal(t, `prefix:{"A":["b"]}`, string(out))
+	})
+}
+
+// TestFinalizeInputHeadersKeepsAwkwardHeaderNames guards the header object
+// being rebuilt as a whole rather than key by key: a "." in a header name is
+// legal (RFC 9110 tchar) but is path syntax to sjson, so a per-key set would
+// nest it instead of writing it out.
+func TestFinalizeInputHeadersKeepsAwkwardHeaderNames(t *testing.T) {
+	in := []byte(`{"header":{"X.Dotted":["one"],"X-Star*":["two"]}}`)
+	out, err := FinalizeInputHeaders(in, func(header http.Header) {
+		header.Set("X-Added", "three")
+	}, nil)
+	require.NoError(t, err)
+
+	header, err := inputHeader(out)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"one"}, header.Values("X.Dotted"))
+	assert.Equal(t, []string{"two"}, header.Values("X-Star*"))
+	assert.Equal(t, []string{"three"}, header.Values("X-Added"))
+}
+
+// TestFinalizeInputHeadersValueReachesUpstreamVerbatim pins the one visible
+// difference from the encoding/json round trip this used to do: json.Marshal
+// escapes "&", "<" and ">" as \u0026 and friends, while Do() reads header
+// values back out with jsonparser, which does not unescape them - so those
+// values used to reach the upstream mangled.
+func TestFinalizeInputHeadersValueReachesUpstreamVerbatim(t *testing.T) {
+	const value = `a&b<c>d`
+
+	received := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received <- r.Header.Get("X-Ampersand")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	input := SetInputMethod(nil, []byte("GET"))
+	input = SetInputURL(input, []byte(server.URL))
+	input, err := FinalizeInputHeaders(input, func(header http.Header) {
+		header.Set("X-Ampersand", value)
+	}, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, Do(http.DefaultClient, context.Background(), input, &bytes.Buffer{}))
+	assert.Equal(t, value, <-received)
+}
+
+// TestFinalizeInputHeadersResultOutlivesThePooledBuffer guards the scratch
+// buffer the header JSON is serialized into: it goes back to the pool as soon
+// as sjson has written the new input, so an already-returned result must not
+// still be pointing at it.
+func TestFinalizeInputHeadersResultOutlivesThePooledBuffer(t *testing.T) {
+	in := []byte(`{"header":{"Authorization":["original"]}}`)
+
+	first, err := FinalizeInputHeaders(in, func(header http.Header) {
+		header.Set("Authorization", "first")
+	}, nil)
+	require.NoError(t, err)
+	firstCopy := string(first)
+
+	for i := 0; i < 10; i++ {
+		_, err := FinalizeInputHeaders(in, func(header http.Header) {
+			header.Set("Authorization", "second-with-a-much-longer-value-to-force-the-buffer-to-grow")
+			header.Set("X-Padding", strings.Repeat("p", 512))
+		}, nil)
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, firstCopy, string(first),
+		"a finalized input must not alias the pooled serialization buffer")
+}
+
+// TestFinalizeInputHeadersConcurrent exercises the shared serialization buffer
+// pool from several goroutines at once - the whole point of this call site is
+// that it runs per request, concurrently.
+func TestFinalizeInputHeadersConcurrent(t *testing.T) {
+	in := []byte(`{"header":{"X-Static":["value"]},"body":{"query":"{ hello }"}}`)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			value := fmt.Sprintf("caller-%d", i)
+			expected := fmt.Sprintf(`{"header":{"X-Caller":["caller-%d"],"X-Static":["value"]},"body":{"query":"{ hello }"}}`, i)
+			for j := 0; j < 50; j++ {
+				out, err := FinalizeInputHeaders(in, func(header http.Header) {
+					header.Set("X-Caller", value)
+				}, nil)
+				assert.NoError(t, err)
+				assert.Equal(t, expected, string(out))
+			}
+		}(i)
+	}
+	wg.Wait()
 }

--- a/v2/pkg/engine/datasource/httpclient/httpclient_test.go
+++ b/v2/pkg/engine/datasource/httpclient/httpclient_test.go
@@ -77,6 +77,70 @@ func TestHttpClient(t *testing.T) {
 	assert.Equal(t, `{"body":{"variables":{"foo":{"bar":$$0$$}}}}`, string(in))
 }
 
+func TestApplyHeaderModifier(t *testing.T) {
+	setAuth := func(value string) func(http.Header) {
+		return func(header http.Header) { header.Set("Authorization", value) }
+	}
+
+	t.Run("nil modifier returns input unchanged", func(t *testing.T) {
+		in := []byte(`{"method":"GET","header":{"Authorization":["old"]}}`)
+		out := ApplyHeaderModifier(in, nil)
+		assert.Equal(t, string(in), string(out))
+	})
+
+	t.Run("no existing header key is a no-op", func(t *testing.T) {
+		in := []byte(`{"method":"GET"}`)
+		out := ApplyHeaderModifier(in, setAuth("new"))
+		assert.Equal(t, `{"method":"GET"}`, string(out))
+	})
+
+	t.Run("non-object header value is a no-op", func(t *testing.T) {
+		in := []byte(`{"method":"GET","header":[1,2,3]}`)
+		out := ApplyHeaderModifier(in, setAuth("new"))
+		assert.Equal(t, `{"method":"GET","header":[1,2,3]}`, string(out))
+	})
+
+	t.Run("existing header object is rewritten by the modifier", func(t *testing.T) {
+		in := []byte(`{"method":"GET","header":{"Authorization":["old"]}}`)
+		out := ApplyHeaderModifier(in, setAuth("new"))
+		assert.Equal(t, `{"method":"GET","header":{"Authorization":["new"]}}`, string(out))
+	})
+
+	t.Run("modifier can add a key alongside existing ones", func(t *testing.T) {
+		in := []byte(`{"header":{"Authorization":["old"]}}`)
+		out := ApplyHeaderModifier(in, func(header http.Header) {
+			header.Set("X-Trace", "abc")
+		})
+		assert.Equal(t, `{"header":{"Authorization":["old"],"X-Trace":["abc"]}}`, string(out))
+	})
+}
+
+func TestMergeInputHeader(t *testing.T) {
+	t.Run("empty upstream headers is a no-op", func(t *testing.T) {
+		in := []byte(`{"method":"GET"}`)
+		assert.Equal(t, `{"method":"GET"}`, string(MergeInputHeader(in, nil)))
+		assert.Equal(t, `{"method":"GET"}`, string(MergeInputHeader(in, http.Header{})))
+	})
+
+	t.Run("no existing header key creates one", func(t *testing.T) {
+		in := []byte(`{"method":"GET"}`)
+		out := MergeInputHeader(in, http.Header{"Authorization": []string{"secret"}})
+		assert.Equal(t, `{"header":{"Authorization":["secret"]},"method":"GET"}`, string(out))
+	})
+
+	t.Run("matching keys are overwritten, other keys are preserved", func(t *testing.T) {
+		in := []byte(`{"header":{"Authorization":["old"],"X-Client":["alpha"]}}`)
+		out := MergeInputHeader(in, http.Header{"Authorization": []string{"new"}})
+		assert.Equal(t, `{"header":{"Authorization":["new"],"X-Client":["alpha"]}}`, string(out))
+	})
+
+	t.Run("non-object existing header value is replaced entirely", func(t *testing.T) {
+		in := []byte(`{"header":[1,2,3]}`)
+		out := MergeInputHeader(in, http.Header{"Authorization": []string{"secret"}})
+		assert.Equal(t, `{"header":{"Authorization":["secret"]}}`, string(out))
+	})
+}
+
 func TestHttpClientDo(t *testing.T) {
 
 	runTest := func(ctx context.Context, input []byte, expectedOutput string) func(t *testing.T) {

--- a/v2/pkg/engine/datasource/httpclient/httpclient_test.go
+++ b/v2/pkg/engine/datasource/httpclient/httpclient_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -11,7 +12,9 @@ import (
 	"testing"
 
 	"github.com/andybalholm/brotli"
+	"github.com/buger/jsonparser"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tidwall/sjson"
 
 	"github.com/TykTechnologies/graphql-go-tools/v2/internal/pkg/quotes"
@@ -88,10 +91,10 @@ func TestApplyHeaderModifier(t *testing.T) {
 		assert.Equal(t, string(in), string(out))
 	})
 
-	t.Run("no existing header key is a no-op", func(t *testing.T) {
+	t.Run("no existing header key creates one", func(t *testing.T) {
 		in := []byte(`{"method":"GET"}`)
 		out := ApplyHeaderModifier(in, setAuth("new"))
-		assert.Equal(t, `{"method":"GET"}`, string(out))
+		assert.Equal(t, `{"header":{"Authorization":["new"]},"method":"GET"}`, string(out))
 	})
 
 	t.Run("non-object header value is a no-op", func(t *testing.T) {
@@ -134,11 +137,124 @@ func TestMergeInputHeader(t *testing.T) {
 		assert.Equal(t, `{"header":{"Authorization":["new"],"X-Client":["alpha"]}}`, string(out))
 	})
 
-	t.Run("non-object existing header value is replaced entirely", func(t *testing.T) {
+	t.Run("non-object existing header value is left untouched", func(t *testing.T) {
 		in := []byte(`{"header":[1,2,3]}`)
 		out := MergeInputHeader(in, http.Header{"Authorization": []string{"secret"}})
-		assert.Equal(t, `{"header":{"Authorization":["secret"]}}`, string(out))
+		assert.Equal(t, `{"header":[1,2,3]}`, string(out))
 	})
+}
+
+// TestFinalizeInputHeaders covers FinalizeInputHeaders directly - behavior that
+// ApplyHeaderModifier/MergeInputHeader can't exercise on their own since each
+// only ever passes one of modifier/upstreamHeaders (never both), and both
+// wrappers swallow the error return instead of surfacing it.
+func TestFinalizeInputHeaders(t *testing.T) {
+	t.Run("nil modifier and empty upstream headers returns input unchanged", func(t *testing.T) {
+		in := []byte(`{"method":"GET","header":{"Authorization":["old"]}}`)
+
+		out, err := FinalizeInputHeaders(in, nil, nil)
+		require.NoError(t, err)
+		assert.Equal(t, string(in), string(out))
+
+		out, err = FinalizeInputHeaders(in, nil, http.Header{})
+		require.NoError(t, err)
+		assert.Equal(t, string(in), string(out))
+	})
+
+	t.Run("modifier normalizes scalar and mixed-case values", func(t *testing.T) {
+		in := []byte(`{"header":{"authorization":"first","Authorization":["second","third"]}}`)
+		out, err := FinalizeInputHeaders(in, func(header http.Header) {
+			header.Add("AUTHORIZATION", "current")
+		}, nil)
+		require.NoError(t, err)
+
+		var decoded struct {
+			Header http.Header `json:"header"`
+		}
+		require.NoError(t, json.Unmarshal(out, &decoded))
+		assert.ElementsMatch(t, []string{"first", "second", "third", "current"}, decoded.Header.Values("Authorization"))
+	})
+
+	t.Run("upstream headers take final precedence over the modifier, other modifier keys survive", func(t *testing.T) {
+		in := []byte(`{"header":{}}`)
+		out, err := FinalizeInputHeaders(in, func(header http.Header) {
+			header.Set("Authorization", "from-modifier")
+			header.Set("X-Trace", "abc")
+		}, http.Header{"Authorization": {"from-upstream"}})
+		require.NoError(t, err)
+
+		var decoded struct {
+			Header http.Header `json:"header"`
+		}
+		require.NoError(t, json.Unmarshal(out, &decoded))
+		assert.Equal(t, []string{"from-upstream"}, decoded.Header.Values("Authorization"),
+			"upstream headers must take final precedence over whatever the modifier set")
+		assert.Equal(t, []string{"abc"}, decoded.Header.Values("X-Trace"),
+			"keys the modifier set that upstream headers don't mention must survive")
+	})
+
+	t.Run("malformed header value returns an error", func(t *testing.T) {
+		_, err := FinalizeInputHeaders([]byte(`{"header":{"Authorization":42}}`), func(http.Header) {}, nil)
+		assert.Error(t, err)
+	})
+}
+
+// TestApplyHeaderModifierCreatesMissingHeader guards against the case where a
+// datasource's input has no "header" key at all yet - ApplyHeaderModifier must
+// still be able to add one, not silently no-op.
+func TestApplyHeaderModifierCreatesMissingHeader(t *testing.T) {
+	in := []byte(`{"method":"GET"}`)
+	out := ApplyHeaderModifier(in, func(header http.Header) {
+		header.Set("Authorization", "new")
+	})
+
+	headerBytes, dataType, _, err := jsonparser.Get(out, HEADER)
+	require.NoError(t, err, "ApplyHeaderModifier must create a \"header\" key when none exists yet, got %s", out)
+	require.Equal(t, jsonparser.Object, dataType)
+
+	var decoded struct {
+		Header http.Header `json:"header"`
+	}
+	require.NoError(t, json.Unmarshal(headerBytes, &decoded.Header))
+	assert.Equal(t, []string{"new"}, decoded.Header.Values("Authorization"))
+}
+
+// TestApplyHeaderModifierAppliesDespiteScalarHeaderValue guards against a
+// datasource input whose "header" object mixes scalar and array-shaped values -
+// a realistic shape for hand-built or third-party datasource configs. The
+// modifier must still be applied to the other keys, rather than the whole
+// operation being silently abandoned because one value didn't parse as
+// []string.
+func TestApplyHeaderModifierAppliesDespiteScalarHeaderValue(t *testing.T) {
+	in := []byte(`{"header":{"Authorization":"first"}}`)
+	out := ApplyHeaderModifier(in, func(header http.Header) {
+		header.Set("X-Trace", "abc")
+	})
+	assert.Contains(t, string(out), `"X-Trace"`,
+		"a scalar-valued existing header entry must not silently prevent the modifier from being applied, got %s", out)
+}
+
+// TestApplyHeaderModifierCanonicalizesHeaderKeyCasing guards against header
+// keys surviving as raw, non-canonical JSON object keys - e.g. "authorization"
+// and "Authorization" must be treated as the same header, not two independent
+// entries.
+func TestApplyHeaderModifierCanonicalizesHeaderKeyCasing(t *testing.T) {
+	in := []byte(`{"header":{"authorization":["legacy"]}}`)
+	out := ApplyHeaderModifier(in, func(header http.Header) {
+		header.Add("Authorization", "current")
+	})
+
+	headerBytes, _, _, err := jsonparser.Get(out, HEADER)
+	require.NoError(t, err)
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(headerBytes, &raw))
+
+	_, hasLowercase := raw["authorization"]
+	assert.False(t, hasLowercase, `header keys must be canonicalized; found a raw "authorization" key in %s`, out)
+
+	var values []string
+	require.NoError(t, json.Unmarshal(raw["Authorization"], &values))
+	assert.Equal(t, []string{"legacy", "current"}, values)
 }
 
 func TestHttpClientDo(t *testing.T) {

--- a/v2/pkg/engine/resolve/async_subscription_context_test.go
+++ b/v2/pkg/engine/resolve/async_subscription_context_test.go
@@ -1,0 +1,160 @@
+package resolve
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type asyncSubscriptionContextKey struct{}
+
+// resolverWithoutEventLoop builds a Resolver that does not run handleEvents, so the test itself
+// can receive the subscription event exactly where the event loop would. New() always starts the
+// event loop and r.events is unbuffered, which would make "who owns the Context?" a race.
+func resolverWithoutEventLoop() *Resolver {
+	return &Resolver{
+		ctx:      context.Background(),
+		events:   make(chan subscriptionEvent),
+		triggers: make(map[uint64]*trigger),
+	}
+}
+
+func asyncSubscriptionPlan() *GraphQLSubscription {
+	return &GraphQLSubscription{
+		Trigger: GraphQLSubscriptionTrigger{
+			Source: createFakeStream(func(counter int) (message string, done bool) {
+				return "", true
+			}, 0, nil),
+			InputTemplate: InputTemplate{
+				Segments: []TemplateSegment{
+					{
+						SegmentType: StaticSegmentType,
+						Data:        []byte(`{"method":"POST","url":"http://localhost:4000","body":{"query":"subscription { counter }"}}`),
+					},
+				},
+			},
+		},
+		Response: &GraphQLResponse{
+			Data: &Object{},
+		},
+	}
+}
+
+// captureAsyncSubscriptionContext starts an async subscription and returns the *Context the
+// resolver handed over to its event loop. Only the pointer is captured here - the values behind
+// it are read by the caller afterwards, which is what makes "did the resolver keep a reference to
+// our Context?" observable without any timing assumptions.
+func captureAsyncSubscriptionContext(t *testing.T, resolver *Resolver, ctx *Context) *Context {
+	t.Helper()
+
+	captured := make(chan *Context, 1)
+	go func() {
+		event := <-resolver.events
+		captured <- event.addSubscription.ctx
+	}()
+
+	recorder := &SubscriptionRecorder{
+		buf:      &bytes.Buffer{},
+		messages: []string{},
+	}
+	id := SubscriptionIdentifier{ConnectionID: 1, SubscriptionID: 1}
+
+	err := resolver.AsyncResolveGraphQLSubscription(ctx, asyncSubscriptionPlan(), recorder, id)
+	require.NoError(t, err)
+
+	select {
+	case handedOver := <-captured:
+		return handedOver
+	case <-time.After(time.Second):
+		t.Fatal("resolver did not hand the subscription over to its event loop")
+		return nil
+	}
+}
+
+// TestAsyncResolveGraphQLSubscriptionOwnsCallerContext guards against the resolver keeping the
+// caller's *Context alive past the call. AsyncResolveGraphQLSubscription returns immediately, but
+// the event loop only dereferences the Context later, in handleAddSubscription - by which time the
+// caller (internalExecutionContext.reset() -> Free()) has long returned it to its pool and
+// prepared it for the next request. The subscription must be started with the request it belongs
+// to, not with whatever request happens to own the pooled Context by then.
+func TestAsyncResolveGraphQLSubscriptionOwnsCallerContext(t *testing.T) {
+	resolver := resolverWithoutEventLoop()
+
+	reqCtx := NewContext(context.Background())
+	reqCtx.Variables = []byte(`{"room":"first"}`)
+	reqCtx.Request.Header = http.Header{"X-Request-Id": {"first"}}
+	reqCtx.InitialPayload = []byte(`{"token":"first"}`)
+	reqCtx.Extensions = []byte(`{"trace":"first"}`)
+
+	handedOver := captureAsyncSubscriptionContext(t, resolver, reqCtx)
+	require.NotNil(t, handedOver)
+
+	// The caller returns its pooled Context and prepares it for the next request.
+	reqCtx.Free()
+	reqCtx.Variables = []byte(`{"room":"second"}`)
+	reqCtx.Request.Header = http.Header{"X-Request-Id": {"second"}}
+	reqCtx.InitialPayload = []byte(`{"token":"second"}`)
+	reqCtx.Extensions = []byte(`{"trace":"second"}`)
+
+	assert.Equal(t, `{"room":"first"}`, string(handedOver.Variables),
+		"the subscription must keep its own request's variables, not the ones of the request that reused the pooled Context")
+	assert.Equal(t, "first", handedOver.Request.Header.Get("X-Request-Id"),
+		"the subscription must keep its own request's headers, not the ones of the request that reused the pooled Context")
+	assert.Equal(t, `{"token":"first"}`, string(handedOver.InitialPayload),
+		"the subscription must keep its own connection init payload, not the one of the request that reused the pooled Context")
+	assert.Equal(t, `{"trace":"first"}`, string(handedOver.Extensions),
+		"the subscription must keep its own request's extensions, not the ones of the request that reused the pooled Context")
+}
+
+// TestAsyncResolveGraphQLSubscriptionKeepsRequestContextAfterCallerFree guards against the
+// subscription losing its request context.Context when the caller frees the pooled Context.
+// Free() nils it, and handleAddSubscription later builds the trigger's context from it -
+// a nil parent there detaches the subscription from the request it was started for.
+func TestAsyncResolveGraphQLSubscriptionKeepsRequestContextAfterCallerFree(t *testing.T) {
+	resolver := resolverWithoutEventLoop()
+
+	requestContext := context.WithValue(context.Background(), asyncSubscriptionContextKey{}, "first")
+	reqCtx := NewContext(requestContext)
+
+	handedOver := captureAsyncSubscriptionContext(t, resolver, reqCtx)
+	require.NotNil(t, handedOver)
+
+	reqCtx.Free()
+
+	require.NotNil(t, handedOver.Context(), "the subscription must keep the request context it was started with")
+	assert.Equal(t, "first", handedOver.Context().Value(asyncSubscriptionContextKey{}))
+}
+
+// TestContextCloneCopiesInitialPayloadAndExtensions guards against clone() sharing the original's
+// InitialPayload/Extensions buffers - a clone handed to a long running subscription would then
+// change underneath it whenever the original is reused.
+func TestContextCloneCopiesInitialPayloadAndExtensions(t *testing.T) {
+	ctx := NewContext(context.Background())
+	ctx.InitialPayload = []byte(`{"token":"current"}`)
+	ctx.Extensions = []byte(`{"trace":"current"}`)
+
+	clone := ctx.clone(context.Background())
+
+	// Overwritten in place: a clone that shares the original's backing array changes with it.
+	copy(ctx.InitialPayload, []byte(`{"token":"changed"}`))
+	copy(ctx.Extensions, []byte(`{"trace":"changed"}`))
+
+	assert.Equal(t, `{"token":"current"}`, string(clone.InitialPayload), "clone() must copy InitialPayload, not share it")
+	assert.Equal(t, `{"trace":"current"}`, string(clone.Extensions), "clone() must copy Extensions, not share it")
+}
+
+// TestContextFreeClearsInitialPayload guards against a pooled Context leaking one request's
+// connection init payload into the next request that reuses it.
+func TestContextFreeClearsInitialPayload(t *testing.T) {
+	ctx := NewContext(context.Background())
+	ctx.InitialPayload = []byte(`{"token":"stale"}`)
+
+	ctx.Free()
+
+	assert.Nil(t, ctx.InitialPayload, "Context.Free() must clear InitialPayload so a reused Context doesn't leak it into an unrelated later request")
+}

--- a/v2/pkg/engine/resolve/authorization_test.go
+++ b/v2/pkg/engine/resolve/authorization_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
 	"sync/atomic"
 	"testing"
 
@@ -55,6 +56,99 @@ func TestAuthorization(t *testing.T) {
 			func(t *testing.T) {
 				assert.Equal(t, int64(2), authorizer.(*testAuthorizer).preFetchCalls.Load())
 				assert.Equal(t, int64(4), authorizer.(*testAuthorizer).objectFieldCalls.Load())
+			}
+	}))
+	t.Run("authorizer receives request-finalized headers", testFnWithPostEvaluation(func(t *testing.T, ctrl *gomock.Controller) (node *GraphQLResponse, ctx Context, expectedOutput string, postEvaluation func(t *testing.T)) {
+		var checked atomic.Int64
+		authorizer := createTestAuthorizer(func(_ *Context, _ string, input json.RawMessage, _ GraphCoordinate) (*AuthorizationDeny, error) {
+			var descriptor struct {
+				Header http.Header `json:"header"`
+			}
+			if err := json.Unmarshal(input, &descriptor); err != nil {
+				t.Errorf("json.Unmarshal(authorizer input %s): %v", input, err)
+				return nil, nil
+			}
+			if got := descriptor.Header.Get("Authorization"); got != "Bearer current" {
+				t.Errorf("AuthorizePreFetch input Authorization = %q, want %q", got, "Bearer current")
+			}
+			checked.Add(1)
+			return nil, nil
+		}, func(_ *Context, _ string, _ json.RawMessage, _ GraphCoordinate) (*AuthorizationDeny, error) {
+			return nil, nil
+		})
+
+		userService := NewMockDataSource(ctrl)
+		userService.EXPECT().
+			Load(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&bytes.Buffer{})).
+			DoAndReturn(func(ctx context.Context, input []byte, w *bytes.Buffer) (err error) {
+				pair := NewBufPair()
+				pair.Data.WriteString(`{"me":{"id":"1234","username":"Me","__typename": "User"}}`)
+				return writeGraphqlResponse(pair, w, false)
+			}).AnyTimes()
+
+		res := &GraphQLResponse{
+			Data: &Object{
+				Fetch: &SingleFetch{
+					InputTemplate: InputTemplate{
+						Segments: []TemplateSegment{
+							{
+								Data:        []byte(`{"method":"POST","url":"http://localhost:4001","header":{"Authorization":["placeholder"]},"body":{"query":"{me {id username}}"}}`),
+								SegmentType: StaticSegmentType,
+							},
+						},
+					},
+					FetchConfiguration: FetchConfiguration{
+						DataSource: userService,
+						PostProcessing: PostProcessingConfiguration{
+							SelectResponseDataPath: []string{"data"},
+						},
+					},
+					Info: &FetchInfo{
+						DataSourceID: "users",
+						RootFields: []GraphCoordinate{
+							{
+								TypeName:             "Query",
+								FieldName:            "me",
+								HasAuthorizationRule: true,
+							},
+						},
+					},
+				},
+				Fields: []*Field{
+					{
+						Name: []byte("me"),
+						Value: &Object{
+							Path:     []string{"me"},
+							Nullable: true,
+							Fields: []*Field{
+								{
+									Name:  []byte("id"),
+									Value: &String{Path: []string{"id"}},
+								},
+								{
+									Name:  []byte("username"),
+									Value: &String{Path: []string{"username"}},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		ctx = Context{
+			ctx:        context.Background(),
+			authorizer: authorizer,
+			HeaderModifier: func(header http.Header) {
+				header.Set("Authorization", "Bearer current")
+			},
+		}
+		return res, ctx,
+			`{"data":{"me":{"id":"1234","username":"Me"}}}`,
+			func(t *testing.T) {
+				if got := checked.Load(); got != 1 {
+					t.Errorf("AuthorizePreFetch finalized-header checks = %d, want 1", got)
+				}
 			}
 	}))
 	t.Run("validate authorizer args", testFnWithPostEvaluation(func(t *testing.T, ctrl *gomock.Controller) (node *GraphQLResponse, ctx Context, expectedOutput string, postEvaluation func(t *testing.T)) {

--- a/v2/pkg/engine/resolve/context.go
+++ b/v2/pkg/engine/resolve/context.go
@@ -23,6 +23,9 @@ type Context struct {
 	authorizer Authorizer
 
 	subgraphErrors error
+
+	UpstreamHeaders http.Header
+	HeaderModifier  func(http.Header)
 }
 
 type AuthorizationDeny struct {

--- a/v2/pkg/engine/resolve/context.go
+++ b/v2/pkg/engine/resolve/context.go
@@ -111,6 +111,7 @@ func (c *Context) clone(ctx context.Context) *Context {
 	cpy.Variables = append([]byte(nil), c.Variables...)
 	cpy.Request.Header = c.Request.Header.Clone()
 	cpy.RenameTypeNames = append([]RenameTypeName(nil), c.RenameTypeNames...)
+	cpy.UpstreamHeaders = c.UpstreamHeaders.Clone()
 	return &cpy
 }
 
@@ -124,6 +125,8 @@ func (c *Context) Free() {
 	c.Stats.Reset()
 	c.subgraphErrors = nil
 	c.authorizer = nil
+	c.UpstreamHeaders = nil
+	c.HeaderModifier = nil
 }
 
 type traceStartKey struct{}

--- a/v2/pkg/engine/resolve/context.go
+++ b/v2/pkg/engine/resolve/context.go
@@ -111,6 +111,8 @@ func (c *Context) clone(ctx context.Context) *Context {
 	cpy.Variables = append([]byte(nil), c.Variables...)
 	cpy.Request.Header = c.Request.Header.Clone()
 	cpy.RenameTypeNames = append([]RenameTypeName(nil), c.RenameTypeNames...)
+	cpy.InitialPayload = append([]byte(nil), c.InitialPayload...)
+	cpy.Extensions = append([]byte(nil), c.Extensions...)
 	cpy.UpstreamHeaders = c.UpstreamHeaders.Clone()
 	return &cpy
 }
@@ -120,6 +122,7 @@ func (c *Context) Free() {
 	c.Variables = nil
 	c.Request.Header = nil
 	c.RenameTypeNames = nil
+	c.InitialPayload = nil
 	c.RequestTracingOptions.DisableAll()
 	c.Extensions = nil
 	c.Stats.Reset()

--- a/v2/pkg/engine/resolve/fetch.go
+++ b/v2/pkg/engine/resolve/fetch.go
@@ -34,8 +34,11 @@ type SingleFetch struct {
 	DependsOnFetchIDs    []int
 	InputTemplate        InputTemplate
 	DataSourceIdentifier []byte
-	Trace                *DataSourceLoadTrace
-	Info                 *FetchInfo
+	// Deprecated: a fetch is part of the plan, which is shared between all concurrent requests
+	// that resolve the same operation, so the trace of a single request must not be stored here.
+	// Resolving records it per request instead; this field is no longer written to.
+	Trace *DataSourceLoadTrace
+	Info  *FetchInfo
 }
 
 type PostProcessingConfiguration struct {
@@ -68,7 +71,10 @@ func (_ *SingleFetch) FetchKind() FetchKind {
 // should be used only for object fields which could be fetched parallel
 type ParallelFetch struct {
 	Fetches []Fetch
-	Trace   *DataSourceLoadTrace
+	// Deprecated: a fetch is part of the plan, which is shared between all concurrent requests
+	// that resolve the same operation, so the trace of a single request must not be stored here.
+	// Resolving records it per request instead; this field is no longer written to.
+	Trace *DataSourceLoadTrace
 }
 
 func (_ *ParallelFetch) FetchKind() FetchKind {
@@ -79,7 +85,10 @@ func (_ *ParallelFetch) FetchKind() FetchKind {
 // should be used only for object fields which should be fetched serial
 type SerialFetch struct {
 	Fetches []Fetch
-	Trace   *DataSourceLoadTrace
+	// Deprecated: a fetch is part of the plan, which is shared between all concurrent requests
+	// that resolve the same operation, so the trace of a single request must not be stored here.
+	// Resolving records it per request instead; this field is no longer written to.
+	Trace *DataSourceLoadTrace
 }
 
 func (_ *SerialFetch) FetchKind() FetchKind {
@@ -93,8 +102,11 @@ type BatchEntityFetch struct {
 	DataSource           DataSource
 	PostProcessing       PostProcessingConfiguration
 	DataSourceIdentifier []byte
-	Trace                *DataSourceLoadTrace
-	Info                 *FetchInfo
+	// Deprecated: a fetch is part of the plan, which is shared between all concurrent requests
+	// that resolve the same operation, so the trace of a single request must not be stored here.
+	// Resolving records it per request instead; this field is no longer written to.
+	Trace *DataSourceLoadTrace
+	Info  *FetchInfo
 }
 
 type BatchInput struct {
@@ -121,8 +133,11 @@ type EntityFetch struct {
 	DataSource           DataSource
 	PostProcessing       PostProcessingConfiguration
 	DataSourceIdentifier []byte
-	Trace                *DataSourceLoadTrace
-	Info                 *FetchInfo
+	// Deprecated: a fetch is part of the plan, which is shared between all concurrent requests
+	// that resolve the same operation, so the trace of a single request must not be stored here.
+	// Resolving records it per request instead; this field is no longer written to.
+	Trace *DataSourceLoadTrace
+	Info  *FetchInfo
 }
 
 type EntityInput struct {
@@ -140,9 +155,14 @@ func (_ *EntityFetch) FetchKind() FetchKind {
 // Usually, you want to batch fetches within a list, which is the default behavior of SingleFetch
 // However, if the data source does not support batching, you can use this fetch to make parallel fetches within a list
 type ParallelListItemFetch struct {
-	Fetch  *SingleFetch
+	Fetch *SingleFetch
+	// Deprecated: the per-item copies belong to a single request, not to the shared plan.
+	// Resolving records them per request instead; this field is no longer written to.
 	Traces []*SingleFetch
-	Trace  *DataSourceLoadTrace
+	// Deprecated: a fetch is part of the plan, which is shared between all concurrent requests
+	// that resolve the same operation, so the trace of a single request must not be stored here.
+	// Resolving records it per request instead; this field is no longer written to.
+	Trace *DataSourceLoadTrace
 }
 
 func (_ *ParallelListItemFetch) FetchKind() FetchKind {

--- a/v2/pkg/engine/resolve/loader.go
+++ b/v2/pkg/engine/resolve/loader.go
@@ -31,9 +31,11 @@ type Loader struct {
 	path         []string
 	traceOptions RequestTraceOptions
 	info         *GraphQLResponseInfo
+	traces       *fetchTraces
 }
 
 func (l *Loader) Free() {
+	l.traces = nil
 	l.info = nil
 	l.ctx = nil
 	l.data = nil
@@ -48,7 +50,8 @@ func (l *Loader) LoadGraphQLResponseData(ctx *Context, response *GraphQLResponse
 	l.errorsRoot = resolvable.errorsRoot
 	l.traceOptions = resolvable.requestTraceOptions
 	l.ctx = ctx
-	l.info = response.Info
+	l.info = response.info()
+	l.traces = &resolvable.fetchTraces
 	return l.walkNode(response.Data, []int{resolvable.dataRoot})
 }
 
@@ -189,9 +192,9 @@ func (l *Loader) resolveAndMergeFetch(fetch Fetch, items []int) error {
 		return l.mergeResult(res, items)
 	case *SerialFetch:
 		if l.traceOptions.Enable {
-			f.Trace = &DataSourceLoadTrace{
+			l.traces.setLoad(f, &DataSourceLoadTrace{
 				Path: l.renderPath(),
-			}
+			})
 		}
 		for i := range f.Fetches {
 			err := l.resolveAndMergeFetch(f.Fetches[i], items)
@@ -201,9 +204,9 @@ func (l *Loader) resolveAndMergeFetch(fetch Fetch, items []int) error {
 		}
 	case *ParallelFetch:
 		if l.traceOptions.Enable {
-			f.Trace = &DataSourceLoadTrace{
+			l.traces.setLoad(f, &DataSourceLoadTrace{
 				Path: l.renderPath(),
-			}
+			})
 		}
 		results := make([]*result, len(f.Fetches))
 		g, ctx := errgroup.WithContext(l.ctx.ctx)
@@ -235,9 +238,9 @@ func (l *Loader) resolveAndMergeFetch(fetch Fetch, items []int) error {
 		}
 	case *ParallelListItemFetch:
 		if l.traceOptions.Enable {
-			f.Trace = &DataSourceLoadTrace{
+			l.traces.setLoad(f, &DataSourceLoadTrace{
 				Path: l.renderPath(),
-			}
+			})
 		}
 		results := make([]*result, len(items))
 		g, ctx := errgroup.WithContext(l.ctx.ctx)
@@ -293,8 +296,10 @@ func (l *Loader) loadFetch(ctx context.Context, fetch Fetch, items []int, res *r
 		return fmt.Errorf("parallel fetch must not be nested")
 	case *ParallelListItemFetch:
 		results := make([]*result, len(items))
+		var itemFetches []*SingleFetch
 		if l.traceOptions.Enable {
-			f.Traces = make([]*SingleFetch, len(items))
+			itemFetches = make([]*SingleFetch, len(items))
+			l.traces.setListItemFetches(f, itemFetches)
 		}
 		g, ctx := errgroup.WithContext(l.ctx.ctx)
 		for i := range items {
@@ -303,10 +308,10 @@ func (l *Loader) loadFetch(ctx context.Context, fetch Fetch, items []int, res *r
 				out: pool.BytesBuffer.Get(),
 			}
 			if l.traceOptions.Enable {
-				f.Traces[i] = new(SingleFetch)
-				*f.Traces[i] = *f.Fetch
+				itemFetches[i] = new(SingleFetch)
+				*itemFetches[i] = *f.Fetch
 				g.Go(func() error {
-					return l.loadFetch(ctx, f.Traces[i], items[i:i+1], results[i])
+					return l.loadFetch(ctx, itemFetches[i], items[i:i+1], results[i])
 				})
 				continue
 			}
@@ -604,12 +609,14 @@ func (l *Loader) loadSingleFetch(ctx context.Context, fetch *SingleFetch, items 
 	if err != nil {
 		return errors.WithStack(err)
 	}
+	var trace *DataSourceLoadTrace
 	if l.traceOptions.Enable {
-		fetch.Trace = &DataSourceLoadTrace{}
+		trace = &DataSourceLoadTrace{}
+		l.traces.setLoad(fetch, trace)
 		if !l.traceOptions.ExcludeRawInputData {
 			inputCopy := make([]byte, input.Len())
 			copy(inputCopy, input.Bytes())
-			fetch.Trace.RawInputData = inputCopy
+			trace.RawInputData = inputCopy
 		}
 	}
 	err = fetch.InputTemplate.Render(l.ctx, input.Bytes(), preparedInput)
@@ -628,7 +635,7 @@ func (l *Loader) loadSingleFetch(ctx context.Context, fetch *SingleFetch, items 
 	if !authorized {
 		return nil
 	}
-	res.err = l.executeSourceLoad(ctx, fetch.DataSource, fetchInput, res.out, fetch.Trace)
+	res.err = l.executeSourceLoad(ctx, fetch.DataSource, fetchInput, res.out, trace)
 	return nil
 }
 
@@ -645,12 +652,14 @@ func (l *Loader) loadEntityFetch(ctx context.Context, fetch *EntityFetch, items 
 		return errors.WithStack(err)
 	}
 
+	var trace *DataSourceLoadTrace
 	if l.traceOptions.Enable {
-		fetch.Trace = &DataSourceLoadTrace{}
+		trace = &DataSourceLoadTrace{}
+		l.traces.setLoad(fetch, trace)
 		if !l.traceOptions.ExcludeRawInputData {
 			itemDataCopy := make([]byte, itemData.Len())
 			copy(itemDataCopy, itemData.Bytes())
-			fetch.Trace.RawInputData = itemDataCopy
+			trace.RawInputData = itemDataCopy
 		}
 	}
 
@@ -667,7 +676,7 @@ func (l *Loader) loadEntityFetch(ctx context.Context, fetch *EntityFetch, items 
 			err = nil // nolint:ineffassign
 			// skip fetch on render item error
 			if l.traceOptions.Enable {
-				fetch.Trace.LoadSkipped = true
+				trace.LoadSkipped = true
 			}
 			return nil
 		}
@@ -678,7 +687,7 @@ func (l *Loader) loadEntityFetch(ctx context.Context, fetch *EntityFetch, items 
 		// skip fetch if item is null
 		res.fetchSkipped = true
 		if l.traceOptions.Enable {
-			fetch.Trace.LoadSkipped = true
+			trace.LoadSkipped = true
 		}
 		return nil
 	}
@@ -686,7 +695,7 @@ func (l *Loader) loadEntityFetch(ctx context.Context, fetch *EntityFetch, items 
 		// skip fetch if item is empty
 		res.fetchSkipped = true
 		if l.traceOptions.Enable {
-			fetch.Trace.LoadSkipped = true
+			trace.LoadSkipped = true
 		}
 		return nil
 	}
@@ -712,22 +721,24 @@ func (l *Loader) loadEntityFetch(ctx context.Context, fetch *EntityFetch, items 
 	if !authorized {
 		return nil
 	}
-	res.err = l.executeSourceLoad(ctx, fetch.DataSource, fetchInput, res.out, fetch.Trace)
+	res.err = l.executeSourceLoad(ctx, fetch.DataSource, fetchInput, res.out, trace)
 	return nil
 }
 
 func (l *Loader) loadBatchEntityFetch(ctx context.Context, fetch *BatchEntityFetch, items []int, res *result) error {
 	res.init(fetch.PostProcessing, fetch.Info)
 
+	var trace *DataSourceLoadTrace
 	if l.traceOptions.Enable {
-		fetch.Trace = &DataSourceLoadTrace{}
+		trace = &DataSourceLoadTrace{}
+		l.traces.setLoad(fetch, trace)
 		if !l.traceOptions.ExcludeRawInputData {
 			buf := &bytes.Buffer{}
 			err := l.itemsData(items, buf)
 			if err != nil {
 				return errors.WithStack(err)
 			}
-			fetch.Trace.RawInputData = buf.Bytes()
+			trace.RawInputData = buf.Bytes()
 		}
 	}
 
@@ -771,7 +782,7 @@ WithNextItem:
 					continue
 				}
 				if l.traceOptions.Enable {
-					fetch.Trace.LoadSkipped = true
+					trace.LoadSkipped = true
 				}
 				return errors.WithStack(err)
 			}
@@ -811,7 +822,7 @@ WithNextItem:
 		// all items were skipped - discard fetch
 		res.fetchSkipped = true
 		if l.traceOptions.Enable {
-			fetch.Trace.LoadSkipped = true
+			trace.LoadSkipped = true
 		}
 		return nil
 	}
@@ -837,7 +848,7 @@ WithNextItem:
 	if !authorized {
 		return nil
 	}
-	res.err = l.executeSourceLoad(ctx, fetch.DataSource, fetchInput, res.out, fetch.Trace)
+	res.err = l.executeSourceLoad(ctx, fetch.DataSource, fetchInput, res.out, trace)
 	return nil
 }
 

--- a/v2/pkg/engine/resolve/loader.go
+++ b/v2/pkg/engine/resolve/loader.go
@@ -18,8 +18,8 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/TykTechnologies/graphql-go-tools/v2/pkg/ast"
-	"github.com/TykTechnologies/graphql-go-tools/v2/pkg/engine/datasource/httpclient"
 	"github.com/TykTechnologies/graphql-go-tools/v2/pkg/astjson"
+	"github.com/TykTechnologies/graphql-go-tools/v2/pkg/engine/datasource/httpclient"
 	"github.com/TykTechnologies/graphql-go-tools/v2/pkg/pool"
 )
 
@@ -617,6 +617,10 @@ func (l *Loader) loadSingleFetch(ctx context.Context, fetch *SingleFetch, items 
 		return l.renderErrorsInvalidInput(res.out)
 	}
 	fetchInput := preparedInput.Bytes()
+	fetchInput, err = l.finalizeInput(fetchInput)
+	if err != nil {
+		return errors.WithStack(err)
+	}
 	authorized, err := l.isFetchAuthorized(fetchInput, fetch.Info, res)
 	if err != nil {
 		return errors.WithStack(err)
@@ -697,6 +701,10 @@ func (l *Loader) loadEntityFetch(ctx context.Context, fetch *EntityFetch, items 
 		return errors.WithStack(err)
 	}
 	fetchInput := preparedInput.Bytes()
+	fetchInput, err = l.finalizeInput(fetchInput)
+	if err != nil {
+		return errors.WithStack(err)
+	}
 	authorized, err := l.isFetchAuthorized(fetchInput, fetch.Info, res)
 	if err != nil {
 		return errors.WithStack(err)
@@ -818,6 +826,10 @@ WithNextItem:
 		return errors.WithStack(err)
 	}
 	fetchInput := preparedInput.Bytes()
+	fetchInput, err = l.finalizeInput(fetchInput)
+	if err != nil {
+		return errors.WithStack(err)
+	}
 	authorized, err := l.isFetchAuthorized(fetchInput, fetch.Info, res)
 	if err != nil {
 		return errors.WithStack(err)
@@ -892,12 +904,6 @@ func setSingleFlightStats(ctx context.Context, stats *SingleFlightStats) context
 }
 
 func (l *Loader) executeSourceLoad(ctx context.Context, source DataSource, input []byte, out *bytes.Buffer, trace *DataSourceLoadTrace) (err error) {
-	if l.ctx.Extensions != nil {
-		input, err = jsonparser.Set(input, l.ctx.Extensions, "body", "extensions")
-		if err != nil {
-			return errors.WithStack(err)
-		}
-	}
 	if l.traceOptions.Enable {
 		ctx = setSingleFlightStats(ctx, &SingleFlightStats{})
 		trace.Path = l.renderPath()
@@ -1006,13 +1012,6 @@ func (l *Loader) executeSourceLoad(ctx context.Context, source DataSource, input
 		ctx = context.WithValue(ctx, disallowSingleFlightContextKey{}, true)
 	}
 
-	if l.ctx.HeaderModifier != nil {
-		input = httpclient.ApplyHeaderModifier(input, l.ctx.HeaderModifier)
-	}
-	if len(l.ctx.UpstreamHeaders) > 0 {
-		input = httpclient.MergeInputHeader(input, l.ctx.UpstreamHeaders)
-	}
-
 	err = source.Load(ctx, input, out)
 	if l.traceOptions.Enable {
 		stats := GetSingleFlightStats(ctx)
@@ -1048,4 +1047,15 @@ func (l *Loader) executeSourceLoad(ctx context.Context, source DataSource, input
 	l.ctx.Stats.NumberOfFetches.Inc()
 	l.ctx.Stats.CombinedResponseSize.Add(int64(out.Len()))
 	return nil
+}
+
+func (l *Loader) finalizeInput(input []byte) ([]byte, error) {
+	var err error
+	if l.ctx.Extensions != nil {
+		input, err = jsonparser.Set(input, l.ctx.Extensions, "body", "extensions")
+		if err != nil {
+			return nil, err
+		}
+	}
+	return httpclient.FinalizeInputHeaders(input, l.ctx.HeaderModifier, l.ctx.UpstreamHeaders)
 }

--- a/v2/pkg/engine/resolve/loader.go
+++ b/v2/pkg/engine/resolve/loader.go
@@ -18,6 +18,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/TykTechnologies/graphql-go-tools/v2/pkg/ast"
+	"github.com/TykTechnologies/graphql-go-tools/v2/pkg/engine/datasource/httpclient"
 	"github.com/TykTechnologies/graphql-go-tools/v2/pkg/astjson"
 	"github.com/TykTechnologies/graphql-go-tools/v2/pkg/pool"
 )
@@ -1004,6 +1005,14 @@ func (l *Loader) executeSourceLoad(ctx context.Context, source DataSource, input
 	if l.info != nil && l.info.OperationType == ast.OperationTypeMutation {
 		ctx = context.WithValue(ctx, disallowSingleFlightContextKey{}, true)
 	}
+
+	if l.ctx.HeaderModifier != nil {
+		input = httpclient.ApplyHeaderModifier(input, l.ctx.HeaderModifier)
+	}
+	if len(l.ctx.UpstreamHeaders) > 0 {
+		input = httpclient.MergeInputHeader(input, l.ctx.UpstreamHeaders)
+	}
+
 	err = source.Load(ctx, input, out)
 	if l.traceOptions.Enable {
 		stats := GetSingleFlightStats(ctx)

--- a/v2/pkg/engine/resolve/loader_test.go
+++ b/v2/pkg/engine/resolve/loader_test.go
@@ -4,11 +4,14 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"testing"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/TykTechnologies/graphql-go-tools/v2/pkg/ast"
 	"github.com/TykTechnologies/graphql-go-tools/v2/pkg/astjson"
@@ -978,7 +981,11 @@ func TestLoader_RedactHeaders(t *testing.T) {
 	switch f := fetch.(type) {
 	case *SingleFetch:
 		{
-			_ = json.Unmarshal(f.Trace.Input, &input)
+			// The trace belongs to this request, not to the plan the fetch is part of.
+			trace := resolvable.fetchTraces.load(f)
+			require.NotNil(t, trace)
+
+			_ = json.Unmarshal(trace.Input, &input)
 			authHeader := input.Header["Authorization"]
 			assert.Equal(t, []string{"****"}, authHeader)
 		}
@@ -987,4 +994,56 @@ func TestLoader_RedactHeaders(t *testing.T) {
 			t.Errorf("Incorrect fetch type")
 		}
 	}
+}
+
+// TestLoader_ResponseInfoDefault pins what the loader makes of a response that carries no Info.
+// ResolveGraphQLResponse used to fill one in on the plan before calling the loader, so the loader
+// always found one; nothing does that for a subscription update, whose response is loaded directly.
+func TestLoader_ResponseInfoDefault(t *testing.T) {
+	loadFailingFetch := func(t *testing.T, info *GraphQLResponseInfo) *Context {
+		t.Helper()
+
+		ctrl := gomock.NewController(t)
+		failingDataSource := NewMockDataSource(ctrl)
+		failingDataSource.EXPECT().
+			Load(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&bytes.Buffer{})).
+			DoAndReturn(func(ctx context.Context, input []byte, w io.Writer) error {
+				return errors.New("upstream is down")
+			})
+
+		response := &GraphQLResponse{
+			Info: info,
+			Data: &Object{
+				Nullable: true,
+				Fetch: &SingleFetch{
+					FetchConfiguration: FetchConfiguration{
+						DataSource: failingDataSource,
+						PostProcessing: PostProcessingConfiguration{
+							SelectResponseErrorsPath: []string{"errors"},
+						},
+					},
+					Info: &FetchInfo{DataSourceID: "Users"},
+				},
+			},
+		}
+
+		ctx := &Context{ctx: context.Background()}
+		resolvable := NewResolvable()
+		loader := &Loader{}
+
+		require.NoError(t, resolvable.Init(ctx, nil, ast.OperationTypeQuery))
+		require.NoError(t, loader.LoadGraphQLResponseData(ctx, response, resolvable))
+		require.Error(t, ctx.SubgraphErrors())
+		return ctx
+	}
+
+	t.Run("should read a response without info as a query", func(t *testing.T) {
+		ctx := loadFailingFetch(t, nil)
+		assert.Contains(t, ctx.SubgraphErrors().Error(), "at path 'query'")
+	})
+
+	t.Run("should read the operation type the response carries", func(t *testing.T) {
+		ctx := loadFailingFetch(t, &GraphQLResponseInfo{OperationType: ast.OperationTypeMutation})
+		assert.Contains(t, ctx.SubgraphErrors().Error(), "at path 'mutation'")
+	})
 }

--- a/v2/pkg/engine/resolve/request_headers_test.go
+++ b/v2/pkg/engine/resolve/request_headers_test.go
@@ -1,0 +1,46 @@
+package resolve
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestContextFreeClearsRequestHeaderOptions guards against a pooled Context
+// leaking one request's UpstreamHeaders/HeaderModifier into the next request
+// that reuses it after Free().
+func TestContextFreeClearsRequestHeaderOptions(t *testing.T) {
+	ctx := NewContext(context.Background())
+	ctx.UpstreamHeaders = http.Header{"Authorization": {"Bearer stale"}}
+	ctx.HeaderModifier = func(http.Header) {}
+
+	ctx.Free()
+
+	assert.Nil(t, ctx.UpstreamHeaders, "Context.Free() must clear UpstreamHeaders so a reused Context doesn't leak it into an unrelated later request")
+	assert.Nil(t, ctx.HeaderModifier, "Context.Free() must clear HeaderModifier so a reused Context doesn't leak it into an unrelated later request")
+}
+
+// TestContextCloneIsolatesRequestHeaderOptions guards against clone() sharing
+// the same underlying UpstreamHeaders map as the original - that would let
+// unrelated concurrent work on the original Context (or the original's later
+// reuse) affect a clone that should be independent.
+func TestContextCloneIsolatesRequestHeaderOptions(t *testing.T) {
+	ctx := NewContext(context.Background())
+	ctx.UpstreamHeaders = http.Header{"Authorization": {"Bearer current"}}
+	ctx.HeaderModifier = func(header http.Header) { header.Set("X-Caller", "current") }
+
+	clone := ctx.clone(context.Background())
+
+	require.NotNil(t, clone.HeaderModifier, "clone() must preserve HeaderModifier, not drop it")
+	require.NotNil(t, clone.UpstreamHeaders, "clone() must preserve UpstreamHeaders, not drop it")
+
+	// Mutating the original's map after cloning must not affect the clone -
+	// otherwise a cloned Context used for independent field resolution could
+	// be changed by unrelated work still using the original.
+	ctx.UpstreamHeaders.Set("Authorization", "Bearer changed")
+
+	assert.Equal(t, "Bearer current", clone.UpstreamHeaders.Get("Authorization"))
+}

--- a/v2/pkg/engine/resolve/resolvable.go
+++ b/v2/pkg/engine/resolve/resolvable.go
@@ -38,6 +38,10 @@ type Resolvable struct {
 
 	authorizationBuf          *bytes.Buffer
 	authorizationBufObjectRef int
+
+	// fetchTraces holds this request's fetch traces. They used to be written onto the fetches of
+	// the plan, which every concurrent request resolving the same operation shares.
+	fetchTraces fetchTraces
 }
 
 func NewResolvable() *Resolvable {
@@ -70,6 +74,7 @@ func (r *Resolvable) Reset() {
 	for k := range r.authorizationDeny {
 		delete(r.authorizationDeny, k)
 	}
+	r.fetchTraces.reset()
 }
 
 func (r *Resolvable) Init(ctx *Context, initialData []byte, operationType ast.OperationType) (err error) {
@@ -203,7 +208,7 @@ func (r *Resolvable) printExtensions(ctx context.Context, root *Object) {
 }
 
 func (r *Resolvable) printTrace(ctx context.Context, root *Object) {
-	trace := GetTrace(ctx, root)
+	trace := getTrace(ctx, root, &r.fetchTraces)
 
 	traceData, err := json.Marshal(trace)
 	if err != nil {

--- a/v2/pkg/engine/resolve/resolve.go
+++ b/v2/pkg/engine/resolve/resolve.go
@@ -17,7 +17,6 @@ import (
 	"go.uber.org/atomic"
 
 	"github.com/TykTechnologies/graphql-go-tools/v2/internal/pkg/xcontext"
-	"github.com/TykTechnologies/graphql-go-tools/v2/pkg/ast"
 	"github.com/TykTechnologies/graphql-go-tools/v2/pkg/engine/datasource/httpclient"
 	"github.com/TykTechnologies/graphql-go-tools/v2/pkg/pool"
 )
@@ -121,16 +120,10 @@ func (r *Resolver) putTools(t *tools) {
 }
 
 func (r *Resolver) ResolveGraphQLResponse(ctx *Context, response *GraphQLResponse, data []byte, writer io.Writer) (err error) {
-	if response.Info == nil {
-		response.Info = &GraphQLResponseInfo{
-			OperationType: ast.OperationTypeQuery,
-		}
-	}
-
 	t := r.getTools()
 	defer r.putTools(t)
 
-	err = t.resolvable.Init(ctx, data, response.Info.OperationType)
+	err = t.resolvable.Init(ctx, data, response.info().OperationType)
 	if err != nil {
 		return err
 	}

--- a/v2/pkg/engine/resolve/resolve.go
+++ b/v2/pkg/engine/resolve/resolve.go
@@ -531,13 +531,7 @@ func (r *Resolver) subscriptionInput(ctx *Context, subscription *GraphQLSubscrip
 			return nil, err
 		}
 	}
-	if ctx.HeaderModifier != nil {
-		input = httpclient.ApplyHeaderModifier(input, ctx.HeaderModifier)
-	}
-	if len(ctx.UpstreamHeaders) > 0 {
-		input = httpclient.MergeInputHeader(input, ctx.UpstreamHeaders)
-	}
-	return input, nil
+	return httpclient.FinalizeInputHeaders(input, ctx.HeaderModifier, ctx.UpstreamHeaders)
 }
 
 type subscriptionUpdater struct {

--- a/v2/pkg/engine/resolve/resolve.go
+++ b/v2/pkg/engine/resolve/resolve.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"reflect"
 	"sync"
 	"time"
 
@@ -144,6 +145,8 @@ func (r *Resolver) ResolveGraphQLResponse(ctx *Context, response *GraphQLRespons
 
 type trigger struct {
 	id            uint64
+	input         string
+	source        SubscriptionDataSource
 	cancel        context.CancelFunc
 	subscriptions map[*Context]*sub
 	inFlight      *sync.WaitGroup
@@ -261,10 +264,17 @@ func (r *Resolver) handleAddSubscription(triggerID uint64, add *addSubscription)
 		writer:  add.writer,
 		id:      add.id,
 	}
-	trig, ok := r.triggers[triggerID]
-	if ok {
-		trig.subscriptions[add.ctx] = s
-		return
+	input := string(add.input)
+	for {
+		trig, ok := r.triggers[triggerID]
+		if !ok {
+			break
+		}
+		if trig.input == input && sameSubscriptionSource(trig.source, add.resolve.Trigger.Source) {
+			trig.subscriptions[add.ctx] = s
+			return
+		}
+		triggerID++
 	}
 	if r.options.Debug {
 		fmt.Printf("resolver:create:trigger:%d\n", triggerID)
@@ -276,8 +286,10 @@ func (r *Resolver) handleAddSubscription(triggerID uint64, add *addSubscription)
 		ctx:       ctx,
 	}
 	clone := add.ctx.clone(ctx)
-	trig = &trigger{
+	trig := &trigger{
 		id:            triggerID,
+		input:         input,
+		source:        add.resolve.Trigger.Source,
 		subscriptions: make(map[*Context]*sub),
 		cancel:        cancel,
 	}
@@ -287,6 +299,17 @@ func (r *Resolver) handleAddSubscription(triggerID uint64, add *addSubscription)
 	if err != nil {
 		cancel()
 	}
+}
+
+func sameSubscriptionSource(left, right SubscriptionDataSource) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	leftType := reflect.TypeOf(left)
+	if leftType != reflect.TypeOf(right) || !leftType.Comparable() {
+		return false
+	}
+	return left == right
 }
 
 func (r *Resolver) handleRemoveSubscription(id SubscriptionIdentifier) {

--- a/v2/pkg/engine/resolve/resolve.go
+++ b/v2/pkg/engine/resolve/resolve.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/TykTechnologies/graphql-go-tools/v2/internal/pkg/xcontext"
 	"github.com/TykTechnologies/graphql-go-tools/v2/pkg/ast"
+	"github.com/TykTechnologies/graphql-go-tools/v2/pkg/engine/datasource/httpclient"
 	"github.com/TykTechnologies/graphql-go-tools/v2/pkg/pool"
 )
 
@@ -529,6 +530,12 @@ func (r *Resolver) subscriptionInput(ctx *Context, subscription *GraphQLSubscrip
 		if err != nil {
 			return nil, err
 		}
+	}
+	if ctx.HeaderModifier != nil {
+		input = httpclient.ApplyHeaderModifier(input, ctx.HeaderModifier)
+	}
+	if len(ctx.UpstreamHeaders) > 0 {
+		input = httpclient.MergeInputHeader(input, ctx.UpstreamHeaders)
 	}
 	return input, nil
 }

--- a/v2/pkg/engine/resolve/resolve.go
+++ b/v2/pkg/engine/resolve/resolve.go
@@ -494,6 +494,11 @@ func (r *Resolver) AsyncResolveGraphQLSubscription(ctx *Context, subscription *G
 		return writeFlushComplete(writer, msg)
 	}
 	uniqueID := xxh.Sum64()
+	requestContext := ctx.Context()
+	if requestContext == nil {
+		requestContext = context.Background()
+	}
+	ownedContext := ctx.clone(requestContext)
 	select {
 	case <-r.ctx.Done():
 		return ErrResolverClosed
@@ -501,7 +506,7 @@ func (r *Resolver) AsyncResolveGraphQLSubscription(ctx *Context, subscription *G
 		triggerID: uniqueID,
 		kind:      subscriptionEventKindAddSubscription,
 		addSubscription: &addSubscription{
-			ctx:     ctx,
+			ctx:     ownedContext,
 			input:   input,
 			resolve: subscription,
 			writer:  writer,

--- a/v2/pkg/engine/resolve/resolve_test.go
+++ b/v2/pkg/engine/resolve/resolve_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/TykTechnologies/graphql-go-tools/v2/pkg/ast"
 	"github.com/TykTechnologies/graphql-go-tools/v2/pkg/testing/flags"
 )
 
@@ -5388,5 +5389,171 @@ func Benchmark_NestedBatchingWithoutChecks(b *testing.B) {
 			ctx.Free()
 			ctxPool.Put(ctx)
 		}
+	})
+}
+
+func TestResolver_ResolveGraphQLResponseDoesNotMutateTheResponse(t *testing.T) {
+	newResponse := func() *GraphQLResponse {
+		return &GraphQLResponse{
+			Data: &Object{
+				Nullable: true,
+			},
+		}
+	}
+
+	t.Run("should leave a missing info untouched", func(t *testing.T) {
+		resolver := newResolver(context.Background())
+		response := newResponse()
+
+		buffer := &bytes.Buffer{}
+		require.NoError(t, resolver.ResolveGraphQLResponse(&Context{ctx: context.Background()}, response, nil, buffer))
+
+		assert.Equal(t, `{"data":{}}`, buffer.String())
+		assert.Nil(t, response.Info, "a response is a cached plan, resolving it must not fill in fields")
+	})
+
+	t.Run("should keep the info the response carries", func(t *testing.T) {
+		resolver := newResolver(context.Background())
+		response := newResponse()
+		response.Info = &GraphQLResponseInfo{OperationType: ast.OperationTypeMutation}
+
+		buffer := &bytes.Buffer{}
+		require.NoError(t, resolver.ResolveGraphQLResponse(&Context{ctx: context.Background()}, response, nil, buffer))
+
+		assert.Equal(t, ast.OperationTypeMutation, response.Info.OperationType)
+	})
+
+	// A response is the cached execution plan, shared by every concurrent request that resolves the
+	// same operation. Filling in a missing field at resolve time is therefore a data race. The
+	// response is deliberately fresh here, since resolving it once up front would hide exactly that.
+	// Only reports under -race.
+	t.Run("should be safe to resolve one response concurrently", func(t *testing.T) {
+		resolver := newResolver(context.Background())
+		response := newResponse()
+
+		var waitGroup sync.WaitGroup
+		for i := 0; i < 50; i++ {
+			waitGroup.Add(1)
+			go func() {
+				defer waitGroup.Done()
+				buffer := &bytes.Buffer{}
+				assert.NoError(t, resolver.ResolveGraphQLResponse(&Context{ctx: context.Background()}, response, nil, buffer))
+				assert.Equal(t, `{"data":{}}`, buffer.String())
+			}()
+		}
+		waitGroup.Wait()
+
+		assert.Nil(t, response.Info)
+	})
+}
+
+func TestGraphQLResponse_info(t *testing.T) {
+	t.Run("should fall back to the shared default", func(t *testing.T) {
+		info := (&GraphQLResponse{}).info()
+
+		require.NotNil(t, info)
+		assert.Equal(t, ast.OperationTypeQuery, info.OperationType)
+		assert.Same(t, defaultGraphQLResponseInfo, info)
+	})
+
+	t.Run("should return the info the response carries", func(t *testing.T) {
+		carried := &GraphQLResponseInfo{OperationType: ast.OperationTypeSubscription}
+
+		assert.Same(t, carried, (&GraphQLResponse{Info: carried}).info())
+	})
+
+	// The default is shared between all responses that carry no info, so it has to stay immutable:
+	// writing through it would change the operation type of every one of them.
+	t.Run("should hand the same default to every response", func(t *testing.T) {
+		assert.Same(t, (&GraphQLResponse{}).info(), (&GraphQLResponse{}).info())
+		assert.Equal(t, ast.OperationTypeQuery, defaultGraphQLResponseInfo.OperationType)
+	})
+}
+
+// TestResolver_ResolveGraphQLResponseDoesNotMutateThePlanWhileTracing guards the same invariant as
+// the test above for request tracing: the loader used to hang each fetch's DataSourceLoadTrace off
+// the plan's fetch structs, which are shared by every concurrent request resolving that operation.
+func TestResolver_ResolveGraphQLResponseDoesNotMutateThePlanWhileTracing(t *testing.T) {
+	newPlan := func() (*GraphQLResponse, *ParallelFetch, *SingleFetch) {
+		singleFetch := &SingleFetch{
+			InputTemplate: InputTemplate{
+				Segments: []TemplateSegment{
+					{
+						Data:        []byte(`{"method":"POST","url":"http://localhost:4000"}`),
+						SegmentType: StaticSegmentType,
+					},
+				},
+			},
+			FetchConfiguration: FetchConfiguration{
+				DataSource: FakeDataSource(`{"hello":"world"}`),
+			},
+			Info: &FetchInfo{DataSourceID: "Greetings"},
+		}
+		parallelFetch := &ParallelFetch{Fetches: []Fetch{singleFetch}}
+
+		return &GraphQLResponse{
+			Data: &Object{
+				Fetch: parallelFetch,
+				Fields: []*Field{
+					{
+						Name: []byte("hello"),
+						Value: &String{
+							Path: []string{"hello"},
+						},
+					},
+				},
+			},
+		}, parallelFetch, singleFetch
+	}
+
+	tracingContext := func() *Context {
+		return &Context{
+			ctx: SetTraceStart(context.Background(), true),
+			RequestTracingOptions: RequestTraceOptions{
+				Enable:                                 true,
+				EnablePredictableDebugTimings:          true,
+				IncludeTraceOutputInResponseExtensions: true,
+			},
+		}
+	}
+
+	t.Run("should leave the plan untouched", func(t *testing.T) {
+		resolver := newResolver(context.Background())
+		response, parallelFetch, singleFetch := newPlan()
+
+		buffer := &bytes.Buffer{}
+		require.NoError(t, resolver.ResolveGraphQLResponse(tracingContext(), response, nil, buffer))
+
+		assert.Nil(t, parallelFetch.Trace, "a fetch is part of the cached plan, tracing must not write to it")
+		assert.Nil(t, singleFetch.Trace, "a fetch is part of the cached plan, tracing must not write to it")
+	})
+
+	t.Run("should still report the trace of every fetch", func(t *testing.T) {
+		resolver := newResolver(context.Background())
+		response, _, _ := newPlan()
+
+		buffer := &bytes.Buffer{}
+		require.NoError(t, resolver.ResolveGraphQLResponse(tracingContext(), response, nil, buffer))
+
+		assert.Contains(t, buffer.String(), `"data":{"hello":"world"}`)
+		assert.Contains(t, buffer.String(), `"datasource_load_trace"`)
+		assert.Contains(t, buffer.String(), `"data_source_id":"Greetings"`)
+	})
+
+	// Only reports under -race.
+	t.Run("should be safe to resolve one plan concurrently", func(t *testing.T) {
+		resolver := newResolver(context.Background())
+		response, _, _ := newPlan()
+
+		var waitGroup sync.WaitGroup
+		for i := 0; i < 50; i++ {
+			waitGroup.Add(1)
+			go func() {
+				defer waitGroup.Done()
+				buffer := &bytes.Buffer{}
+				assert.NoError(t, resolver.ResolveGraphQLResponse(tracingContext(), response, nil, buffer))
+			}()
+		}
+		waitGroup.Wait()
 	})
 }

--- a/v2/pkg/engine/resolve/response.go
+++ b/v2/pkg/engine/resolve/response.go
@@ -30,6 +30,23 @@ type GraphQLResponseInfo struct {
 	OperationType ast.OperationType
 }
 
+// defaultGraphQLResponseInfo is the info of a response that carries none. It is shared and
+// must stay immutable.
+var defaultGraphQLResponseInfo = &GraphQLResponseInfo{
+	OperationType: ast.OperationTypeQuery,
+}
+
+// info returns the info of the response, or the shared default when it has none. It never
+// writes to the response: a response is a cached plan, shared between all concurrent
+// requests that resolve the same operation, so filling in a missing field here would be a
+// data race.
+func (r *GraphQLResponse) info() *GraphQLResponseInfo {
+	if r.Info != nil {
+		return r.Info
+	}
+	return defaultGraphQLResponseInfo
+}
+
 type RenameTypeName struct {
 	From, To []byte
 }

--- a/v2/pkg/engine/resolve/subscription_trigger_grouping_test.go
+++ b/v2/pkg/engine/resolve/subscription_trigger_grouping_test.go
@@ -1,0 +1,261 @@
+package resolve
+
+import (
+	"bytes"
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cespare/xxhash/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type startedTrigger struct {
+	input   string
+	updater SubscriptionUpdater
+}
+
+// collidingSubscriptionSource is shaped like the real graphql datasource: its UniqueRequestID
+// identifies the upstream *connection* (URL, headers, ...) and never the operation, so every
+// subscription it serves gets the same trigger ID no matter which operation it carries.
+type collidingSubscriptionSource struct {
+	mu       sync.Mutex
+	started  []startedTrigger
+	messages map[string]string // rendered input -> message the upstream pushes for that operation
+}
+
+func (s *collidingSubscriptionSource) UniqueRequestID(_ *Context, _ []byte, xxh *xxhash.Digest) error {
+	_, err := xxh.WriteString("same-upstream-connection")
+	return err
+}
+
+func (s *collidingSubscriptionSource) Start(_ *Context, input []byte, updater SubscriptionUpdater) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.started = append(s.started, startedTrigger{input: string(input), updater: updater})
+	return nil
+}
+
+// pushUpdates makes every started trigger push the message configured for its operation. It is
+// called from the test rather than from Start, because Start itself runs on the resolver's event
+// loop - the very goroutine that has to receive the update.
+func (s *collidingSubscriptionSource) pushUpdates() {
+	s.mu.Lock()
+	started := append([]startedTrigger(nil), s.started...)
+	messages := s.messages
+	s.mu.Unlock()
+
+	for _, trigger := range started {
+		trigger.updater.Update([]byte(messages[trigger.input]))
+	}
+}
+
+func (s *collidingSubscriptionSource) startedInputs() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	inputs := make([]string, 0, len(s.started))
+	for _, trigger := range s.started {
+		inputs = append(inputs, trigger.input)
+	}
+	return inputs
+}
+
+// uncomparableSubscriptionSource is a data source whose dynamic type cannot be compared with ==,
+// which would panic if sameSubscriptionSource compared it anyway.
+type uncomparableSubscriptionSource []string
+
+func (uncomparableSubscriptionSource) UniqueRequestID(_ *Context, _ []byte, _ *xxhash.Digest) error {
+	return nil
+}
+
+func (uncomparableSubscriptionSource) Start(_ *Context, _ []byte, _ SubscriptionUpdater) error {
+	return nil
+}
+
+// TestSameSubscriptionSource covers the check that decides whether a subscription may join an
+// existing trigger. Answering "yes" for two sources that are not actually the same upstream is
+// what feeds one subscriber another one's data, so everything but a genuine identity is a "no".
+func TestSameSubscriptionSource(t *testing.T) {
+	source := &collidingSubscriptionSource{}
+	sameTypeOtherInstance := &collidingSubscriptionSource{}
+	otherType := createFakeStream(func(counter int) (message string, done bool) {
+		return "", true
+	}, 0, nil)
+
+	t.Run("the same instance is the same source", func(t *testing.T) {
+		assert.True(t, sameSubscriptionSource(source, source))
+	})
+
+	t.Run("two instances of the same type are two sources", func(t *testing.T) {
+		assert.False(t, sameSubscriptionSource(source, sameTypeOtherInstance))
+	})
+
+	t.Run("different types are never the same source", func(t *testing.T) {
+		assert.False(t, sameSubscriptionSource(source, otherType))
+		assert.False(t, sameSubscriptionSource(otherType, source))
+	})
+
+	t.Run("nil is only the same as nil", func(t *testing.T) {
+		assert.True(t, sameSubscriptionSource(nil, nil))
+		assert.False(t, sameSubscriptionSource(source, nil))
+		assert.False(t, sameSubscriptionSource(nil, source))
+	})
+
+	t.Run("an uncomparable source is rejected instead of panicking", func(t *testing.T) {
+		// Comparing interfaces that hold an uncomparable type panics at runtime, which would take
+		// down the resolver's event loop rather than just fail to reuse a trigger.
+		assert.NotPanics(t, func() {
+			assert.False(t, sameSubscriptionSource(
+				uncomparableSubscriptionSource{"a"},
+				uncomparableSubscriptionSource{"a"},
+			))
+		})
+	})
+}
+
+func collidingSubscriptionPlan(source SubscriptionDataSource, input string) *GraphQLSubscription {
+	return &GraphQLSubscription{
+		Trigger: GraphQLSubscriptionTrigger{
+			Source: source,
+			InputTemplate: InputTemplate{
+				Segments: []TemplateSegment{
+					{
+						SegmentType: StaticSegmentType,
+						Data:        []byte(input),
+					},
+				},
+			},
+			PostProcessing: PostProcessingConfiguration{
+				SelectResponseDataPath:   []string{"data"},
+				SelectResponseErrorsPath: []string{"errors"},
+			},
+		},
+		Response: &GraphQLResponse{
+			Data: &Object{
+				Fields: []*Field{
+					{
+						Name: []byte("counter"),
+						Value: &Integer{
+							Path: []string{"counter"},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// TestResolver_SubscriptionsAreNotMergedByTriggerIDAlone guards against unrelated subscriptions
+// being merged onto one trigger. The trigger ID only identifies the upstream connection, so two
+// subscriptions can share it while asking for entirely different operations - merging them means
+// the second operation is never started upstream and its subscriber is fed the first one's data.
+func TestResolver_SubscriptionsAreNotMergedByTriggerIDAlone(t *testing.T) {
+	const (
+		firstInput  = `{"url":"http://localhost:4000","body":{"query":"subscription { first }"}}`
+		secondInput = `{"url":"http://localhost:4000","body":{"query":"subscription { second }"}}`
+
+		firstMessage  = `{"data":{"counter":1}}`
+		secondMessage = `{"data":{"counter":2}}`
+	)
+
+	subscribe := func(t *testing.T, resolver *Resolver, plan *GraphQLSubscription, id int64) *SubscriptionRecorder {
+		t.Helper()
+
+		recorder := &SubscriptionRecorder{
+			buf:      &bytes.Buffer{},
+			messages: []string{},
+		}
+		require.NoError(t, resolver.AsyncResolveGraphQLSubscription(
+			NewContext(context.Background()),
+			plan,
+			recorder,
+			SubscriptionIdentifier{ConnectionID: id, SubscriptionID: id},
+		))
+		return recorder
+	}
+
+	// The resolver handles one event at a time, so once it has picked up an event, every event
+	// queued before it - every subscription added above - has already been handled completely.
+	// Removing a client that does not exist is a no-op that travels through the same channel.
+	syncWithEventLoop := func(t *testing.T, resolver *Resolver) {
+		t.Helper()
+		require.NoError(t, resolver.AsyncUnsubscribeClient(-1))
+	}
+
+	t.Run("different operations over the same connection", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		resolver := newResolver(ctx)
+
+		source := &collidingSubscriptionSource{messages: map[string]string{
+			firstInput:  firstMessage,
+			secondInput: secondMessage,
+		}}
+
+		first := subscribe(t, resolver, collidingSubscriptionPlan(source, firstInput), 1)
+		second := subscribe(t, resolver, collidingSubscriptionPlan(source, secondInput), 2)
+		syncWithEventLoop(t, resolver)
+
+		assert.ElementsMatch(t, []string{firstInput, secondInput}, source.startedInputs(),
+			"both operations must be started upstream, not just the one that created the trigger")
+
+		source.pushUpdates()
+		first.AwaitMessages(t, 1, time.Second)
+		second.AwaitMessages(t, 1, time.Second)
+
+		assert.Equal(t, []string{firstMessage}, first.Messages())
+		assert.Equal(t, []string{secondMessage}, second.Messages(),
+			"a subscription must only ever see the data of its own operation")
+	})
+
+	t.Run("different sources with the same input", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		resolver := newResolver(ctx)
+
+		firstSource := &collidingSubscriptionSource{messages: map[string]string{firstInput: firstMessage}}
+		secondSource := &collidingSubscriptionSource{messages: map[string]string{firstInput: secondMessage}}
+
+		first := subscribe(t, resolver, collidingSubscriptionPlan(firstSource, firstInput), 1)
+		second := subscribe(t, resolver, collidingSubscriptionPlan(secondSource, firstInput), 2)
+		syncWithEventLoop(t, resolver)
+
+		assert.Equal(t, []string{firstInput}, firstSource.startedInputs())
+		assert.Equal(t, []string{firstInput}, secondSource.startedInputs(),
+			"a subscription served by a different data source must not be attached to another source's trigger")
+
+		firstSource.pushUpdates()
+		secondSource.pushUpdates()
+		first.AwaitMessages(t, 1, time.Second)
+		second.AwaitMessages(t, 1, time.Second)
+
+		assert.Equal(t, []string{firstMessage}, first.Messages())
+		assert.Equal(t, []string{secondMessage}, second.Messages())
+	})
+
+	// Regression guard: splitting triggers must not go so far that identical subscriptions stop
+	// sharing one upstream connection.
+	t.Run("identical subscriptions still share one trigger", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		resolver := newResolver(ctx)
+
+		source := &collidingSubscriptionSource{messages: map[string]string{firstInput: firstMessage}}
+
+		first := subscribe(t, resolver, collidingSubscriptionPlan(source, firstInput), 1)
+		second := subscribe(t, resolver, collidingSubscriptionPlan(source, firstInput), 2)
+		syncWithEventLoop(t, resolver)
+
+		assert.Equal(t, []string{firstInput}, source.startedInputs(),
+			"identical subscriptions must be multiplexed onto a single upstream operation")
+
+		source.pushUpdates()
+		first.AwaitMessages(t, 1, time.Second)
+		second.AwaitMessages(t, 1, time.Second)
+
+		assert.Equal(t, []string{firstMessage}, first.Messages())
+		assert.Equal(t, []string{firstMessage}, second.Messages())
+	})
+}

--- a/v2/pkg/engine/resolve/trace.go
+++ b/v2/pkg/engine/resolve/trace.go
@@ -3,9 +3,74 @@ package resolve
 import (
 	"context"
 	"encoding/json"
+	"sync"
 
 	"github.com/google/uuid"
 )
+
+// fetchTraces collects the traces recorded while one request is resolved. They must not be hung off
+// the fetches themselves: a plan is shared by every concurrent request that resolves the same
+// operation, so writing to it is a data race. Parallel fetches record concurrently within a single
+// request, hence the mutex. The zero value is ready to use and all methods tolerate a nil receiver.
+type fetchTraces struct {
+	mu sync.Mutex
+	// loads holds the trace of every fetch that was loaded, keyed by the fetch it belongs to.
+	loads map[Fetch]*DataSourceLoadTrace
+	// listItemFetches holds the per-item copies a ParallelListItemFetch was resolved with.
+	listItemFetches map[*ParallelListItemFetch][]*SingleFetch
+}
+
+func (t *fetchTraces) reset() {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.loads = nil
+	t.listItemFetches = nil
+}
+
+func (t *fetchTraces) setLoad(fetch Fetch, trace *DataSourceLoadTrace) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.loads == nil {
+		t.loads = make(map[Fetch]*DataSourceLoadTrace)
+	}
+	t.loads[fetch] = trace
+}
+
+func (t *fetchTraces) load(fetch Fetch) *DataSourceLoadTrace {
+	if t == nil {
+		return nil
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.loads[fetch]
+}
+
+func (t *fetchTraces) setListItemFetches(fetch *ParallelListItemFetch, fetches []*SingleFetch) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.listItemFetches == nil {
+		t.listItemFetches = make(map[*ParallelListItemFetch][]*SingleFetch)
+	}
+	t.listItemFetches[fetch] = fetches
+}
+
+func (t *fetchTraces) listItemFetchesOf(fetch *ParallelListItemFetch) []*SingleFetch {
+	if t == nil {
+		return nil
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.listItemFetches[fetch]
+}
 
 type RequestTraceOptions struct {
 	// Enable switches tracing on or off
@@ -141,14 +206,14 @@ func getNodeType(kind NodeKind) TraceNodeType {
 	}
 }
 
-func parseField(f *Field) *TraceField {
+func parseField(f *Field, traces *fetchTraces) *TraceField {
 	if f == nil {
 		return nil
 	}
 
 	field := &TraceField{
 		Name:  string(f.Name),
-		Value: parseNode(f.Value),
+		Value: parseNode(f.Value, traces),
 	}
 
 	if f.Info == nil {
@@ -162,7 +227,7 @@ func parseField(f *Field) *TraceField {
 	return field
 }
 
-func parseFetch(fetch Fetch) *TraceFetch {
+func parseFetch(fetch Fetch, traces *fetchTraces) *TraceFetch {
 	traceFetch := &TraceFetch{
 		Id: uuid.NewString(),
 	}
@@ -170,9 +235,9 @@ func parseFetch(fetch Fetch) *TraceFetch {
 	switch f := fetch.(type) {
 	case *SingleFetch:
 		traceFetch.Type = TraceFetchTypeSingle
-		if f.Trace != nil {
-			traceFetch.DataSourceLoadTrace = f.Trace
-			traceFetch.Path = f.Trace.Path
+		if trace := traces.load(f); trace != nil {
+			traceFetch.DataSourceLoadTrace = trace
+			traceFetch.Path = trace.Path
 		}
 		if f.Info != nil {
 			traceFetch.DataSourceID = f.Info.DataSourceID
@@ -180,43 +245,41 @@ func parseFetch(fetch Fetch) *TraceFetch {
 
 	case *ParallelFetch:
 		traceFetch.Type = TraceFetchTypeParallel
-		if f.Trace != nil {
-			traceFetch.Path = f.Trace.Path
+		if trace := traces.load(f); trace != nil {
+			traceFetch.Path = trace.Path
 		}
 		for _, subFetch := range f.Fetches {
-			traceFetch.Fetches = append(traceFetch.Fetches, parseFetch(subFetch))
+			traceFetch.Fetches = append(traceFetch.Fetches, parseFetch(subFetch, traces))
 		}
 
 	case *SerialFetch:
 		traceFetch.Type = TraceFetchTypeSerial
-		if f.Trace != nil {
-			traceFetch.Path = f.Trace.Path
+		if trace := traces.load(f); trace != nil {
+			traceFetch.Path = trace.Path
 		}
 		for _, subFetch := range f.Fetches {
-			traceFetch.Fetches = append(traceFetch.Fetches, parseFetch(subFetch))
+			traceFetch.Fetches = append(traceFetch.Fetches, parseFetch(subFetch, traces))
 		}
 
 	case *ParallelListItemFetch:
 		traceFetch.Type = TraceFetchTypeParallelListItem
-		if f.Trace != nil {
-			traceFetch.Path = f.Trace.Path
+		if trace := traces.load(f); trace != nil {
+			traceFetch.Path = trace.Path
 		}
-		traceFetch.Fetches = append(traceFetch.Fetches, parseFetch(f.Fetch))
-		if f.Traces != nil {
-			for _, trace := range f.Traces {
-				if trace.Trace != nil {
-					traceFetch.DataSourceLoadTraces = append(traceFetch.DataSourceLoadTraces, trace.Trace)
-				}
-				if trace.Info != nil {
-					traceFetch.DataSourceID = trace.Info.DataSourceID
-				}
+		traceFetch.Fetches = append(traceFetch.Fetches, parseFetch(f.Fetch, traces))
+		for _, itemFetch := range traces.listItemFetchesOf(f) {
+			if trace := traces.load(itemFetch); trace != nil {
+				traceFetch.DataSourceLoadTraces = append(traceFetch.DataSourceLoadTraces, trace)
+			}
+			if itemFetch.Info != nil {
+				traceFetch.DataSourceID = itemFetch.Info.DataSourceID
 			}
 		}
 	case *EntityFetch:
 		traceFetch.Type = TraceFetchTypeEntity
-		if f.Trace != nil {
-			traceFetch.DataSourceLoadTrace = f.Trace
-			traceFetch.Path = f.Trace.Path
+		if trace := traces.load(f); trace != nil {
+			traceFetch.DataSourceLoadTrace = trace
+			traceFetch.Path = trace.Path
 		}
 		if f.Info != nil {
 			traceFetch.DataSourceID = f.Info.DataSourceID
@@ -224,9 +287,9 @@ func parseFetch(fetch Fetch) *TraceFetch {
 
 	case *BatchEntityFetch:
 		traceFetch.Type = TraceFetchTypeBatchEntity
-		if f.Trace != nil {
-			traceFetch.DataSourceLoadTrace = f.Trace
-			traceFetch.Path = f.Trace.Path
+		if trace := traces.load(f); trace != nil {
+			traceFetch.DataSourceLoadTrace = trace
+			traceFetch.Path = trace.Path
 		}
 		if f.Info != nil {
 			traceFetch.DataSourceID = f.Info.DataSourceID
@@ -239,7 +302,7 @@ func parseFetch(fetch Fetch) *TraceFetch {
 	return traceFetch
 }
 
-func parseNode(n Node) *TraceNode {
+func parseNode(n Node, traces *fetchTraces) *TraceNode {
 	node := &TraceNode{
 		NodeType: getNodeType(n.NodeKind()),
 		Nullable: n.NodeKind() == NodeKindNull || n.NodePath() == nil,
@@ -249,16 +312,16 @@ func parseNode(n Node) *TraceNode {
 	switch v := n.(type) {
 	case *Object:
 		for _, field := range v.Fields {
-			node.Fields = append(node.Fields, parseField(field))
+			node.Fields = append(node.Fields, parseField(field, traces))
 		}
-		node.Fetch = parseFetch(v.Fetch)
+		node.Fetch = parseFetch(v.Fetch, traces)
 
 	case *Array:
 		if v.Item != nil {
-			node.Items = append(node.Items, parseNode(v.Item))
+			node.Items = append(node.Items, parseNode(v.Item, traces))
 		} else if len(v.Items) > 0 {
 			for _, item := range v.Items {
-				node.Items = append(node.Items, parseNode(item))
+				node.Items = append(node.Items, parseNode(item, traces))
 			}
 		}
 
@@ -270,8 +333,15 @@ func parseNode(n Node) *TraceNode {
 	return node
 }
 
+// GetTrace assembles the trace of a resolved response. It cannot report the per-fetch load traces,
+// which belong to a single request rather than to the shared plan - resolving a response reports
+// those itself, through Resolvable.
 func GetTrace(ctx context.Context, root *Object) *TraceNode {
-	node := parseNode(root)
+	return getTrace(ctx, root, nil)
+}
+
+func getTrace(ctx context.Context, root *Object, traces *fetchTraces) *TraceNode {
+	node := parseNode(root, traces)
 	node.Info = GetTraceInfo(ctx)
 	return node
 }

--- a/v2/pkg/graphql/execution_engine_v2.go
+++ b/v2/pkg/graphql/execution_engine_v2.go
@@ -23,7 +23,6 @@ import (
 	"github.com/TykTechnologies/graphql-go-tools/v2/pkg/engine/postprocess"
 	"github.com/TykTechnologies/graphql-go-tools/v2/pkg/engine/resolve"
 	"github.com/TykTechnologies/graphql-go-tools/v2/pkg/operationreport"
-	"github.com/TykTechnologies/graphql-go-tools/v2/pkg/pool"
 )
 
 type EngineResultWriter struct {
@@ -157,6 +156,11 @@ type ExecutionEngineV2 struct {
 	customExecutionEngineExecutor *CustomExecutionEngineV2Executor
 }
 
+type executionPlanCacheKey struct {
+	document      string
+	operationName string
+}
+
 type WebsocketBeforeStartHook interface {
 	OnBeforeStart(reqCtx context.Context, operation *Request) error
 }
@@ -166,7 +170,7 @@ type ExecutionOptionsV2 func(postProcessor *postprocess.Processor, resolveContex
 func WithUpstreamHeaders(header http.Header) ExecutionOptionsV2 {
 	return func(postProcessor *postprocess.Processor, resolveContext *resolve.Context) {
 		if resolveContext != nil {
-			resolveContext.UpstreamHeaders = header
+			resolveContext.UpstreamHeaders = header.Clone()
 		}
 	}
 }
@@ -345,17 +349,17 @@ func (e *ExecutionEngineV2) Execute(ctx context.Context, operation *Request, wri
 	}
 */
 func (e *ExecutionEngineV2) getCachedPlan(postProcessor *postprocess.Processor, operation, definition *ast.Document, operationName string, report *operationreport.Report) plan.Plan {
-
-	hash := pool.Hash64.Get()
-	hash.Reset()
-	defer pool.Hash64.Put(hash)
-	err := astprinter.Print(operation, definition, hash)
+	var printedDocument bytes.Buffer
+	err := astprinter.Print(operation, definition, &printedDocument)
 	if err != nil {
 		report.AddInternalError(err)
 		return nil
 	}
 
-	cacheKey := hash.Sum64()
+	cacheKey := executionPlanCacheKey{
+		document:      printedDocument.String(),
+		operationName: operationName,
+	}
 
 	if cached, ok := e.executionPlanCache.Get(cacheKey); ok {
 		if p, ok := cached.(plan.Plan); ok {
@@ -365,6 +369,11 @@ func (e *ExecutionEngineV2) getCachedPlan(postProcessor *postprocess.Processor, 
 
 	e.plannerMu.Lock()
 	defer e.plannerMu.Unlock()
+	if cached, ok := e.executionPlanCache.Get(cacheKey); ok {
+		if p, ok := cached.(plan.Plan); ok {
+			return p
+		}
+	}
 	planResult := e.planner.Plan(operation, definition, operationName, report)
 	if report.HasErrors() {
 		return nil

--- a/v2/pkg/graphql/execution_engine_v2.go
+++ b/v2/pkg/graphql/execution_engine_v2.go
@@ -165,7 +165,9 @@ type ExecutionOptionsV2 func(postProcessor *postprocess.Processor, resolveContex
 
 func WithUpstreamHeaders(header http.Header) ExecutionOptionsV2 {
 	return func(postProcessor *postprocess.Processor, resolveContext *resolve.Context) {
-		postProcessor.AddPostProcessor(postprocess.NewProcessInjectHeader(header))
+		if resolveContext != nil {
+			resolveContext.UpstreamHeaders = header
+		}
 	}
 }
 
@@ -198,10 +200,10 @@ func WithAdditionalHttpHeaders(headers http.Header, excludeByKeys ...string) Exe
 
 func WithHeaderModifier(modifier postprocess.HeaderModifier) ExecutionOptionsV2 {
 	return func(postProcessor *postprocess.Processor, resolveContext *resolve.Context) {
-		if modifier == nil {
+		if modifier == nil || resolveContext == nil {
 			return
 		}
-		postProcessor.AddPostProcessor(postprocess.NewProcessModifyHeader(modifier))
+		resolveContext.HeaderModifier = modifier
 	}
 }
 

--- a/v2/pkg/graphql/execution_engine_v2_header_options_test.go
+++ b/v2/pkg/graphql/execution_engine_v2_header_options_test.go
@@ -1,0 +1,198 @@
+package graphql
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/jensneuse/abstractlogger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/TykTechnologies/graphql-go-tools/v2/pkg/engine/datasource/graphql_datasource"
+	"github.com/TykTechnologies/graphql-go-tools/v2/pkg/engine/plan"
+	"github.com/TykTechnologies/graphql-go-tools/v2/pkg/engine/postprocess"
+	"github.com/TykTechnologies/graphql-go-tools/v2/pkg/engine/resolve"
+	"github.com/TykTechnologies/graphql-go-tools/v2/pkg/operationreport"
+	"github.com/TykTechnologies/graphql-go-tools/v2/pkg/starwars"
+)
+
+// These tests verify that WithHeaderModifier/WithUpstreamHeaders are applied
+// fresh on every Execute call - including when the underlying plan is served
+// from the engine's plan cache - rather than only once at plan-build time.
+// Each test calls Execute twice on the SAME engine with the SAME query but a
+// DIFFERENT header option value, so the second call is guaranteed to hit the
+// plan cache.
+
+// newHeaderOptionsTestEngine builds a single ExecutionEngineV2 whose one
+// upstream datasource has a baseline "Authorization" header configured (so
+// WithHeaderModifier has an existing "header" JSON object to rewrite) and
+// whose RoundTripper records every outgoing request's headers, in call order.
+func newHeaderOptionsTestEngine(t *testing.T) (engine *ExecutionEngineV2, capturedHeaders *[]http.Header) {
+	t.Helper()
+
+	schema := starwarsSchema(t)
+	capturedHeaders = &[]http.Header{}
+
+	dataSources := []plan.DataSourceConfiguration{
+		{
+			RootNodes: []plan.TypeField{
+				{TypeName: "Query", FieldNames: []string{"hero"}},
+			},
+			ChildNodes: []plan.TypeField{
+				{TypeName: "Character", FieldNames: []string{"name"}},
+			},
+			Factory: &graphql_datasource.Factory{
+				HTTPClient: testNetHttpClient(t, roundTripperTestCase{
+					expectedHost:     "example.com",
+					expectedPath:     "/",
+					sendResponseBody: `{"data":{"hero":{"name":"Luke Skywalker"}}}`,
+					sendStatusCode:   200,
+					capturedHeaders:  capturedHeaders,
+				}),
+			},
+			Custom: graphql_datasource.ConfigJson(graphql_datasource.Configuration{
+				Fetch: graphql_datasource.FetchConfiguration{
+					URL:    "https://example.com/",
+					Method: "GET",
+					Header: http.Header{"Authorization": []string{"placeholder"}},
+				},
+				UpstreamSchema: string(schema.Document()),
+			}),
+		},
+	}
+
+	engineConf := NewEngineV2Configuration(schema)
+	engineConf.SetDataSources(dataSources)
+	engineConf.SetFieldConfigurations([]plan.FieldConfiguration{})
+
+	var err error
+	engine, err = NewExecutionEngineV2(context.Background(), abstractlogger.Noop{}, engineConf)
+	require.NoError(t, err)
+
+	return engine, capturedHeaders
+}
+
+func heroRequest(t *testing.T) Request {
+	return loadStarWarsQuery(starwars.FileSimpleHeroQuery, nil)(t)
+}
+
+func TestExecutionEngineV2_Execute_HeaderModifierAppliedPerRequest(t *testing.T) {
+	engine, capturedHeaders := newHeaderOptionsTestEngine(t)
+	ctx := context.Background()
+
+	setAuthHeader := func(value string) postprocess.HeaderModifier {
+		return func(header http.Header) { header.Set("Authorization", value) }
+	}
+
+	// First call: this is a plan-cache MISS, so it populates the cache.
+	op1 := heroRequest(t)
+	w1 := NewEngineResultWriter()
+	err := engine.Execute(ctx, &op1, &w1, WithHeaderModifier(setAuthHeader("value-A")))
+	require.NoError(t, err)
+	require.Equal(t, `{"data":{"hero":{"name":"Luke Skywalker"}}}`, w1.String())
+
+	// Second call: DIFFERENT header value, but the SAME query text -> plan-cache HIT.
+	op2 := heroRequest(t)
+	w2 := NewEngineResultWriter()
+	err = engine.Execute(ctx, &op2, &w2, WithHeaderModifier(setAuthHeader("value-B")))
+	require.NoError(t, err)
+	require.Equal(t, `{"data":{"hero":{"name":"Luke Skywalker"}}}`, w2.String())
+
+	// Sanity check: both calls really did hash to the same cached plan.
+	require.Equal(t, 1, engine.executionPlanCache.Len(), "test setup invariant: both calls must hash to the same cached plan")
+
+	require.Len(t, *capturedHeaders, 2)
+	assert.Equal(t, "value-A", (*capturedHeaders)[0].Get("Authorization"))
+	assert.Equal(t, "value-B", (*capturedHeaders)[1].Get("Authorization"),
+		"the second call must use its own header value, not a value cached from the first call")
+}
+
+func TestExecutionEngineV2_Execute_UpstreamHeadersAppliedPerRequest(t *testing.T) {
+	engine, capturedHeaders := newHeaderOptionsTestEngine(t)
+	ctx := context.Background()
+
+	authHeader := func(value string) http.Header {
+		return http.Header{"Authorization": []string{value}}
+	}
+
+	// First call: this is a plan-cache MISS, so it populates the cache.
+	op1 := heroRequest(t)
+	w1 := NewEngineResultWriter()
+	err := engine.Execute(ctx, &op1, &w1, WithUpstreamHeaders(authHeader("value-A")))
+	require.NoError(t, err)
+	require.Equal(t, `{"data":{"hero":{"name":"Luke Skywalker"}}}`, w1.String())
+
+	// Second call: DIFFERENT header value, but the SAME query text -> plan-cache HIT.
+	op2 := heroRequest(t)
+	w2 := NewEngineResultWriter()
+	err = engine.Execute(ctx, &op2, &w2, WithUpstreamHeaders(authHeader("value-B")))
+	require.NoError(t, err)
+	require.Equal(t, `{"data":{"hero":{"name":"Luke Skywalker"}}}`, w2.String())
+
+	require.Equal(t, 1, engine.executionPlanCache.Len(), "test setup invariant: both calls must hash to the same cached plan")
+
+	require.Len(t, *capturedHeaders, 2)
+	assert.Equal(t, "value-A", (*capturedHeaders)[0].Get("Authorization"))
+	assert.Equal(t, "value-B", (*capturedHeaders)[1].Get("Authorization"),
+		"the second call must use its own header value, not a value cached from the first call")
+}
+
+func TestExecutionEngineV2_Execute_PlanCacheHeaderIsRequestScoped(t *testing.T) {
+	schema := starwarsSchema(t)
+
+	dataSources := []plan.DataSourceConfiguration{
+		{
+			RootNodes: []plan.TypeField{
+				{TypeName: "Query", FieldNames: []string{"hero"}},
+			},
+			ChildNodes: []plan.TypeField{
+				{TypeName: "Character", FieldNames: []string{"name"}},
+			},
+			Factory: &graphql_datasource.Factory{},
+			Custom: graphql_datasource.ConfigJson(graphql_datasource.Configuration{
+				Fetch: graphql_datasource.FetchConfiguration{
+					URL:    "https://example.com/",
+					Method: "GET",
+					Header: http.Header{"Authorization": []string{"placeholder"}},
+				},
+				UpstreamSchema: string(schema.Document()),
+			}),
+		},
+	}
+
+	engineConf := NewEngineV2Configuration(schema)
+	engineConf.SetDataSources(dataSources)
+	engineConf.SetFieldConfigurations([]plan.FieldConfiguration{})
+
+	engine, err := NewExecutionEngineV2(context.Background(), abstractlogger.Noop{}, engineConf)
+	require.NoError(t, err)
+
+	operation := heroRequest(t)
+	require.NoError(t, engine.Normalize(&operation))
+
+	execCtx := newInternalExecutionContext()
+	WithHeaderModifier(func(header http.Header) {
+		header.Set("Authorization", "value-A")
+	})(execCtx.postProcessor, execCtx.resolveContext)
+
+	var report operationreport.Report
+	planResult, err := engine.Plan(execCtx.postProcessor, &operation, &report)
+	require.NoError(t, err)
+	require.False(t, report.HasErrors())
+	require.Equal(t, 1, engine.executionPlanCache.Len())
+
+	syncPlan, ok := planResult.(*plan.SynchronousResponsePlan)
+	require.True(t, ok)
+	singleFetch, ok := syncPlan.Response.Data.Fetch.(*resolve.SingleFetch)
+	require.True(t, ok)
+
+	renderedBuf := &bytes.Buffer{}
+	renderCtx := resolve.NewContext(context.Background())
+	err = singleFetch.InputTemplate.Render(renderCtx, nil, renderedBuf)
+	require.NoError(t, err)
+
+	assert.NotContains(t, renderedBuf.String(), "value-A",
+		"the cached plan must not contain any per-request header value frozen into its static InputTemplate segments")
+}

--- a/v2/pkg/graphql/execution_engine_v2_helpers_test.go
+++ b/v2/pkg/graphql/execution_engine_v2_helpers_test.go
@@ -23,12 +23,20 @@ type roundTripperTestCase struct {
 	expectedBody     string
 	sendStatusCode   int
 	sendResponseBody string
+	// capturedHeaders, if non-nil, receives a clone of req.Header for every
+	// request handled by this round tripper, in call order. Test-only
+	// instrumentation for tests asserting on per-request header behavior.
+	capturedHeaders *[]http.Header
 }
 
 func createTestRoundTripper(t *testing.T, testCase roundTripperTestCase) testRoundTripper {
 	return func(req *http.Request) *http.Response {
 		assert.Equal(t, testCase.expectedHost, req.URL.Host)
 		assert.Equal(t, testCase.expectedPath, req.URL.Path)
+
+		if testCase.capturedHeaders != nil {
+			*testCase.capturedHeaders = append(*testCase.capturedHeaders, req.Header.Clone())
+		}
 
 		if len(testCase.expectedBody) > 0 {
 			var receivedBodyBytes []byte

--- a/v2/pkg/graphql/execution_engine_v2_test.go
+++ b/v2/pkg/graphql/execution_engine_v2_test.go
@@ -190,6 +190,20 @@ func TestWithHeaderModifier(t *testing.T) {
 	})
 }
 
+// TestWithUpstreamHeadersCopiesInput guards against WithUpstreamHeaders holding
+// onto the caller's http.Header by reference. If a caller mutates or reuses
+// that map after Execute returns (or while a request is still in flight),
+// resolveContext.UpstreamHeaders must not be affected.
+func TestWithUpstreamHeadersCopiesInput(t *testing.T) {
+	headers := http.Header{"Authorization": {"Bearer original"}}
+	resolveContext := &resolve.Context{}
+
+	WithUpstreamHeaders(headers)(nil, resolveContext)
+	headers.Set("Authorization", "Bearer mutated")
+
+	assert.Equal(t, "Bearer original", resolveContext.UpstreamHeaders.Get("Authorization"))
+}
+
 type ExecutionEngineV2TestCase struct {
 	schema                            *Schema
 	operation                         func(t *testing.T) Request
@@ -1430,6 +1444,86 @@ func TestExecutionEngineV2_GetCachedPlan(t *testing.T) {
 		assert.Equal(t, 2, engine.executionPlanCache.Len())
 		assert.NotEqual(t, cachedPlan, oldestCachedPlan.(*plan.SubscriptionResponsePlan))
 	})
+}
+
+// TestExecutionEngineV2_GetCachedPlan_DifferentOperationNameSameDocument guards
+// against the plan cache key being derived only from the printed document text.
+// A single document can contain multiple named operations; selecting a
+// different one via OperationName must not be served a plan cached for a
+// different operation just because the underlying document text is identical.
+func TestExecutionEngineV2_GetCachedPlan_DifferentOperationNameSameDocument(t *testing.T) {
+	schema, err := NewSchemaFromString(testSubscriptionDefinition)
+	require.NoError(t, err)
+
+	combinedQuery := testSubscriptionLastRegisteredUserOperation + "\n" + testSubscriptionLiveUserCountOperation
+
+	lastRegisteredUserRequest := Request{
+		OperationName: "LastRegisteredUser",
+		Variables:     nil,
+		Query:         combinedQuery,
+	}
+	validationResult, err := lastRegisteredUserRequest.ValidateForSchema(schema)
+	require.NoError(t, err)
+	require.True(t, validationResult.Valid)
+	normalizationResult, err := lastRegisteredUserRequest.Normalize(schema)
+	require.NoError(t, err)
+	require.True(t, normalizationResult.Successful)
+
+	liveUserCountRequest := Request{
+		OperationName: "LiveUserCount",
+		Variables:     nil,
+		Query:         combinedQuery,
+	}
+	validationResult, err = liveUserCountRequest.ValidateForSchema(schema)
+	require.NoError(t, err)
+	require.True(t, validationResult.Valid)
+	normalizationResult, err = liveUserCountRequest.Normalize(schema)
+	require.NoError(t, err)
+	require.True(t, normalizationResult.Successful)
+
+	engineConfig := NewEngineV2Configuration(schema)
+	engineConfig.SetDataSources([]plan.DataSourceConfiguration{
+		{
+			RootNodes: []plan.TypeField{
+				{
+					TypeName:   "Subscription",
+					FieldNames: []string{"lastRegisteredUser", "liveUserCount"},
+				},
+			},
+			ChildNodes: []plan.TypeField{
+				{
+					TypeName:   "User",
+					FieldNames: []string{"id", "username", "email"},
+				},
+			},
+			Factory: &graphql_datasource.Factory{},
+			Custom: graphql_datasource.ConfigJson(graphql_datasource.Configuration{
+				Subscription: graphql_datasource.SubscriptionConfiguration{
+					URL: "http://localhost:8080",
+				},
+			}),
+		},
+	})
+
+	engine, err := NewExecutionEngineV2(context.Background(), abstractlogger.NoopLogger, engineConfig)
+	require.NoError(t, err)
+	require.Equal(t, 0, engine.executionPlanCache.Len())
+
+	firstExecCtx := newInternalExecutionContext()
+	report := operationreport.Report{}
+	firstPlan := engine.getCachedPlan(firstExecCtx.postProcessor, &lastRegisteredUserRequest.document, &schema.document, lastRegisteredUserRequest.OperationName, &report)
+	require.False(t, report.HasErrors())
+	require.Equal(t, 1, engine.executionPlanCache.Len())
+
+	secondExecCtx := newInternalExecutionContext()
+	report = operationreport.Report{}
+	secondPlan := engine.getCachedPlan(secondExecCtx.postProcessor, &liveUserCountRequest.document, &schema.document, liveUserCountRequest.OperationName, &report)
+	require.False(t, report.HasErrors())
+
+	assert.Equal(t, 2, engine.executionPlanCache.Len(),
+		"the plan cache key must include operationName - two requests selecting different named operations out of the same document text must not collide into one cache entry")
+	assert.NotEqual(t, firstPlan, secondPlan,
+		"a request for \"LiveUserCount\" must not be served the cached plan built for \"LastRegisteredUser\" just because the printed document text is identical")
 }
 
 func BenchmarkIntrospection(b *testing.B) {

--- a/v2/pkg/graphql/execution_engine_v2_test.go
+++ b/v2/pkg/graphql/execution_engine_v2_test.go
@@ -171,22 +171,22 @@ func TestWithHeaderModifier(t *testing.T) {
 		}
 	}
 
-	t.Run("should add modify header postprocess", func(t *testing.T) {
+	t.Run("should set header modifier on resolve context", func(t *testing.T) {
 		processor := &postprocess.Processor{}
-		require.Equal(t, 0, processor.Count())
+		resolveContext := &resolve.Context{}
 
 		optionFunc := WithHeaderModifier(headerModifier)
-		optionFunc(processor, nil)
-		assert.Equal(t, 1, processor.Count())
+		optionFunc(processor, resolveContext)
+		assert.NotNil(t, resolveContext.HeaderModifier)
 	})
 
-	t.Run("should not touch post processor if no modifier is provided", func(t *testing.T) {
+	t.Run("should not touch resolve context if no modifier is provided", func(t *testing.T) {
 		processor := &postprocess.Processor{}
-		require.Equal(t, 0, processor.Count())
+		resolveContext := &resolve.Context{}
 
 		optionFunc := WithHeaderModifier(nil)
-		optionFunc(processor, nil)
-		assert.Equal(t, 0, processor.Count())
+		optionFunc(processor, resolveContext)
+		assert.Nil(t, resolveContext.HeaderModifier)
 	})
 }
 

--- a/v2/pkg/graphql/schema.go
+++ b/v2/pkg/graphql/schema.go
@@ -119,6 +119,7 @@ func (s *Schema) Normalize() (result NormalizationResult, err error) {
 
 	s.rawSchema = normalizedSchema.rawSchema
 	s.document = normalizedSchema.document
+	s.hash = normalizedSchema.hash
 	s.isNormalized = true
 	return NormalizationResult{Successful: true, Errors: nil}, nil
 }

--- a/v2/pkg/graphql/schema_test.go
+++ b/v2/pkg/graphql/schema_test.go
@@ -2,6 +2,7 @@ package graphql
 
 import (
 	"bytes"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -1899,3 +1900,82 @@ type VehiclesEdge {
   """A cursor for use in pagination"""
   cursor: String!
 }`
+
+func TestSchema_Hash(t *testing.T) {
+	const schemaDefinition = "type Query { hello: String }"
+
+	// The hash is the identity of the schema for Request.validForSchema, so every constructor has
+	// to produce one. There is a single &Schema{} literal behind all of them; this keeps it that way.
+	t.Run("should be available right after construction", func(t *testing.T) {
+		constructors := map[string]func() (*Schema, error){
+			"from string": func() (*Schema, error) {
+				return NewSchemaFromString(schemaDefinition)
+			},
+			"from reader": func() (*Schema, error) {
+				return NewSchemaFromReader(bytes.NewBufferString(schemaDefinition))
+			},
+		}
+
+		for name, newSchema := range constructors {
+			t.Run(name, func(t *testing.T) {
+				schema, err := newSchema()
+				require.NoError(t, err)
+
+				hash := schema.Hash()
+				assert.NotZero(t, hash, "the hash has to be computed while the schema is built, not on first use")
+				assert.Equal(t, hash, schema.Hash(), "Hash() has to be a pure read")
+			})
+		}
+	})
+
+	t.Run("should follow the document after normalization", func(t *testing.T) {
+		// The extension is merged into the type by normalization, so the document - and with it the
+		// hash - really does change.
+		schema, err := NewSchemaFromString("type Query { hello: String }\nextend type Query { world: String }")
+		require.NoError(t, err)
+		beforeNormalization := schema.Hash()
+
+		normalizationResult, err := schema.Normalize()
+		require.NoError(t, err)
+		require.True(t, normalizationResult.Successful)
+
+		// What the hash has to describe now is the document the schema currently holds.
+		normalized, err := createSchema(schema.rawSchema, false)
+		require.NoError(t, err)
+
+		assert.Equal(t, normalized.Hash(), schema.Hash(), "Hash() has to describe the document the schema holds")
+		assert.NotEqual(t, beforeNormalization, schema.Hash(), "normalization changed the document, so it has to change the hash")
+	})
+
+	// A schema is shared between every request of an API, so a lazy write in Hash() is a data race
+	// between concurrent requests. Only reports under -race.
+	t.Run("should be safe to read concurrently", func(t *testing.T) {
+		reference, err := NewSchemaFromString(schemaDefinition)
+		require.NoError(t, err)
+		_, err = reference.Normalize()
+		require.NoError(t, err)
+		expected := reference.Hash()
+		require.NotZero(t, expected)
+
+		schema, err := NewSchemaFromString(schemaDefinition)
+		require.NoError(t, err)
+		_, err = schema.Normalize()
+		require.NoError(t, err)
+
+		var waitGroup sync.WaitGroup
+		for i := 0; i < 50; i++ {
+			waitGroup.Add(2)
+			go func() {
+				defer waitGroup.Done()
+				assert.Equal(t, expected, schema.Hash())
+			}()
+			go func() {
+				defer waitGroup.Done()
+				request := Request{Query: "{ hello }"}
+				_, err := request.ValidateForSchema(schema)
+				assert.NoError(t, err)
+			}()
+		}
+		waitGroup.Wait()
+	})
+}

--- a/v2/pkg/subscription/websocket/handler.go
+++ b/v2/pkg/subscription/websocket/handler.go
@@ -30,6 +30,7 @@ var DefaultProtocol = ProtocolGraphQLTransportWS
 
 // HandleOptions can be used to pass options to the websocket handler.
 type HandleOptions struct {
+	Context                          context.Context
 	Logger                           abstractlogger.Logger
 	Protocol                         Protocol
 	WebSocketInitFunc                InitFunc
@@ -40,6 +41,13 @@ type HandleOptions struct {
 	CustomReadErrorTimeOut           time.Duration
 	CustomSubscriptionEngine         subscription.Engine
 	CustomSubscriptionExecutionRetry int
+}
+
+// WithContext sets the parent context used by the subscription handler.
+func WithContext(ctx context.Context) HandleOptionFunc {
+	return func(opts *HandleOptions) {
+		opts.Context = ctx
+	}
 }
 
 // HandleOptionFunc can be used to define option functions.
@@ -142,6 +150,7 @@ func WithProtocolFromRequestHeaders(req *http.Request) HandleOptionFunc {
 // behavior. By default, it uses the 'graphql-transport-ws' protocol.
 func Handle(done chan bool, errChan chan error, conn net.Conn, executorPool subscription.ExecutorPool, options ...HandleOptionFunc) {
 	definedOptions := HandleOptions{
+		Context:  context.Background(),
 		Logger:   abstractlogger.Noop{},
 		Protocol: DefaultProtocol,
 	}
@@ -206,7 +215,10 @@ func HandleWithOptions(done chan bool, errChan chan error, conn net.Conn, execut
 	}
 
 	close(done)
-	subscriptionHandler.Handle(context.Background()) // Blocking
+	if options.Context == nil {
+		options.Context = context.Background()
+	}
+	subscriptionHandler.Handle(options.Context) // Blocking
 }
 
 func createProtocolHandler(handleOptions HandleOptions, client subscription.TransportClient) (protocolHandler subscription.Protocol, err error) {

--- a/v2/pkg/subscription/websocket/handler_test.go
+++ b/v2/pkg/subscription/websocket/handler_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestWithContext(t *testing.T) {
-	ctx := context.WithValue(context.Background(), struct{}{}, "request")
+	ctx := context.WithValue(context.Background(), ctxCaptureKey{}, "request")
 	options := HandleOptions{}
 
 	WithContext(ctx)(&options)

--- a/v2/pkg/subscription/websocket/handler_test.go
+++ b/v2/pkg/subscription/websocket/handler_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"runtime"
+	"sync"
 	"testing"
 	"time"
 
@@ -23,6 +24,15 @@ import (
 	"github.com/TykTechnologies/graphql-go-tools/v2/pkg/testing/subscriptiontesting"
 )
 
+func TestWithContext(t *testing.T) {
+	ctx := context.WithValue(context.Background(), struct{}{}, "request")
+	options := HandleOptions{}
+
+	WithContext(ctx)(&options)
+
+	assert.Equal(t, ctx, options.Context)
+}
+
 func TestHandleWithOptions(t *testing.T) {
 	t.Skip("timing not compatible with async rewrite of resolver")
 	t.Run("should handle protocol graphql-ws", func(t *testing.T) {
@@ -35,7 +45,7 @@ func TestHandleWithOptions(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		executorPoolV2 := setupExecutorPoolV2(t, ctx, chatServer.URL, nil)
+		executorPoolV2 := setupExecutorPoolV2(t, ctx, chatServer.URL, nil, httpclient.DefaultNetHttpClient)
 		serverConn, _ := net.Pipe()
 		testClient := NewTestClient(false)
 
@@ -110,7 +120,7 @@ func TestHandleWithOptions(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		executorPoolV2 := setupExecutorPoolV2(t, ctx, chatServer.URL, nil)
+		executorPoolV2 := setupExecutorPoolV2(t, ctx, chatServer.URL, nil, httpclient.DefaultNetHttpClient)
 		serverConn, _ := net.Pipe()
 		testClient := NewTestClient(false)
 
@@ -185,7 +195,7 @@ func TestHandleWithOptions(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		executorPoolV2 := setupExecutorPoolV2(t, ctx, chatServer.URL, &FailingOnBeforeStartHook{})
+		executorPoolV2 := setupExecutorPoolV2(t, ctx, chatServer.URL, &FailingOnBeforeStartHook{}, httpclient.DefaultNetHttpClient)
 		serverConn, _ := net.Pipe()
 		testClient := NewTestClient(false)
 
@@ -225,6 +235,142 @@ func TestHandleWithOptions(t *testing.T) {
 	})
 }
 
+type ctxCaptureKey struct{}
+
+// contextCapturingRoundTripper records the context.Context attached to the last outbound
+// request it forwards, so a test can assert what a caller-supplied context actually reached
+// the real upstream HTTP call.
+type contextCapturingRoundTripper struct {
+	next http.RoundTripper
+
+	mu   sync.Mutex
+	last context.Context
+}
+
+func (c *contextCapturingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	c.mu.Lock()
+	c.last = req.Context()
+	c.mu.Unlock()
+	return c.next.RoundTrip(req)
+}
+
+func (c *contextCapturingRoundTripper) lastContext() context.Context {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.last
+}
+
+func TestHandleWithOptions_ContextValuePropagatesToUpstreamRequest(t *testing.T) {
+	chatServer := httptest.NewServer(subscriptiontesting.ChatGraphQLEndpointHandler())
+	defer chatServer.Close()
+
+	poolCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	capturingTransport := &contextCapturingRoundTripper{next: http.DefaultTransport}
+	capturingClient := &http.Client{Transport: capturingTransport}
+
+	executorPoolV2 := setupExecutorPoolV2(t, poolCtx, chatServer.URL, nil, capturingClient)
+	serverConn, _ := net.Pipe()
+	testClient := NewTestClient(false)
+
+	handleCtx := context.WithValue(context.Background(), ctxCaptureKey{}, "expected-value")
+
+	done := make(chan bool)
+	errChan := make(chan error)
+	go Handle(
+		done,
+		errChan,
+		serverConn,
+		executorPoolV2,
+		WithContext(handleCtx),
+		WithCustomClient(testClient),
+		WithCustomSubscriptionUpdateInterval(50*time.Millisecond),
+		WithCustomKeepAliveInterval(3600*time.Second),
+	)
+
+	require.Eventually(t, func() bool {
+		<-done
+		return true
+	}, 1*time.Second, 2*time.Millisecond)
+
+	testClient.writeMessageFromClient([]byte(`{"type":"connection_init"}`))
+	assert.Eventually(t, func() bool {
+		expectedMessage := []byte(`{"type":"connection_ack"}`)
+		actualMessage := testClient.readMessageToClient()
+		assert.Equal(t, expectedMessage, actualMessage)
+		return true
+	}, 1*time.Second, 2*time.Millisecond, "never satisfied on connection_init")
+
+	testClient.writeMessageFromClient([]byte(`{"id":"1","type":"subscribe","payload":{"query":"{ room(name:\"#my_room\") { name } }"}}`))
+	assert.Eventually(t, func() bool {
+		expectedMessage := []byte(`{"id":"1","type":"next","payload":{"data":{"room":{"name":"#my_room"}}}}`)
+		actualMessage := testClient.readMessageToClient()
+		assert.Equal(t, expectedMessage, actualMessage)
+		expectedMessage = []byte(`{"id":"1","type":"complete"}`)
+		actualMessage = testClient.readMessageToClient()
+		assert.Equal(t, expectedMessage, actualMessage)
+		return true
+	}, 2*time.Second, 2*time.Millisecond, "never satisfied on room query")
+
+	capturedCtx := capturingTransport.lastContext()
+	require.NotNil(t, capturedCtx, "expected the upstream request to have been made with a non-nil context")
+	assert.Equal(t, "expected-value", capturedCtx.Value(ctxCaptureKey{}),
+		"expected the context value set via WithContext to propagate to the outbound upstream request")
+}
+
+func TestHandleWithOptions_CanceledContextAbortsOperation(t *testing.T) {
+	chatServer := httptest.NewServer(subscriptiontesting.ChatGraphQLEndpointHandler())
+	defer chatServer.Close()
+
+	poolCtx, cancelPool := context.WithCancel(context.Background())
+	defer cancelPool()
+
+	executorPoolV2 := setupExecutorPoolV2(t, poolCtx, chatServer.URL, nil, httpclient.DefaultNetHttpClient)
+	serverConn, _ := net.Pipe()
+	testClient := NewTestClient(false)
+
+	handleCtx, cancelHandle := context.WithCancel(context.Background())
+	cancelHandle() // canceled before Handle even starts
+
+	done := make(chan bool)
+	errChan := make(chan error)
+	go Handle(
+		done,
+		errChan,
+		serverConn,
+		executorPoolV2,
+		WithContext(handleCtx),
+		WithCustomClient(testClient),
+		WithCustomSubscriptionUpdateInterval(50*time.Millisecond),
+		WithCustomKeepAliveInterval(3600*time.Second),
+	)
+
+	require.Eventually(t, func() bool {
+		<-done
+		return true
+	}, 1*time.Second, 2*time.Millisecond)
+
+	testClient.writeMessageFromClient([]byte(`{"type":"connection_init"}`))
+	assert.Eventually(t, func() bool {
+		expectedMessage := []byte(`{"type":"connection_ack"}`)
+		actualMessage := testClient.readMessageToClient()
+		assert.Equal(t, expectedMessage, actualMessage)
+		return true
+	}, 1*time.Second, 2*time.Millisecond, "never satisfied on connection_init")
+
+	// A context that's already canceled before Handle even starts is Done() from the very first
+	// check onwards, so the connection is torn down right after handling connection_init - the
+	// subscribe message below is written but never processed, and no further response ever arrives.
+	testClient.writeMessageFromClient([]byte(`{"id":"1","type":"subscribe","payload":{"query":"{ room(name:\"#my_room\") { name } }"}}`))
+	select {
+	case actualMessage := <-testClient.messageToClient:
+		t.Fatalf("expected no further response once the context was already canceled before Handle started, got %s", actualMessage)
+	case <-time.After(300 * time.Millisecond):
+		// expected: the canceled context tore down the connection before the query could be processed.
+	}
+}
+
 func TestWithProtocolFromRequestHeaders(t *testing.T) {
 	runTest := func(headerKey string, headerValue string, expectedProtocol Protocol) func(t *testing.T) {
 		return func(t *testing.T) {
@@ -252,7 +398,7 @@ func TestWithProtocolFromRequestHeaders(t *testing.T) {
 	})
 }
 
-func setupExecutorPoolV2(t *testing.T, ctx context.Context, chatServerURL string, onBeforeStartHook graphql.WebsocketBeforeStartHook) *subscription.ExecutorV2Pool {
+func setupExecutorPoolV2(t *testing.T, ctx context.Context, chatServerURL string, onBeforeStartHook graphql.WebsocketBeforeStartHook, httpClient *http.Client) *subscription.ExecutorV2Pool {
 	chatSchemaBytes, err := subscriptiontesting.LoadSchemaFromExamplesDirectoryWithinPkg()
 	require.NoError(t, err)
 
@@ -273,7 +419,7 @@ func setupExecutorPoolV2(t *testing.T, ctx context.Context, chatServerURL string
 				{TypeName: "Message", FieldNames: []string{"text", "createdBy"}},
 			},
 			Factory: &graphql_datasource.Factory{
-				HTTPClient: httpclient.DefaultNetHttpClient,
+				HTTPClient: httpClient,
 			},
 			Custom: graphql_datasource.ConfigJson(graphql_datasource.Configuration{
 				Fetch: graphql_datasource.FetchConfiguration{


### PR DESCRIPTION
## Summary

Five fixes for state that was shared between unrelated GraphQL requests: cached plans, pooled
execution contexts, upstream websocket connections and resolver triggers. In each case one caller's
headers, credentials or subscription data could end up serving another caller. Every fix is applied
to both the `pkg/` (v1) and `v2/pkg/` trees and landed as its own commit.

The common shape: things that are per-request — upstream headers, connection_init payloads, request
contexts, the operation itself — were written into, keyed on, or handed to structures that outlive
the request (the plan cache, a pooled `resolve.Context`, a client-wide field, a hash that doesn't
identify what it groups).

## What changed

### 1. move header modification to the execution phase

Upstream headers and header modifiers were applied by registering post-processors on the plan
post-processor. `getCachedPlan` stores the post-processed plan in `executionPlanCache`, so the first
request's headers were baked into the plan that every later request with the same operation reuses.

`WithUpstreamHeaders` / `WithHeaderModifier` now write to the per-request `resolve.Context`
(`UpstreamHeaders`, `HeaderModifier`) and are applied when the fetch input is built.

### 2. isolate request specific execution state

Header work was split across `ApplyHeaderModifier` / `MergeInputHeader`, applied late in the load
path and silently returning the input unchanged on any error; the pooled `resolve.Context` also kept
`UpstreamHeaders` / `HeaderModifier` alive past `Free()`.

Consolidated into `httpclient.FinalizeInputHeaders(input, modifier, upstreamHeaders)`, which reports
errors instead of no-op'ing, applied per fetch in `Loader.finalizeInput` (single / entity / batch)
and in `Resolver.subscriptionInput`. `Context.Free()` clears the request-scoped fields and `clone()`
deep-copies them.

### 3. preserve the subscription request context

`websocket.HandleWithOptions` called `subscriptionHandler.Handle(context.Background())`, so a
websocket subscription's upstream calls were never tied to the incoming request: no cancellation, no
deadline or trace propagation.

Adds `HandleOptions.Context` and `WithContext(ctx)` (nil-safe, defaults to `context.Background()`).
The context reaches the outbound upstream HTTP request, which lets a caller such as the gateway's
websocket handoff forward the incoming request's context.

### 4. context ownership and orphaned goroutines in SSE

Two defects:

- `gqlSSEConnectionHandler.StartBlocking` never returned when the subscribe goroutine finished
  without reporting an error — upstream `event: complete`, end of stream, or a failed subscription
  request. The goroutine leaked and, because teardown happens in its deferred func, the client's
  subscription was never completed and stayed open until the client disconnected. A `done` channel
  now ends the loop.
- `AsyncResolveGraphQLSubscription` handed the caller's pooled `*resolve.Context` to the resolver's
  event loop and returned immediately; the caller then freed it for the next request, so the trigger
  could be started with a freed or already-reused context. It now snapshots the context
  synchronously. `clone()` also copies `InitialPayload` / `Extensions`, and `Free()` clears
  `InitialPayload`.

### 5. make subscription grouping collision safe

Three groupings that merged unrelated work:

- **Upstream connection reuse** was keyed on `hash(URL, headers)`, computed *before* the
  `connection_init` message exists. That payload comes from `OnWsConnectionInitCallback(reqCtx, …)`,
  the hook used to forward the calling user's credentials, so two users with identical upstream
  headers were multiplexed onto the connection authenticated as the first one. The key is now an
  exact descriptor that includes the init message and, in v2, the resolved forwarded client headers.
- **The negotiated sub-protocol** was written back onto the shared client
  (`c.wsSubProtocol = conn.Subprotocol()`), making the first upstream's choice a client-wide default
  that also narrowed the protocols offered on every later dial. It is a local now.
- **Resolver triggers** were grouped purely by `triggerID`, which for the graphql datasource hashes
  the connection descriptor (URL, headers, forwarded headers, extensions) and never the operation. A
  second subscription with a different query was attached to the first trigger, never started
  upstream, and was fed the first subscription's messages. Triggers now carry their `input` and
  `source` and probe for an exact match before joining.

### 6. fix: compute the schema hash once at construction

Schema.Hash() filled in s.hash on first use. A schema is shared by every request of an API, so
two concurrent requests validating against it raced on that write — both callers,
Request.ValidateForSchema and Request.IsValidated, are on the request path. The hash is now
computed while the schema is built (which is what the v2 module already did) and Hash() is a pure
read; Normalize() carries the hash of the normalized document across, in both trees.

### 7. fix: stop mutating the cached plan at resolve time

ResolveGraphQLResponse filled in response.Info on first use. A GraphQLResponse is the cached
execution plan, shared by every concurrent request resolving that operation, so the write raced with
the read two lines below and with Loader.LoadGraphQLResponseData. The planner only populates
Info when Config.IncludeInfo is set, which nothing in the engine wrapper or the gateway does, so
this fired for live traffic on every operation. Resolving now reads through a shared immutable
default instead of writing.

The same pattern applied to request tracing: the loader wrote each fetch's DataSourceLoadTrace
onto the plan's fetch structs, racing between concurrent traced requests. Traces now live in a
per-request table on Resolvable; GetTrace's exported signature is unchanged and the Trace
fields on the fetch structs are left in place but deprecated.
Behaviour note: with Info no longer filled in, a subscription update's response falls back to
the shared default (OperationTypeQuery) where the loader previously saw nil. Subgraph error
paths reported during subscription updates therefore gain a query prefix
(… at path 'query.field'). The query and mutation paths are unchanged. 

### 8. `perf: cut the per-fetch cost of finalizing headers` (from review)

Fix 2 moved header work out of the plan and onto the fetch path, so it stopped being computed once
per cached plan and started being computed once per fetch. Same round trip as before —
`ProcessModifyHeader` already did `jsonparser.Get` → `json.Unmarshal` → modifier → `json.Marshal` →
`jsonparser.Set` — but no longer amortised, and the gateway installs a header modifier on every
GraphQL request, so the early return in `FinalizeInputHeaders` never fires in production.

Profiling the call split showed where it actually goes, per fetch with a five-header input:

| stage | ns/op | allocs/op |
| --- | --- | --- |
| read the header object | 2877 | 54 |
| modifier callback (caller's code) | 400 | 6 |
| `json.Marshal` | 595 | 14 |
| `sjson.SetRawBytes` | 378 | 2 |

The read side is two thirds of it, and all of that is `encoding/json` building an intermediate
`map[string]json.RawMessage` and a `[]string` per entry, only to throw them away. It now walks the
object once with `jsonparser.ObjectEach`/`ArrayEach`. The write side hand-rolls the object instead
of reflecting over `http.Header`, into a pooled buffer. `sjson.SetRawBytes` stays a single call — it
copies the whole input document, so setting keys individually would have cost one copy per header.

**4402 → 1947 ns/op, 77 → 27 allocs/op, 4163 → 1825 B/op** (Apple M4 Max, both trees). The
`nothing to do` early return stays allocation-free.

`http.Header` still has to be materialised — `HeaderModifier` is `func(http.Header)` and the
gateway's implementation rewrites every entry — so the map itself is the remaining floor.

## Tests

47 new test functions (28 distinct names, most present in both trees), ~1.5k lines. Each fix's tests
were written first and observed failing against the unpatched code. Highlights:

| Area | Tests |
| --- | --- |
| Plan cache / header isolation | `TestExecutionEngineV2_Execute_PlanCacheHeaderIsRequestScoped`, `..._UpstreamHeadersAppliedPerRequest`, `..._HeaderModifierAppliedPerRequest` |
| Header finalization | `TestFinalizeInputHeaders`, `TestApplyHeaderModifier*`, `TestMergeInputHeader`, `TestContextFreeClearsRequestHeaderOptions`, `TestContextCloneIsolatesRequestHeaderOptions` |
| Subscription request context | `TestWithContext`, `TestHandleWithOptions_ContextValuePropagatesToUpstreamRequest`, `TestHandleWithOptions_CanceledContextAbortsOperation` |
| SSE lifetime & context ownership | `TestSSEConnectionHandlerStartBlockingReturnsWhenUpstreamStops`, `TestAsyncResolveGraphQLSubscriptionOwnsCallerContext`, `...KeepsRequestContextAfterCallerFree`, `TestContextCloneCopiesInitialPayloadAndExtensions`, `TestContextFreeClearsInitialPayload` |
| Connection & trigger grouping | `TestSubscriptionClientConnectionInitIsolation`, `TestSubscriptionClientDoesNotPinNegotiatedSubProtocol`, `TestResolver_SubscriptionsAreNotMergedByTriggerIDAlone`, plus direct unit tests for the new helpers: `TestConnectionKey`, `TestSameSubscriptionSource` |

Existing contracts were deliberately kept green: `TestWebsocketSubscriptionClientDeDuplication` (v1)
and `TestWebsocketConnectionReuse` (v2) still yield one handler for equivalent descriptors and two
when forwarded headers differ, and
`TestResolver_SubscriptionsAreNotMergedByTriggerIDAlone/identical_subscriptions_still_share_one_trigger`
guards that multiplexing survives the trigger split.

## Notes for reviewers

- Trigger reuse now additionally requires the same `Trigger.Source` pointer. Identical operations
  share a cached plan and therefore still multiplex; a plan-cache miss would open a second upstream
  connection instead of sharing one — more connections, never wrong data.
- Connection keys are exact strings instead of 64-bit hashes, so they can only ever split connections
  the hash used to merge. Map keys are larger.
- `FinalizeInputHeaders` returns an error where the previous helpers silently returned the input
  unchanged.
- No public API removed. `websocket.HandleOptions` gains `Context`, and `WithContext` is additive.

## Related

Follows #446 (TT-17442, upstream websocket connection reuse ignoring per-request auth headers) and
#447 (TT-17578, websocket request context leaking into engine fetches), which fixed adjacent cases
in the same area.


Thanks to @chrisanderton and @LLe27 for initial research and patches for this issue(s)